### PR TITLE
Unified configuration/building system for ARC V1 and V2 

### DIFF
--- a/gcc/ChangeLog.ARC
+++ b/gcc/ChangeLog.ARC
@@ -1,3 +1,8 @@
+2013-08-23 Claudiu Zissulescu <claziss@synopsys.com>
+
+	* gcc/config/arc/arc.h: Fix multilib defaults.
+	* gcc/config/arc/t-arc-newlib: Add multilib support for EM.
+
 2013-07-14 Claudiu Zissulescu <claziss@synopsys.com>
 
 	* config/arc/arc.md: Add SET<cc> instructions for ARCv2.

--- a/gcc/config/arc/arc.h
+++ b/gcc/config/arc/arc.h
@@ -308,9 +308,9 @@ along with GCC; see the file COPYING3.  If not see
 
 #ifndef MULTILIB_DEFAULTS
 #if TARGET_CPU_DEFAULT == TARGET_CPU_EM
-#define MULTILIB_DEFAULTS { "mav2em" }
+#define MULTILIB_DEFAULTS { "mcpu=ARCv2EM" }
 #else
-#define MULTILIB_DEFAULTS { "mARC700" }
+#define MULTILIB_DEFAULTS { "mcpu=ARC700" }
 #endif
 #endif
 

--- a/gcc/config/arc/t-arc-newlib
+++ b/gcc/config/arc/t-arc-newlib
@@ -1,27 +1,26 @@
 # GCC Makefile fragment for Synopsys DesignWare ARC with newlib.
-
+#
 # Copyright (C) 2007-2012 Free Software Foundation, Inc.
-
+#
 # This file is part of GCC.
-
+#
 # GCC is free software; you can redistribute it and/or modify it under the
 # terms of the GNU General Public License as published by the Free Software
 # Foundation; either version 3, or (at your option) any later version.
-
+#
 # GCC is distributed in the hope that it will be useful, but WITHOUT ANY
 # WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
 # FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 # details.
-
+#
 # You should have received a copy of the GNU General Public License along
 # with GCC; see the file COPYING3.  If not see
 # <http://www.gnu.org/licenses/>.
-
+#
 # Selecting -mA5 uses the same functional multilib files/libraries
 # as get used for -mARC600 aka -mA6.
 MULTILIB_OPTIONS  = mcpu=ARC600/mcpu=ARC601/mcpu=ARC700/mcpu=ARCv2EM mmul64/mmul32x16 mnorm
 MULTILIB_DIRNAMES = arc600 arc601 arc700 em mul64 mul32x16 norm
-
 #
 # Aliases:
 MULTILIB_MATCHES  = mcpu?ARC600=mcpu?arc600
@@ -37,17 +36,16 @@ MULTILIB_MATCHES += mcpu?ARC700=mARC700
 MULTILIB_MATCHES += mcpu?ARCv2EM=mEM
 MULTILIB_MATCHES += mcpu?ARCv2EM=mARCv2EM
 MULTILIB_MATCHES += mcpu?ARCv2EM=mav2em
-
 #
 # These don't make sense for the ARC700 or ARCv2 default target:
 MULTILIB_EXCEPTIONS = mmul64* mmul32x16*
 # And neither of the -mmul* options make sense without -mnorm:
-MULTILIB_EXCEPTIONS += mARC600/mmul64/!mnorm mcpu=ARC601/mmul64/!mnorm mARC600/mmul32x16/!mnorm
+MULTILIB_EXCLUSIONS = mARC600/mmul64/!mnorm mcpu=ARC601/mmul64/!mnorm mARC600/mmul32x16/!mnorm
 # Exclusions for ARC700
 MULTILIB_EXCEPTIONS += mcpu=ARC700/mnorm* mcpu=ARC700/mmul64* mcpu=ARC700/mmul32x16*
 # Exclusions for ARCv2EM
 MULTILIB_EXCEPTIONS += mcpu=ARCv2EM/mmul64* mcpu=ARCv2EM/mmul32x16*
