### PR TITLE
Restore blink register after millicode optimisation.

### DIFF
--- a/gcc/ChangeLog.ARC
+++ b/gcc/ChangeLog.ARC
@@ -1,3 +1,8 @@
+2015-04-08  Andrew Burgess  <andrew.burgess@embecosm.com>
+
+	* config/arc/arc.c (arc_expand_prologue): Restore blink register
+	if needed after millicode optimisation.
+
 2015-03-24  Claudiu Zissulescu <claziss@synopsys.com>
 	    Andrew Burgess  <andrew.burgess@embecosm.com>
 


### PR DESCRIPTION
If the blink register is read in a function that has made use of the
millicode optimisation to spill registers to the stack then, previously,
we would read an invalid value for the blink register.  This patch adds
code to restore the blink register from the stack, ensuring that the
correct value of blink is read.

gcc/ChangeLog:

```
* config/arc/arc.c (arc_expand_prologue): Restore blink register
if needed after millicode optimisation.
```
