### PR TITLE
Setup environment in testsuite before first usage of compiler

### DIFF
--- a/gcc/ChangeLog.ARC
+++ b/gcc/ChangeLog.ARC
@@ -1,3 +1,9 @@
+2013-06-24	Anton Kolesov	<anton.kolesov@synopsys.com>
+
+	* testsuite/lib/c-torture.exp: Setup linker environemnt variables before
+	checking linker plugin support.
+	* testsuite/lib/gcc-dg.exp: Likewise.
+
 2013-06-18  Anton Kolesov	<anton.kolesov@synopsys.com>
 
 	* testsuite/gcc.target/arc/branch_shortening-O0-fPIC-1.c: Add a testcase

--- a/gcc/testsuite/lib/c-torture.exp
+++ b/gcc/testsuite/lib/c-torture.exp
@@ -50,6 +50,23 @@ if [info exists ADDITIONAL_TORTURE_OPTIONS] {
 	[concat $C_TORTURE_OPTIONS $ADDITIONAL_TORTURE_OPTIONS]
 }
 
+global GCC_UNDER_TEST
+if ![info exists GCC_UNDER_TEST] {
+    set GCC_UNDER_TEST "[find_gcc]"
+}
+
+# LTO_TORTURE_OPTIONS should go after setting up environment, because it will
+# try to compile file and without proper environment this compilation will always
+# fail.
+global orig_environment_saved
+
+# This file may be sourced, so don't override environment settings
+# that have been previously setup.
+if { $orig_environment_saved == 0 } {
+    append ld_library_path [gcc-set-multilib-library-path $GCC_UNDER_TEST]
+    set_ld_library_path_env_vars
+}
+
 set LTO_TORTURE_OPTIONS ""
 if [check_effective_target_lto] {
     # When having plugin test both slim and fat LTO and plugin/nonplugin
@@ -65,20 +82,6 @@ if [check_effective_target_lto] {
 	  { -O2 -flto }
       ]
     }
-}
-
-global GCC_UNDER_TEST
-if ![info exists GCC_UNDER_TEST] {
-    set GCC_UNDER_TEST "[find_gcc]"
-}
-
-global orig_environment_saved
-
-# This file may be sourced, so don't override environment settings
-# that have been previously setup.
-if { $orig_environment_saved == 0 } {
-    append ld_library_path [gcc-set-multilib-library-path $GCC_UNDER_TEST]
-    set_ld_library_path_env_vars
 }
 
 #

--- a/gcc/testsuite/lib/gcc-dg.exp
+++ b/gcc/testsuite/lib/gcc-dg.exp
@@ -72,6 +72,18 @@ if [info exists ADDITIONAL_TORTURE_OPTIONS] {
 	[concat $DG_TORTURE_OPTIONS $ADDITIONAL_TORTURE_OPTIONS]
 }
 
+# LTO_TORTURE_OPTIONS should go after setting up environment, because it will
+# try to compile file and without proper environment this compilation will always
+# fail.
+global orig_environment_saved
+
+# This file may be sourced, so don't override environment settings
+# that have been previously setup.
+if { $orig_environment_saved == 0 } {
+    append ld_library_path [gcc-set-multilib-library-path $GCC_UNDER_TEST]
+    set_ld_library_path_env_vars
+}
+
 set LTO_TORTURE_OPTIONS ""
 
 # Some torture-options cause intermediate code output, unusable for
@@ -95,15 +107,6 @@ if [check_effective_target_lto] {
 	  { -O2 -flto }
       ]
     }
-}
-
-global orig_environment_saved
-
-# This file may be sourced, so don't override environment settings
-# that have been previously setup.
-if { $orig_environment_saved == 0 } {
-    append ld_library_path [gcc-set-multilib-library-path $GCC_UNDER_TEST]
-    set_ld_library_path_env_vars
 }
 
 # Define gcc callbacks for dg.exp.


### PR DESCRIPTION
In testsuite environment should be setup before compiler usage. Currently it is done before any actual tests are run, but after Dejagnu check for linker plugin support. Because environment is not set properly check for plugin support always fails, regardless of whether linker plugins are supported. What is more if several tests are running in one Dejagnu instance, then they inherit environment of previous one, thus only the first linker plugin check will fail due to environment, following checks will get a proper environment and will succeed (if linker plugins are supported). As a consequence not only the results will be misleading (because invalid compiler options will be used in torture testing) but also the results will differ depending on how tests a run: in single thread mode when every test will run subsequently in the same Dejagnu instance (only one linker test will fail) or in a parallel environment when test are running in different environments (multiple linker tests will fail).

2013-06-24  Anton Kolesov   anton.kolesov@synopsys.com

```
* testsuite/lib/c-torture.exp: Setup linker environment variables before
checking linker plugin support.
* testsuite/lib/gcc-dg.exp: Likewise.
```