-
+#
 # Local Variables:
 # mode: Makefile
 # End:

--- a/gcc/config/arc/t-arc-newlib
+++ b/gcc/config/arc/t-arc-newlib
@@ -19,8 +19,9 @@
 
 # Selecting -mA5 uses the same functional multilib files/libraries
 # as get used for -mARC600 aka -mA6.
-MULTILIB_OPTIONS=mcpu=ARC600/mcpu=ARC601 mmul64/mmul32x16 mnorm
-MULTILIB_DIRNAMES=arc600 arc601 mul64 mul32x16 norm
+MULTILIB_OPTIONS  = mcpu=ARC600/mcpu=ARC601/mcpu=ARC700/mcpu=ARCv2EM mmul64/mmul32x16 mnorm
+MULTILIB_DIRNAMES = arc600 arc601 arc700 em mul64 mul32x16 norm
+
 #
 # Aliases:
 MULTILIB_MATCHES  = mcpu?ARC600=mcpu?arc600
@@ -31,8 +32,22 @@ MULTILIB_MATCHES += mcpu?ARC600=mno-mpy
 MULTILIB_MATCHES += mcpu?ARC601=mcpu?arc601
 MULTILIB_MATCHES += EL=mlittle-endian
 MULTILIB_MATCHES += EB=mbig-endian
+MULTILIB_MATCHES += mcpu?ARC700=mA7
+MULTILIB_MATCHES += mcpu?ARC700=mARC700
+MULTILIB_MATCHES += mcpu?ARCv2EM=mEM
+MULTILIB_MATCHES += mcpu?ARCv2EM=mARCv2EM
+MULTILIB_MATCHES += mcpu?ARCv2EM=mav2em
+
 #
-# These don't make sense for the ARC700 default target:
-MULTILIB_EXCEPTIONS=mmul64* mmul32x16* mnorm*
+# These don't make sense for the ARC700 or ARCv2 default target:
+MULTILIB_EXCEPTIONS = mmul64* mmul32x16*
 # And neither of the -mmul* options make sense without -mnorm:
-MULTILIB_EXCLUSIONS=mARC600/mmul64/!mnorm mcpu=ARC601/mmul64/!mnorm mARC600/mmul32x16/!mnorm
+MULTILIB_EXCEPTIONS += mARC600/mmul64/!mnorm mcpu=ARC601/mmul64/!mnorm mARC600/mmul32x16/!mnorm
+# Exclusions for ARC700
+MULTILIB_EXCEPTIONS += mcpu=ARC700/mnorm* mcpu=ARC700/mmul64* mcpu=ARC700/mmul32x16*
+# Exclusions for ARCv2EM
+MULTILIB_EXCEPTIONS += mcpu=ARCv2EM/mmul64* mcpu=ARCv2EM/mmul32x16*
+
+# Local Variables:
+# mode: Makefile
+# End:

--- a/libgcc/ChangeLog.ARC
+++ b/libgcc/ChangeLog.ARC
@@ -1,3 +1,15 @@
+2013-08-22  Claudiu Zissulescu <claziss@synopsys.com>
+
+	* libgcc/config.host: Unique build configuration settings for ARC
+	processors.
+	* libgcc/config/arc/gmon/dcache_linesz.S: Disable reading the cache
+	configuration for EM.
+	* libgcc/config/arc/gmon/profil.S: Disable using profiling functions
+	for EM.
+	* libgcc/config/arc/lib1funcs.S: Use custom ASM code to emulate
+	div/rem, mult and floating point operations whenever these are not
+	available for the selected V2 architecture.
+
 2013-06-08  Joern Rennecke  <joern.rennecke@embecosm.com>
 
 	* config/arc/dp-hack.h

--- a/libgcc/config.host
+++ b/libgcc/config.host
@@ -319,21 +319,8 @@ alpha*-dec-*vms*)
 	md_unwind_header=alpha/vms-unwind.h
 	;;
 arc*-*-elf*)
