### PR TITLE
GCC generating out of range branch instructions.

### DIFF
--- a/gcc/ChangeLog.ARC
+++ b/gcc/ChangeLog.ARC
@@ -1,5 +1,10 @@
 2015-08-29  Andrew Burgess  <andrew.burgess@embecosm.com>
 
+	* config/arc/arc.md (doloop_begin_i): Remove duplicate code for
+	outputting alignment.
+
+2015-08-29  Andrew Burgess  <andrew.burgess@embecosm.com>
+
 	* config/arc/arc.c (arc_label_align): Switch from 'LABEL' to
 	'label'.
 

--- a/gcc/ChangeLog.ARC
+++ b/gcc/ChangeLog.ARC
@@ -1,5 +1,10 @@
 2015-08-29  Andrew Burgess  <andrew.burgess@embecosm.com>
 
+	* config/arc/arc.md (doloop_begin_i): Switch to using
+	ASM_OUTPUT_ALIGN.
+
+2015-08-29  Andrew Burgess  <andrew.burgess@embecosm.com>
+
 	* config/arc/arc.md (doloop_begin_i): Remove duplicate code for
 	outputting alignment.
 

--- a/gcc/ChangeLog.ARC
+++ b/gcc/ChangeLog.ARC
@@ -1,3 +1,8 @@
+2015-08-29  Andrew Burgess  <andrew.burgess@embecosm.com>
+
+	* config/arc/arc.c (arc_label_align): Switch from 'LABEL' to
+	'label'.
+
 2015-07-27  Claudiu Zissulescu  <claziss@synopsys.com>
 
 	* config/arc/arc.md (indirect_jump): Fix PRM inconsistency.

--- a/gcc/ChangeLog.ARC
+++ b/gcc/ChangeLog.ARC
@@ -1,5 +1,10 @@
 2015-08-29  Andrew Burgess  <andrew.burgess@embecosm.com>
 
+	* config/arc/arc.md (doloop_begin_i): Account for the effects
+	of alignment in instruction length.
+
+2015-08-29  Andrew Burgess  <andrew.burgess@embecosm.com>
+
 	* config/arc/arc.md (doloop_begin_i): Remove commented out code,
 	and associated comment.
 

--- a/gcc/ChangeLog.ARC
+++ b/gcc/ChangeLog.ARC
@@ -1,5 +1,10 @@
 2015-08-29  Andrew Burgess  <andrew.burgess@embecosm.com>
 
+	* config/arc/arc.md (doloop_begin_i): Remove commented out code,
+	and associated comment.
+
+2015-08-29  Andrew Burgess  <andrew.burgess@embecosm.com>
+
 	* config/arc/arc.md (doloop_begin_i): Only generate '0:' label if
 	required.
 

--- a/gcc/ChangeLog.ARC
+++ b/gcc/ChangeLog.ARC
@@ -1,5 +1,10 @@
 2015-08-29  Andrew Burgess  <andrew.burgess@embecosm.com>
 
+	* config/arc/arc.md (doloop_begin_i): Only generate '0:' label if
+	required.
+
+2015-08-29  Andrew Burgess  <andrew.burgess@embecosm.com>
+
 	* config/arc/arc.md (doloop_begin_i): Switch to using
 	ASM_OUTPUT_ALIGN.
 

--- a/gcc/ChangeLog.ARC
+++ b/gcc/ChangeLog.ARC
@@ -1,5 +1,13 @@
 2015-08-29  Andrew Burgess  <andrew.burgess@embecosm.com>
 
+	* config/arc/arc.md (pass_arc_hazard_avoidance): New variable.
+	(arc_init): Register new pass.
+	(arc_final_prescan_insn): Remove nop insertion.
+	(arc_hazard_avoidance): New function.
+	* timevar.def (TV_HAZARD_AVOID): New time variable.
+
+2015-08-29  Andrew Burgess  <andrew.burgess@embecosm.com>
+
 	* config/arc/arc.md (doloop_begin_i): Account for the effects
 	of alignment in instruction length.
 

--- a/gcc/config/arc/arc.c
+++ b/gcc/config/arc/arc.c
@@ -858,6 +858,29 @@ struct rtl_opt_pass pass_arc_ifcvt =
  }
 };
 
+
+static unsigned arc_hazard_avoidance (void);
+static struct rtl_opt_pass pass_arc_hazard_avoidance =
+{
+ {
+  RTL_PASS,
+  "arc_hazard",				/* name */
+  OPTGROUP_NONE,			/* optinfo_flags */
+  NULL,					/* gate */
+  arc_hazard_avoidance,			/* execute */
+  NULL,					/* sub */
+  NULL,					/* next */
+  0,					/* static_pass_number */
+  TV_HAZARD_AVOID,			/* tv_id */
+  0,					/* properties_required */
+  0,					/* properties_provided */
+  0,					/* properties_destroyed */
+  0,					/* todo_flags_start */
+  TODO_df_finish			/* todo_flags_finish */
+ }
+};
+
+
 /* Called by OVERRIDE_OPTIONS to initialize various things.  */
 
 void
