### PR TITLE
libstdc++: Disable gc-sections to work around binutils bug

### DIFF
--- a/libstdc++-v3/acinclude.m4
+++ b/libstdc++-v3/acinclude.m4
@@ -296,9 +296,6 @@ AC_DEFUN([GLIBCXX_CHECK_LINKER_FEATURES], [
       fi
       rm -f conftest.c conftest.o conftest
     fi
-    if test "$ac_gcsections" = "yes"; then
-      SECTION_LDFLAGS="-Wl,--gc-sections $SECTION_LDFLAGS"
-    fi
     AC_MSG_RESULT($ac_gcsections)
 
     if test "$ac_test_CFLAGS" = set; then

--- a/libstdc++-v3/configure
+++ b/libstdc++-v3/configure
@@ -20653,9 +20653,6 @@ rm -f core conftest.err conftest.$ac_objext \
       fi
       rm -f conftest.c conftest.o conftest
     fi
-    if test "$ac_gcsections" = "yes"; then
-      SECTION_LDFLAGS="-Wl,--gc-sections $SECTION_LDFLAGS"
-    fi
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_gcsections" >&5
 $as_echo "$ac_gcsections" >&6; }
 
@@ -27688,9 +27685,6 @@ rm -f core conftest.err conftest.$ac_objext \
       fi
       rm -f conftest.c conftest.o conftest
     fi
-    if test "$ac_gcsections" = "yes"; then
-      SECTION_LDFLAGS="-Wl,--gc-sections $SECTION_LDFLAGS"
-    fi
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_gcsections" >&5
 $as_echo "$ac_gcsections" >&6; }
 
@@ -33618,9 +33612,6 @@ rm -f core conftest.err conftest.$ac_objext \
 	fi
       fi
       rm -f conftest.c conftest.o conftest
-    fi
-    if test "$ac_gcsections" = "yes"; then
-      SECTION_LDFLAGS="-Wl,--gc-sections $SECTION_LDFLAGS"
     fi
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_gcsections" >&5
 $as_echo "$ac_gcsections" >&6; }
@@ -45496,9 +45487,6 @@ rm -f core conftest.err conftest.$ac_objext \
       fi
       rm -f conftest.c conftest.o conftest
     fi
-    if test "$ac_gcsections" = "yes"; then
-      SECTION_LDFLAGS="-Wl,--gc-sections $SECTION_LDFLAGS"
-    fi
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_gcsections" >&5
 $as_echo "$ac_gcsections" >&6; }
 
@@ -45709,9 +45697,6 @@ rm -f core conftest.err conftest.$ac_objext \
 	fi
       fi
       rm -f conftest.c conftest.o conftest
-    fi
-    if test "$ac_gcsections" = "yes"; then
-      SECTION_LDFLAGS="-Wl,--gc-sections $SECTION_LDFLAGS"
     fi
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_gcsections" >&5
 $as_echo "$ac_gcsections" >&6; }
@@ -46184,9 +46169,6 @@ rm -f core conftest.err conftest.$ac_objext \
 	fi
       fi
       rm -f conftest.c conftest.o conftest
-    fi
-    if test "$ac_gcsections" = "yes"; then
-      SECTION_LDFLAGS="-Wl,--gc-sections $SECTION_LDFLAGS"
     fi
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_gcsections" >&5
 $as_echo "$ac_gcsections" >&6; }
@@ -52470,9 +52452,6 @@ rm -f core conftest.err conftest.$ac_objext \
       fi
       rm -f conftest.c conftest.o conftest
     fi
-    if test "$ac_gcsections" = "yes"; then
-      SECTION_LDFLAGS="-Wl,--gc-sections $SECTION_LDFLAGS"
-    fi
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_gcsections" >&5
 $as_echo "$ac_gcsections" >&6; }
 
@@ -58386,9 +58365,6 @@ rm -f core conftest.err conftest.$ac_objext \
       fi
       rm -f conftest.c conftest.o conftest
     fi
-    if test "$ac_gcsections" = "yes"; then
-      SECTION_LDFLAGS="-Wl,--gc-sections $SECTION_LDFLAGS"
-    fi
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_gcsections" >&5
 $as_echo "$ac_gcsections" >&6; }
 
@@ -58552,9 +58528,6 @@ rm -f core conftest.err conftest.$ac_objext \
 	fi
       fi
       rm -f conftest.c conftest.o conftest
-    fi
-    if test "$ac_gcsections" = "yes"; then
-      SECTION_LDFLAGS="-Wl,--gc-sections $SECTION_LDFLAGS"
     fi
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_gcsections" >&5
 $as_echo "$ac_gcsections" >&6; }
@@ -58780,9 +58753,6 @@ rm -f core conftest.err conftest.$ac_objext \
 	fi
       fi
       rm -f conftest.c conftest.o conftest
-    fi
-    if test "$ac_gcsections" = "yes"; then
-      SECTION_LDFLAGS="-Wl,--gc-sections $SECTION_LDFLAGS"
     fi
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_gcsections" >&5
 $as_echo "$ac_gcsections" >&6; }
@@ -64696,9 +64666,6 @@ rm -f core conftest.err conftest.$ac_objext \
 	fi
       fi
       rm -f conftest.c conftest.o conftest
-    fi
-    if test "$ac_gcsections" = "yes"; then
-      SECTION_LDFLAGS="-Wl,--gc-sections $SECTION_LDFLAGS"
     fi
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_gcsections" >&5
 $as_echo "$ac_gcsections" >&6; }


### PR DESCRIPTION
I don't think this should go into mainline, as this is a workaround usefull only for released source code.

This is to work around the following error message:
BFD (GNU Binutils) 2.23.2 assertion fail elf32-arc.c:2140

Signed-off-by: Mischa Jonker mjonker@synopsys.com
Signed-off-by: Anton Kolesov anton.kolesov@synopsys.com