-	case x"${with_cpu}" in
-	     xarc600|xarc601|xarc700)
-	     	echo "Configure for ARCv1"
-	     	tmake_file="arc/t-arc-newlib arc/t-arc"
-		extra_parts="crti.o crtn.o crtend.o crtbegin.o crtendS.o crtbeginS.o libgmon.a crtg.o crtgend.o"
-		;;
-	     xEM)
-	     	echo "Configure for ARCv2"
-		tmake_file="arc/t-arc-em t-fdpbit"
-		extra_parts="crti.o crtn.o crtend.o crtbegin.o crtendS.o crtbeginS.o crtg.o crtgend.o"
-                ;;
-	     *) echo "Unknown cpu type"
-	     	exit 1
-		;;
-        esac
+	tmake_file="arc/t-arc-newlib arc/t-arc"
+	extra_parts="crti.o crtn.o crtend.o crtbegin.o crtendS.o crtbeginS.o libgmon.a crtg.o crtgend.o"
 	;;
 arc*-*-linux-uclibc*)
 	tmake_file="${tmake_file} t-slibgcc-libgcc t-slibgcc-nolc-override arc/t-arc700-uClibc arc/t-arc"

--- a/libgcc/config/arc/gmon/dcache_linesz.S
+++ b/libgcc/config/arc/gmon/dcache_linesz.S
@@ -38,6 +38,7 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 	.global	__dcache_linesz
 	.balign	4
 __dcache_linesz:
+#ifndef __EM__
 	lr	r12,[D_CACHE_BUILD]
 	extb_s	r0,r12
 	breq_s	r0,0,.Lsz_nocache
@@ -51,5 +52,6 @@ __dcache_linesz:
 	asl_s	r0,r0,r12
 	j_s	[blink]
 .Lsz_nocache:
+#endif /* !__EM__ */
 	mov_s	r0,1
 	j_s	[blink]

--- a/libgcc/config/arc/gmon/profil.S
+++ b/libgcc/config/arc/gmon/profil.S
@@ -45,6 +45,7 @@ __profil_offset:
 	.global	__dcache_linesz
 	.global __profil
 	FUNC(__profil)
+#ifndef __EM__
 .Lstop_profiling:
 	sr	r0,[CONTROL0]
 	j_s	[blink]
@@ -107,11 +108,18 @@ nocache:
 	j_s	[blink]
 	.balign	4
 1:	j	__profil_irq
+#else
+__profil:
+	.balign	4
+	mov_s	r0,0
+	j_s	[blink]
+#endif /* !__EM__ */
 	ENDFUNC(__profil)
 
 	FUNC(__profil_irq)
 	.balign 4	; make final jump unaligned to avoid delay penalty
 	.balign 32,0,12	; make sure the code spans no more that two cache lines
+#ifndef __EM__
 	nop_s
 __profil_irq:
 	push_s	r0
@@ -129,6 +137,7 @@ nostore:ld.ab	r2,[sp,8]
 	pop_s	r0
 	j.f	[ilink1]
 	ENDFUNC(__profil_irq)
+#endif /* !__EM__ */
 
 ; could save one cycle if the counters were allocated at link time and
 ; the contents of __profil_offset were pre-computed at link time, like this:

--- a/libgcc/config/arc/lib1funcs.S
+++ b/libgcc/config/arc/lib1funcs.S
@@ -32,29 +32,29 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
    This exception does not however invalidate any other reasons why
    the executable file might be covered by the GNU General Public License.  */
 
- 
+
  /* ANSI concatenation macros.  */
- 
+
  #define CONCAT1(a, b) CONCAT2(a, b)
  #define CONCAT2(a, b) a ## b
- 
+
  /* Use the right prefix for global labels.  */
- 
+
  #define SYM(x) CONCAT1 (__USER_LABEL_PREFIX__, x)
- 
+
 #ifndef WORKING_ASSEMBLER
 #define abs_l abs
 #define asl_l asl
 #define mov_l mov
 #endif
