### PR TITLE
Fix cross building for Windows

### DIFF
--- a/gcc/ChangeLog.ARC
+++ b/gcc/ChangeLog.ARC
@@ -1,3 +1,7 @@
+2015-05-20  Anton Kolesov  <Anton.Kolesov@synopsys.com>
+
+	* config.gcc: Allow configuration without --with-cpu=.
+
 2015-05-20  Claudiu Zissulescu <claziss@synopsys.com>
 
 	* common/config/arc/arc-common.c: ATOMIC opts only for ARC 700

--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -3298,7 +3298,7 @@ case "${target}" in
 	arc*-*-*) # was:	arc*-*-linux-uclibc)
 		supported_defaults="cpu abi"
 		case $with_cpu in
-		  arc600|arc601|arc700|EM|HS|arcem|archs)
+		  ""|arc600|arc601|arc700|EM|HS|arcem|archs)
 			;;
 		  *) echo "Unknown cpu type"
 			exit 1

--- a/libgcc/ChangeLog
+++ b/libgcc/ChangeLog
@@ -1,3 +1,7 @@
+2014-08-13  Steve Ellcey  <sellcey@mips.com>
+
+	* crtstuff.c: Undef caddr_t.
+
 2014-12-19  Release Manager
 
 	* GCC 4.8.4 released.

--- a/libgcc/crtstuff.c
+++ b/libgcc/crtstuff.c
@@ -52,6 +52,7 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
    identified the set of defines that need to go into auto-target.h,
    this will have to do.  */
 #include "auto-host.h"
+#undef caddr_t
 #undef pid_t
 #undef rlim_t
 #undef ssize_t


### PR DESCRIPTION
When building GNU Toolchain for Windows on a Linux host I get an error:

```
$ arc-elf32-gcc   -g -O2 -DIN_GCC -DCROSS_DIRECTORY_STRUCTURE -isystem \
./include  -I. -I. -I../.././gcc -I/home/akolesov/ws/arc-2015.06-beta1/gcc/libgcc \
-I/home/akolesov/ws/arc-2015.06-beta1/gcc/libgcc/. \
-I/home/akolesov/ws/arc-2015.06-beta1/gcc/libgcc/../gcc \
-I/home/akolesov/ws/arc-2015.06-beta1/gcc/libgcc/../include   \
-g0 -finhibit-size-directive -fno-inline -fno-exceptions -fno-zero-initialized-in-bss \
-fno-toplevel-reorder -fno-tree-vectorize -fno-stack-protector  -I. -I. -I../.././gcc \
-I/home/akolesov/ws/arc-2015.06-beta1/gcc/libgcc \
-I/home/akolesov/ws/arc-2015.06-beta1/gcc/libgcc/. \
-I/home/akolesov/ws/arc-2015.06-beta1/gcc/libgcc/../gcc \
-I/home/akolesov/ws/arc-2015.06-beta1/gcc/libgcc/../include -o crtbegin.o  \
-c /home/akolesov/ws/arc-2015.06-beta1/gcc/libgcc/crtstuff.c -DCRT_BEGIN
In file included from /home/akolesov/ws/arc-2015.06-beta1/gcc/libgcc/crtstuff.c:54:0:
../.././gcc/auto-host.h:1940:17: error: expected identifier or ‘(’ before ‘char’
 #define caddr_t char *
```

That error happens only on canadian cross build, because `caddr_t` is defined in `auto-host.h` only for it, but not for the native build. I do not know why. In fact I don't even really understand why current code causes an error. But applying this magically fixes my woes.

Unfortunately commit description instead of explaining _why_ this patch is required and what it fixes, explains only what is being done, which is a waste of bytes for such a short patch,
