### PR TITLE
Add -mno-sdata option to the test's compilation options

### DIFF
--- a/gcc/ChangeLog.ARC
+++ b/gcc/ChangeLog.ARC
@@ -1,3 +1,8 @@
+2015-06-03  Yuriy Kolerov  <yuriy.kolerov@synopsys.com>
+
+	* gcc/testsuite/gcc.dg/tree-ssa/ssa-store-ccp-2.c: Add
+	-mno-sdata option to the test's compilation options.
+
 2015-05-26  Claudiu Zissulescu <claziss@synopsys.com>
 
 	* common/config/arc/arc-common.c (arc_handle_option): Fix mpy

--- a/gcc/testsuite/gcc.dg/tree-ssa/ssa-store-ccp-2.c
+++ b/gcc/testsuite/gcc.dg/tree-ssa/ssa-store-ccp-2.c
@@ -1,5 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-O2 -fdump-tree-optimized" } */
+/* { dg-options "-O2 -fdump-tree-optimized -mno-sdata" { target arc*-*-elf32 } } */
 
 const int conststaticvariable;
 


### PR DESCRIPTION
SDATA section is forced by default and ARC compiler decides
to omit global constants references before linking stage.
Thus this test fails:
`gcc/testsuite/gcc.dg/tree-ssa/ssa-store-ccp-2.c`

It's necessary to pass -mno-sdata option to the compiler
to not use SDATA section.

STAR: 9000905889

Signed-off-by: Yuriy Kolerov yuriy.kolerov@synopsys.com