- 	
+
 #define FUNC(X)         .type SYM(X),@function
 #define HIDDEN_FUNC(X)	FUNC(X)` .hidden X
 #define ENDFUNC0(X)     .Lfe_##X: .size X,.Lfe_##X-X
 #define ENDFUNC(X)      ENDFUNC0(X)
 
-	
-	
+
+
 #ifdef  L_mulsi3
 	.section .text
 	.align 4
@@ -64,10 +64,10 @@ SYM(__mulsi3):
 
 /* This the simple version.
 
-  while (a) 
+  while (a)
     {
       if (a & 1)
-        r += b;
+	r += b;
       a >>= 1;
       b <<= 1;
     }
@@ -98,7 +98,7 @@ SYM(__mulsi3):
 	add_s	r1,r1,r1
 .Lend:	j_s [blink]
 	ENDFUNC(__mulsi3)
-#elif !defined (__OPTIMIZE_SIZE__) && !defined(__ARC601__)
+#elif !defined (__OPTIMIZE_SIZE__) && !defined(__ARC601__) && defined (__Xbarrel_shifter)
 	/* Up to 3.5 times faster than the simpler code below, but larger.  */
 	FUNC(__mulsi3)
 	ror.f	r2,r0,4
@@ -119,7 +119,7 @@ SYM(__mulsi3):
 	add2.cs	r0,r0,r1
 	j_s	[blink]
 	ENDFUNC(__mulsi3)
-#elif !defined (__OPTIMIZE_SIZE__) /* __ARC601__ */
+#elif !defined (__OPTIMIZE_SIZE__) /* __ARC601__, anything without barrel shifter */
 	FUNC(__mulsi3)
 	lsr.f r2,r0
 	mov_s r0,0
@@ -132,7 +132,7 @@ SYM(__mulsi3):
 	add2.cs r0,r0,r1
 	lsr.f r2,r2
 	add3.cs r0,r0,r1
-	bne.d .Loop	
+	bne.d .Loop
 	add3 r1,r3,r1
 	j_s	[blink]
 	ENDFUNC(__mulsi3)
@@ -143,17 +143,17 @@ SYM(__mulsi3):
 .Lloop:
 	bbit0 r0,0,@.Ly
 	add_s r2,r2,r1		; r += b
-.Ly:	
+.Ly:
 	lsr_s r0,r0		; a >>= 1
-	asl_s r1,r1		; b <<= 1	
-	brne_s r0,0,@.Lloop	
+	asl_s r1,r1		; b <<= 1
+	brne_s r0,0,@.Lloop
 .Ldone:
 	j_s.d [blink]
 	mov_s r0,r2
 	ENDFUNC(__mulsi3)
 /********************************************************/
 #endif
-	
+
 #endif /* L_mulsi3 */
 
 #ifdef  L_umulsidi3
@@ -178,10 +178,10 @@ SYM(__umulsi3_highpart):
 
 /* This the simple version.
 
-  while (a) 
+  while (a)
     {
       if (a & 1)
-        r += b;
+	r += b;
       a >>= 1;
       b <<= 1;
     }
@@ -368,7 +368,8 @@ SYM(__udivmodsi4):
 	j_s.d	[blink]
 	mov.c	r0,0
 #elif !defined (__OPTIMIZE_SIZE__)
-#ifdef __ARC_NORM__
+#if defined (__ARC_NORM__) && defined (__Xbarrel_shifter)
+	/* Anything with norm and barrel_shifter instructions. */
 	lsr_s r2,r0
 	brhs.d r1,r2,.Lret0_3
 	norm r2,r2
@@ -393,12 +394,17 @@ SYM(__udivmodsi4):
 	lsr_s r1,r1
 	cmp_s r0,r1
 	xor.f r2,lp_count,31
+#ifndef __EM__
 	mov_s lp_count,r2
