### PR TITLE
gcc: Fix generated assembler for doloop_begin_i.

### DIFF
--- a/gcc/ChangeLog.ARC
+++ b/gcc/ChangeLog.ARC
@@ -1,3 +1,8 @@
+2015-09-08  Andrew Burgess  <andrew.burgess@embecosm.com>
+
+	* config/arc/arc.md (doloop_begin_i): Make correct use of
+	parameters in generated assembler.
+
 2015-08-29  Andrew Burgess  <andrew.burgess@embecosm.com>
 
 	* config/arc/arc.md (pass_arc_hazard_avoidance): New variable.

--- a/gcc/config/arc/arc.md
+++ b/gcc/config/arc/arc.md
@@ -5113,7 +5113,7 @@
 	     is known.  But that would require extra testing.  */
 	  arc_clear_unalign ();
 	  ASM_OUTPUT_ALIGN (asm_out_file, 2);
-	  return "push_s r0\;add r0,pcl,24\;sr r0,[2]; LP_START\;add r0,pcl,.L__GCC__LP%1-.+2\;sr r0,[3]; LP_END\;pop_s r0";
+	  return "push_s r0\;add r0,pcl,@%4@pcl\;sr r0,[2]; LP_START\;add r0,pcl,@.L__GCC__LP%1@pcl\;sr r0,[3]; LP_END\;pop_s r0";
 	}
       output_asm_insn ((size < 2048
 			? "lp .L__GCC__LP%1" : "sr .L__GCC__LP%1,[3]; LP_END"),


### PR DESCRIPTION
Commit 23a04c4 removed some duplicate code from doloop_begin_i, however,
the second version of the code, which was never reached before, but now
is, was not quite correct; it failed to make use of the instruction
operands, instead hard coding values into the generated assembler.

Now that commit 23a04c4 has been made, the previously unused, second
piece of code is being tested, this commit fixes the problems by
updating the generated assembler to match the original that was removed
in 23a04c4, this should resolve all issues.

gcc/ChangeLog:

```
* config/arc/arc.md (doloop_begin_i): Make correct use of
parameters in generated assembler.
```
