### PR TITLE
Add -mno-sdata option to the generator of tests for bare metal

### DIFF
--- a/gcc/ChangeLog.ARC
+++ b/gcc/ChangeLog.ARC
@@ -1,3 +1,13 @@
+2015-06-03  Yuriy Kolerov  <yuriy.kolerov@synopsys.com>
+
+	* gcc/testsuite/g++.dg/compat/struct-layout-1_generate.c: 
+	Add -mno-sdata option to the generator of tests for bare
+	metal targets. It's necessary because the generator
+	generates too much global variables for "t001" test and
+	linker fails because some of them don't fit to SDATA.
+	* gcc/testsuite/gcc.dg/compat/struct-layout-1_generate.c:
+	Likewise.
+
 2015-06-09  Andrew Burgess  <andrew.burgess@embecosm.com>
 
 	* config/arc/arc.c (arc_compute_frame_size): Disable millicode

--- a/gcc/testsuite/g++.dg/compat/struct-layout-1_generate.c
+++ b/gcc/testsuite/g++.dg/compat/struct-layout-1_generate.c
@@ -49,7 +49,8 @@ const char *dg_options[] = {
 "/* { dg-options \"%s-I%s -fno-common\" { target hppa*-*-hpux* powerpc*-*-darwin* *-*-mingw32* *-*-cygwin* } } */\n",
 "/* { dg-options \"%s-I%s -mno-mmx -fno-common -Wno-abi\" { target i?86-*-darwin* x86_64-*-darwin* i?86-*-mingw32* x86_64-*-mingw32* i?86-*-cygwin* } } */\n",
 "/* { dg-options \"%s-I%s -mno-base-addresses\" { target mmix-*-* } } */\n",
-"/* { dg-options \"%s-I%s -mlongcalls -mtext-section-literals\" { target xtensa*-*-* } } */\n"
+"/* { dg-options \"%s-I%s -mlongcalls -mtext-section-literals\" { target xtensa*-*-* } } */\n",
+"/* { dg-options \"%s-I%s -mno-sdata -Wno-abi\" { target arc*-*-elf32 } } */\n"
 #define NDG_OPTIONS (sizeof (dg_options) / sizeof (dg_options[0]))
 };
 

--- a/gcc/testsuite/gcc.dg/compat/struct-layout-1_generate.c
+++ b/gcc/testsuite/gcc.dg/compat/struct-layout-1_generate.c
@@ -50,7 +50,8 @@ const char *dg_options[] = {
 "/* { dg-options \"%s-I%s -fno-common\" { target hppa*-*-hpux* powerpc*-*-darwin* } } */\n",
 "/* { dg-options \"%s-I%s -mno-mmx -fno-common -Wno-abi\" { target i?86-*-darwin* x86_64-*-darwin* } } */\n",
 "/* { dg-options \"%s-I%s -mno-base-addresses\" { target mmix-*-* } } */\n",
-"/* { dg-options \"%s-I%s -mlongcalls -mtext-section-literals\" { target xtensa*-*-* } } */\n"
+"/* { dg-options \"%s-I%s -mlongcalls -mtext-section-literals\" { target xtensa*-*-* } } */\n",
+"/* { dg-options \"%s-I%s -mno-sdata -Wno-abi\" { target arc*-*-elf32 } } */\n"
 #define NDG_OPTIONS (sizeof (dg_options) / sizeof (dg_options[0]))
 };
 


### PR DESCRIPTION
This fix is related to these generators of tests:

```
gcc/testsuite/g++.dg/compat/struct-layout-1_generate.c
gcc/testsuite/gcc.dg/compat/struct-layout-1_generate.c
```

It's necessary because the generator generates too much global variables for "t001" test and linker fails because some of them doesn't fit to SDATA.

Signed-off-by: Yuriy Kolerov yuriy.kolerov@synopsys.com