+#else
+	mov lp_count,r2
+	nop_s
+#endif /* !__EM__ */
 #endif /* !__ARC_NORM__ */
 	sub.cc r0,r0,r1
 	mov_s r3,3
 	sbc r3,r3,0
-#ifndef __ARC601__
+#if !defined (__ARC601__) && defined (__Xbarrel_shifter)
 	asl_s r3,r3,r2
 	rsub r1,r1,1
 	lpne @.Lloop2_end
@@ -450,18 +456,18 @@ SYM(__udivmodsi4):
 	mov_s r2,1		; bit = 1
 	mov_s r3,0		; res = 0
 .Lloop1:
-  	brhs r1,r0,@.Lloop2
+	brhs r1,r0,@.Lloop2
 	bbit1 r1,31,@.Lloop2
 	asl_s r1,r1		; den <<= 1
 	b.d @.Lloop1
 	asl_s r2,r2		; bit <<= 1
 .Lloop2:
-  	brlo r0,r1,@.Lshiftdown
+	brlo r0,r1,@.Lshiftdown
 	sub_s r0,r0,r1		; num -= den
 	or_s r3,r3,r2		; res |= bit
 .Lshiftdown:
 	lsr_s r2,r2		; bit >>= 1
-	lsr_s r1,r1		; den >>= 1	
+	lsr_s r1,r1		; den >>= 1
 	brne_s r2,0,@.Lloop2
 .Ldivmodend:
 	mov_s r1,r0		; r1 = mod
@@ -471,7 +477,7 @@ SYM(__udivmodsi4):
 #endif
 	ENDFUNC(__udivmodsi4)
 
-#endif
+#endif /* L_divmod_tools */
 
 #ifdef  L_udivsi3
 	.section .text
@@ -780,15 +786,15 @@ __muldiv:
 	neg	r4,r2
 	ld.as	r5,[pcl,r4]
 	abs_s	r12,r0
-        bic.f	0,r2,r4
-        mpyhu.ne r12,r12,r5
+	bic.f	0,r2,r4
+	mpyhu.ne r12,r12,r5
 	norm	r3,r2
 	xor.f	0,r0,r1
-        ; write port allocation stall
-        rsub	r3,r3,30
-        lsr	r0,r12,r3
-        j_s.d	[blink]
-        neg.mi	r0,r0
+	; write port allocation stall
+	rsub	r3,r3,30
+	lsr	r0,r12,r3
+	j_s.d	[blink]
+	neg.mi	r0,r0
 
 	.balign	4
 SYM(__divsi3):
@@ -871,7 +877,7 @@ SYM(__divsi3):
 #endif	/* ifndef __ARC700__ */
 	ENDFUNC(__divsi3)
 
-	
+
 #endif /* L_divsi3 */
 
 #ifdef  L_umodsi3
@@ -908,11 +914,11 @@ SYM(__modsi3):
 	mov_s r6,r0
 	abs_s r0,r0
 	bl.d @SYM(__udivmodsi4)
-	 abs_s r1,r1
+	abs_s r1,r1
 	tst r6,r6
 	neg_s r0,r1
 	j_s.d [r12]
-	 mov.pl r0,r1
+	mov.pl r0,r1
 #else /* __ARC700__ */
 	abs_s	r2,r1
 	norm.f	r4,r0
@@ -946,7 +952,7 @@ SYM(__modsi3):
        .section .text
        .align 4
        .global SYM (__clzsi2)
-SYM(__clzsi2):	
+SYM(__clzsi2):
 #ifdef __ARC_NORM__
 	HIDDEN_FUNC(__clzsi2)
 	norm.f	r0,r0
@@ -954,7 +960,8 @@ SYM(__clzsi2):
 	j_s.d	[blink]
 	add.pl	r0,r0,1
 	ENDFUNC(__clzsi2)
-#elif defined (__ARC601__)
+#elif defined (__ARC601__) || !defined (__Xbarrel_shifter)
+	/* Anything wihtout barrel shifter */
 	FUNC(__clzsi2)
 	mov lp_count,10
 	mov_l r1,0
