### PR TITLE
Mark some -fcompare-debug tests as expected fails

### DIFF
--- a/gcc/ChangeLog.ARC
+++ b/gcc/ChangeLog.ARC
@@ -1,3 +1,19 @@
+2015-06-03  Yuriy Kolerov  <yuriy.kolerov@synopsys.com>
+
+	* gcc/testsuite/c-c++-common/pr44832.c: Mark as expected
+	fail for ARC targets because -fcompare-debug check always
+	fails because of the feature of the current ZOL
+	implementation.
+	* gcc/testsuite/gcc.dg/pr42630.c: Likewise.
+	* gcc/testsuite/gcc.dg/pr42631.c: Likewise.
+	* gcc/testsuite/gcc.dg/pr42916.c: Likewise.
+	* gcc/testsuite/gcc.dg/pr44023.c: Likewise.
+	* gcc/testsuite/gcc.dg/pr46771.c: Likewise.
+	* gcc/testsuite/gcc.dg/pr47881.c: Likewise.
+	* gcc/testsuite/gcc.dg/pr48159-1.c: Likewise.
+	* gcc/testsuite/gcc.dg/pr48159-2.c: Likewise.
+	* gcc/testsuite/gcc.dg/pr50017.c: Likewise.
+
 2015-05-26  Claudiu Zissulescu <claziss@synopsys.com>
 
 	* common/config/arc/arc-common.c (arc_handle_option): Fix mpy

--- a/gcc/testsuite/c-c++-common/pr44832.c
+++ b/gcc/testsuite/c-c++-common/pr44832.c
@@ -3,6 +3,7 @@
 /* { dg-options "-O2 -fcompare-debug" } */
 /* { dg-options "-O2 -fcompare-debug -fno-short-enums" {target short_enums} } */
 /* { dg-require-effective-target int32plus } */
+/* { dg-xfail-if "" { arc*-*-* } { "*" } { "" } } */
 
 struct rtx_def;
 typedef struct rtx_def *rtx;

--- a/gcc/testsuite/gcc.dg/pr42630.c
+++ b/gcc/testsuite/gcc.dg/pr42630.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-O1 -fvariable-expansion-in-unroller -funroll-loops -fcompare-debug" } */
-/* { dg-xfail-if "" { powerpc-ibm-aix* } { "*" } { "" } } */
+/* { dg-xfail-if "" { powerpc-ibm-aix* arc*-*-* } { "*" } { "" } } */
 
 int sum(int *buf, int len)
 {

--- a/gcc/testsuite/gcc.dg/pr42631.c
+++ b/gcc/testsuite/gcc.dg/pr42631.c
@@ -15,7 +15,7 @@
 
 /* { dg-do compile } */
 /* { dg-options "-g -O1 -funroll-loops -fcompare-debug" } */
-/* { dg-xfail-if "" { powerpc-ibm-aix* } { "*" } { "" } } */
+/* { dg-xfail-if "" { powerpc-ibm-aix* arc*-*-* } { "*" } { "" } } */
 
 void foo()
 {

--- a/gcc/testsuite/gcc.dg/pr42916.c
+++ b/gcc/testsuite/gcc.dg/pr42916.c
@@ -1,6 +1,6 @@
 /* { dg-do compile } */
 /* { dg-options "-O1 -funroll-loops -ftree-vectorize -fcompare-debug" } */
-/* { dg-xfail-if "" { powerpc-ibm-aix* } { "*" } { "" } } */
+/* { dg-xfail-if "" { powerpc-ibm-aix* arc*-*-* } { "*" } { "" } } */
 
 int seed;
 

--- a/gcc/testsuite/gcc.dg/pr44023.c
+++ b/gcc/testsuite/gcc.dg/pr44023.c
@@ -3,7 +3,7 @@
 /* { dg-options "-fcompare-debug -O2" } */
 /* { dg-options "-fcompare-debug -O2 -mcpu=ev67" { target alpha*-*-* } } */
 /* { dg-require-effective-target int32plus } */
-/* { dg-xfail-if "" { powerpc-ibm-aix* } { "*" } { "" } } */
+/* { dg-xfail-if "" { powerpc-ibm-aix* arc*-*-* } { "*" } { "" } } */
 
 void
 foo (unsigned f, long v, unsigned *w, unsigned a, unsigned b, unsigned e, unsigned c, unsigned d)

--- a/gcc/testsuite/gcc.dg/pr46771.c
+++ b/gcc/testsuite/gcc.dg/pr46771.c
@@ -1,7 +1,7 @@
 /* PR debug/46771 */
 /* { dg-do compile } */
 /* { dg-options "-O -ftree-vectorize -fcompare-debug" } */
-/* { dg-xfail-if "" { powerpc-ibm-aix* } { "*" } { "" } } */
+/* { dg-xfail-if "" { powerpc-ibm-aix* arc*-*-* } { "*" } { "" } } */
 
 unsigned char v[1600];
 

--- a/gcc/testsuite/gcc.dg/pr47881.c
+++ b/gcc/testsuite/gcc.dg/pr47881.c
@@ -1,7 +1,7 @@
 /* PR debug/47881 */
 /* { dg-do compile } */
 /* { dg-options "-O -fcompare-debug -fno-dce -funroll-loops -fno-web" } */
-/* { dg-xfail-if "" { powerpc-ibm-aix* } { "*" } { "" } } */
+/* { dg-xfail-if "" { powerpc-ibm-aix* arc*-*-* } { "*" } { "" } } */
 
 extern int data[];
 

--- a/gcc/testsuite/gcc.dg/pr48159-1.c
+++ b/gcc/testsuite/gcc.dg/pr48159-1.c
@@ -1,6 +1,7 @@
 /* PR debug/48159 */
 /* { dg-do compile } */
 /* { dg-options "-O3 -fcompare-debug" } */
+/* { dg-xfail-if "" { arc*-*-* } { "*" } { "" } } */
 
 void
 foo (double x, int y, double *__restrict z, double *__restrict w)

--- a/gcc/testsuite/gcc.dg/pr48159-2.c
+++ b/gcc/testsuite/gcc.dg/pr48159-2.c
@@ -1,6 +1,7 @@
 /* PR debug/48159 */
 /* { dg-do compile } */ 
 /* { dg-options "-O2 -ftree-loop-distribution -fcompare-debug" } */
+/* { dg-xfail-if "" { arc*-*-* } { "*" } { "" } } */
 
 int foo (int * __restrict__ ia, int * __restrict__ ib,
 	 int * __restrict__ oxa, int * __restrict__ oxb)

--- a/gcc/testsuite/gcc.dg/pr50017.c
+++ b/gcc/testsuite/gcc.dg/pr50017.c
@@ -1,7 +1,7 @@
 /* PR debug/50017 */
 /* { dg-do compile } */
 /* { dg-options "-O3 -fcompare-debug" } */
-/* { dg-xfail-if "" { powerpc-ibm-aix* } { "*" } { "" } } */
+/* { dg-xfail-if "" { powerpc-ibm-aix* arc*-*-* } { "*" } { "" } } */
 
 struct S { int r, i; };
 


### PR DESCRIPTION
These tests always fail because of the feature of the current ZOL implementation for ARC targets.

Point is that one value in the internal representation always differs for debug and not debug configuration. The value that is changing is the INSN_UID of loop end insn. The INSN_UID may vary from compilation to compilation. Hence, the error.

When ZOL implementation will be changed these tests must be reviewed.

STAR: 9000906644

Signed-off-by: Yuriy Kolerov yuriy.kolerov@synopsys.com