@@ -1030,11 +1053,18 @@ arc_init (void)
 	1, PASS_POS_INSERT_BEFORE
       };
 
+  static struct register_pass_info arc_hazard_info
+    = { &pass_arc_hazard_avoidance.pass, "shorten",
+        1, PASS_POS_INSERT_BEFORE
+      };
+
   if (optimize > 1 && !TARGET_NO_COND_EXEC)
     {
       register_pass (&arc_ifcvt4_info);
       register_pass (&arc_ifcvt5_info);
     }
+
+  register_pass (&arc_hazard_info);
 }
 
 /* Check ARC options, generate derived target attributes.  */
@@ -4658,23 +4688,6 @@ arc_final_prescan_insn (rtx insn, rtx *opvec ATTRIBUTE_UNUSED,
 	fprintf (asm_out_file, " *");
       fprintf (asm_out_file, "\n");
     }
-
-  /* Output a nop if necessary to prevent a hazard.
-     Don't do this for delay slots: inserting a nop would
-     alter semantics, and the only time we would find a hazard is for a
-     call function result - and in that case, the hazard is spurious to
-     start with.  */
-  if (PREV_INSN (insn)
-      && PREV_INSN (NEXT_INSN (insn)) == insn
-      && arc_hazard (prev_real_insn (insn), insn))
-    {
-      current_output_insn =
-	emit_insn_before (gen_nop (), NEXT_INSN (PREV_INSN (insn)));
-      final_scan_insn (current_output_insn, asm_out_file, optimize, 1, NULL);
-      current_output_insn = insn;
-    }
-  /* Restore extraction data which might have been clobbered by arc_hazard.  */
-  extract_constrain_insn_cached (insn);
 
   if (!cfun->machine->prescan_initialized)
     {
@@ -9572,6 +9585,37 @@ arc_ifcvt (void)
 	}
       arc_ccfsm_post_advance (insn, statep);
     }
+  return 0;
+}
+
+/* ARC hazard avoidance.  It is important that this is done before branch
+   shortening, as this can insert nop instructions.
+
+   Some hazard avoidance is also performed at the start of arc_reorg (with
+   a call to workaround_arc_anomaly) it would be nice if that hazard
+   avoidance could also be moved here.  */
+
+static unsigned
+arc_hazard_avoidance (void)
+{
+  rtx insn;
+
+  for (insn = get_insns (); insn; insn = NEXT_INSN (insn))
+    {
+      /* Output a nop if necessary to prevent a hazard.
+         Don't do this for delay slots: inserting a nop would alter
+         semantics, and the only time we would find a hazard is for a call
+         function result - and in that case, the hazard is spurious to
+         start with.  */
+      if (PREV_INSN (insn)
+          && NEXT_INSN (insn)
+          && PREV_INSN (NEXT_INSN (insn)) == insn
+          && arc_hazard (prev_real_insn (insn), insn))
+        {
+          emit_insn_before (gen_nop (), NEXT_INSN (PREV_INSN (insn)));
+        }
+    }
+
   return 0;
 }
 