@@ -971,6 +978,7 @@ SYM(__clzsi2):
 	add.pl r0,r0,1
 	ENDFUNC(__clzsi2)
 #else
+	/* Only with barrel shifter */
 	FUNC(__clzsi2)
 	asl.f 0,r0,2
 	mov r1,-1
@@ -997,7 +1005,7 @@ SYM(__clzsi2):
 
 
 ;;; MILLICODE THUNK LIB ;***************
-	
+
 ;;; 	.macro push_regs from, to, offset
 ;;; 		st_s "\from", [sp, \offset]
 ;;; 		.if \to-\from
@@ -1014,22 +1022,22 @@ SYM(__clzsi2):
 ;;;;   		.set regno, \from+1
 ;;;;   		.set shift, 32
 ;;;;   		.set shift, shift - 1
-;;;;   #		st_s %shift @3 lsl #shift 
+;;;;   #		st_s %shift @3 lsl #shift
 ;;;;   		.if \to-\from
 ;;;;   		sum "(\from+1)", \to, "(\three)"
-;;;;   		.endif		
+;;;;   		.endif
 ;;;;   	.endm
-;;;;   	
+;;;;
 ;;;;   	SUM 0,5, 9
-;;;;   	
-;	.altmacro		
+;;;;
+;	.altmacro
 ;;  	.macro push_regs from=0, to=3, offset
 ;;  		st_s r\from, [sp, \offset]
 ;;  		.if \to-\from
 ;;  			push_regs "\from+1 ",\to,"(\offset+4)"
 ;;  		.endif
 ;;  	.endm
-;;  
+;;
 ;;  	.macro expand_to_push from=13, to
 ;;  ;		.section .text
 ;;  ;		.align 4
@@ -1037,11 +1045,11 @@ SYM(__clzsi2):
 ;;  ;		.type foo,
 ;;  	st_13_to_25:
 ;;  ;		push_regs \from, \to, 0
-;;  	push_regs 0,3		; 
+;;  	push_regs 0,3		;
 ;;  	.endm
-;;  
+;;
 ;;  	expand_to_push 13,18
-;;  
+;;
 ;#endif
 
 #ifdef L_millicodethunk_st
@@ -1072,25 +1080,25 @@ SYM(__clzsi2):
 	.align 4
 SYM(__st_r13_to_r25):
 	st r25, [sp,48]
-SYM(__st_r13_to_r24):	
+SYM(__st_r13_to_r24):
 	st r24, [sp,44]
-SYM(__st_r13_to_r23):	
+SYM(__st_r13_to_r23):
 	st r23, [sp,40]
-SYM(__st_r13_to_r22):	
+SYM(__st_r13_to_r22):
 	st r22, [sp,36]
-SYM(__st_r13_to_r21):	
+SYM(__st_r13_to_r21):
 	st r21, [sp,32]
-SYM(__st_r13_to_r20):	
-	st r20, [sp,28]		
-SYM(__st_r13_to_r19):	
+SYM(__st_r13_to_r20):
+	st r20, [sp,28]
+SYM(__st_r13_to_r19):
 	st r19, [sp,24]
-SYM(__st_r13_to_r18):	
+SYM(__st_r13_to_r18):
 	st r18, [sp,20]
-SYM(__st_r13_to_r17):	
+SYM(__st_r13_to_r17):
 	st r17, [sp,16]
-SYM(__st_r13_to_r16):	
+SYM(__st_r13_to_r16):
 	st r16, [sp,12]
-SYM(__st_r13_to_r15):	
+SYM(__st_r13_to_r15):
 #ifdef __ARC700__
 	st r15, [sp,8] ; minimum function size to avoid stall: 6 bytes.
 #else
@@ -1098,7 +1106,7 @@ SYM(__st_r13_to_r15):
 #endif
 	st_s r14, [sp,4]
 	j_s.d [%blink]
-	st_s r13, [sp,0]	
+	st_s r13, [sp,0]
 	ENDFUNC(__st_r13_to_r15)
 	ENDFUNC(__st_r13_to_r16)
 	ENDFUNC(__st_r13_to_r17)
@@ -1116,7 +1124,7 @@ SYM(__st_r13_to_r15):
 #ifdef L_millicodethunk_ld
 	.section .text
 	.align 4
-;	================================== 
+;	==================================
 ;	the loads
 
 	.global SYM(__ld_r13_to_r15)
@@ -1152,7 +1160,7 @@ SYM(__ld_r13_to_r22):
 SYM(__ld_r13_to_r21):
 	ld r21, [sp,32]
 SYM(__ld_r13_to_r20):
-	ld r20, [sp,28]		
+	ld r20, [sp,28]
 SYM(__ld_r13_to_r19):
 	ld r19, [sp,24]
 SYM(__ld_r13_to_r18):
@@ -1221,7 +1229,7 @@ SYM(__ld_r13_to_r22_ret):
 SYM(__ld_r13_to_r21_ret):
 	ld r21, [sp,32]
 SYM(__ld_r13_to_r20_ret):
-	ld r20, [sp,28]		
+	ld r20, [sp,28]
 SYM(__ld_r13_to_r19_ret):
 	ld r19, [sp,24]
 SYM(__ld_r13_to_r18_ret):
@@ -1262,9 +1270,9 @@ SYM(__ld_r13_to_r14_ret):
 #ifdef  L_muldf3
 #ifdef __ARC700__
 #include "ieee-754/muldf3.S"
-#elif defined (__ARC_NORM__) && defined(__ARC_MUL64__)
+#elif defined (__ARC_NORM__) && defined (__ARC_MUL64__)
 #include "ieee-754/arc600-mul64/muldf3.S"
-#elif defined (__ARC_NORM__) && defined(__ARC_MUL32BY16__)
+#elif defined (__ARC_NORM__) && defined (__ARC_MUL32BY16__)
 #include "ieee-754/arc600-dsp/muldf3.S"
 #endif
 #endif
@@ -1278,9 +1286,9 @@ SYM(__ld_r13_to_r14_ret):
 #ifdef  L_mulsf3
 #ifdef __ARC700__
 #include "ieee-754/mulsf3.S"
-#elif defined (__ARC_NORM__) && defined(__ARC_MUL64__)
+#elif defined (__ARC_NORM__) && defined (__ARC_MUL64__)
 #include "ieee-754/arc600-mul64/mulsf3.S"
-#elif defined (__ARC_NORM__) && defined(__ARC_MUL32BY16__)
+#elif defined (__ARC_NORM__) && defined (__ARC_MUL32BY16__)
 #include "ieee-754/arc600-dsp/mulsf3.S"
 #elif defined (__ARC_NORM__)
 #include "ieee-754/arc600/mulsf3.S"
@@ -1290,9 +1298,9 @@ SYM(__ld_r13_to_r14_ret):
 #ifdef  L_divdf3
 #ifdef __ARC700__
 #include "ieee-754/divdf3.S"
-#elif defined (__ARC_NORM__) && defined(__ARC_MUL64__)
+#elif defined (__ARC_NORM__) && defined (__ARC_MUL64__)
 #include "ieee-754/arc600-mul64/divdf3.S"
-#elif defined (__ARC_NORM__) && defined(__ARC_MUL32BY16__)
+#elif defined (__ARC_NORM__) && defined (__ARC_MUL32BY16__)
 #include "ieee-754/arc600-dsp/divdf3.S"
 #endif
 #endif


### PR DESCRIPTION
Unified configuration/building system for either architectural variants. Now, selecting --with-multilib, the building infrastructure builds the required libraries for EM or ARC600/ARC700. I.e., selecting with-cpu=arc700, the multilib feature builds additionally EM specific libs. While with-cpu=EM, the multilib feature builds ARCv1 specific libs.