--- a/gcc/config/arc/arc.c
+++ b/gcc/config/arc/arc.c
@@ -10402,7 +10402,7 @@ arc_scheduling_not_expected (void)
 int
 arc_label_align (rtx label)
 {
-  int loop_align = LOOP_ALIGN (LABEL);
+  int loop_align = LOOP_ALIGN (label);
 
   if (loop_align > align_labels_log)
     {

--- a/gcc/config/arc/arc.md
+++ b/gcc/config/arc/arc.md
@@ -5042,20 +5042,8 @@
     loop_start = NULL_RTX;
   /* Size implications of the alignment will be taken care of by the
      alignment inserted at the loop start.  */
-  if (LOOP_ALIGN (0) && INTVAL (operands[1]))
-    {
-      asm_fprintf (asm_out_file, "\t.p2align %d\\n", LOOP_ALIGN (0));
-      arc_clear_unalign ();
-    }
   if (!INTVAL (operands[1]))
     return "; LITTLE LOST LOOP";
-  if (loop_start && flag_pic)
-    {
-      /* ??? Can do better for when a scratch register
-	 is known.  But that would require extra testing.  */
-      arc_clear_unalign ();
-      return ".p2align 2\;push_s r0\;add r0,pcl,@%4@pcl\;sr r0,[2]; LP_START\;add r0,pcl,@.L__GCC__LP%1@pcl\;sr r0,[3]; LP_END\;pop_s r0";
-    }
   /* Check if the loop end is in range to be set by the lp instruction.  */
   size = INTVAL (operands[3]) < 2 ? 0 : 2048;
   for (scan = insn; scan && size < 2048; scan = NEXT_INSN (scan))

--- a/gcc/config/arc/arc.md
+++ b/gcc/config/arc/arc.md
@@ -5101,7 +5101,7 @@
     }
   if (LOOP_ALIGN (0))
     {
-      asm_fprintf (asm_out_file, "\t.p2align %d\\n", LOOP_ALIGN (0));
+      ASM_OUTPUT_ALIGN (asm_out_file, LOOP_ALIGN (0));
       arc_clear_unalign ();
     }
   gcc_assert (n_insns || GET_CODE (next_nonnote_insn (insn)) == CODE_LABEL);
@@ -5112,7 +5112,8 @@
 	  /* ??? Can do better for when a scratch register
 	     is known.  But that would require extra testing.  */
 	  arc_clear_unalign ();
-	  return ".p2align 2\;push_s r0\;add r0,pcl,24\;sr r0,[2]; LP_START\;add r0,pcl,.L__GCC__LP%1-.+2\;sr r0,[3]; LP_END\;pop_s r0";
+	  ASM_OUTPUT_ALIGN (asm_out_file, 2);
+	  return "push_s r0\;add r0,pcl,24\;sr r0,[2]; LP_START\;add r0,pcl,.L__GCC__LP%1-.+2\;sr r0,[3]; LP_END\;pop_s r0";
 	}
       output_asm_insn ((size < 2048
 			? "lp .L__GCC__LP%1" : "sr .L__GCC__LP%1,[3]; LP_END"),

--- a/gcc/config/arc/arc.md
+++ b/gcc/config/arc/arc.md
@@ -5142,8 +5142,8 @@
 }
   [(set_attr "type" "loop_setup")
    (set_attr_alternative "length"
-     [(if_then_else (match_test "flag_pic") (const_int 26) (const_int 16))
-      (if_then_else (match_test "flag_pic") (const_int 30) (const_int 16))
+     [(if_then_else (match_test "flag_pic") (const_int 26) (const_int 18))
+      (if_then_else (match_test "flag_pic") (const_int 30) (const_int 18))
       (const_int 0)])]
   ;; ??? we should really branch shorten this insn, but then we'd
   ;; need a proper label first.  N.B. the end label can not only go out

--- a/gcc/config/arc/arc.md
+++ b/gcc/config/arc/arc.md
@@ -5123,7 +5123,11 @@
 		       operands);
       if (TARGET_ARC600 && n_insns < 1)
 	output_asm_insn ("nop", operands);
-      return (TARGET_ARC600 && n_insns < 3) ? "nop_s\;nop_s\;0:" : "0:";
+      if (TARGET_ARC600 && n_insns < 3)
+	 output_asm_insn ("nop_s\;nop_s", operands);
+      if (!loop_start)
+        output_asm_insn ("0:", operands);
+      return "";
     }
   else if (TARGET_ARC600 && n_insns < 3)
     {

--- a/gcc/config/arc/arc.md
+++ b/gcc/config/arc/arc.md
@@ -5142,9 +5142,6 @@
 }
   [(set_attr "type" "loop_setup")
    (set_attr_alternative "length"
-;     FIXME: length is usually 4, but we need branch shortening
-;     to get this right.
-;     [(if_then_else (match_test "TARGET_ARC600") (const_int 16) (const_int 4))
      [(if_then_else (match_test "flag_pic") (const_int 26) (const_int 16))
       (if_then_else (match_test "flag_pic") (const_int 30) (const_int 16))
       (const_int 0)])]

--- a/gcc/timevar.def
+++ b/gcc/timevar.def
@@ -255,6 +255,7 @@ DEFTIMEVAR (TV_TREE_UNINIT           , "uninit var analysis")
 DEFTIMEVAR (TV_PLUGIN_INIT           , "plugin initialization")
 DEFTIMEVAR (TV_PLUGIN_RUN            , "plugin execution")
 DEFTIMEVAR (TV_GIMPLE_SLSR           , "straight-line strength reduction")
+DEFTIMEVAR (TV_HAZARD_AVOID          , "hazard avoidance")
 
 /* Everything else in rest_of_compilation not included above.  */
 DEFTIMEVAR (TV_EARLY_LOCAL	     , "early local passes")


### PR DESCRIPTION
This series addresses a couple of issues where either instructions are under reporting their length, or where extra nop instructions are being added to the instruction stream at a very late stage.  Both of these problems cause branch shortening to make an incorrect choice about when a short branch can be used.  This in turn causes the generated assembler to fail to assemble.

This series starts with a few small clean up patches, the last two patches in the series are the real work.  Please see the individual commit messages for more detail on each patch.
