### PR TITLE
arc: doloop_begin_i, handle NULL_RTX case.

### DIFF
--- a/gcc/ChangeLog.ARC
+++ b/gcc/ChangeLog.ARC
@@ -1,3 +1,8 @@
+2015-09-29  Andrew Burgess  <andrew.burgess@embecosm.com>
+
+	* config/arc/arc.md (doloop_begin_i): Handle case where
+	loop_start is NULL_RTX.
+
 2015-09-08  Andrew Burgess  <andrew.burgess@embecosm.com>
 
 	* config/arc/arc.md (doloop_begin_i): Make correct use of

--- a/gcc/config/arc/arc.md
+++ b/gcc/config/arc/arc.md
@@ -5113,7 +5113,22 @@
 	     is known.  But that would require extra testing.  */
 	  arc_clear_unalign ();
 	  ASM_OUTPUT_ALIGN (asm_out_file, 2);
-	  return "push_s r0\;add r0,pcl,@%4@pcl\;sr r0,[2]; LP_START\;add r0,pcl,@.L__GCC__LP%1@pcl\;sr r0,[3]; LP_END\;pop_s r0";
+	  output_asm_insn ("push_s r0", operands);
+	  if (loop_start == NULL_RTX)
+            /* When loop_start is NULL_RTX then the first instruction of
+               the loop is immediately after this doloop_begin_i
+               instruction, in order to load the start of loop address we
+               therefore use the immediate 24 here, this is the number of
+               bytes from the start of the 'push_s r0' above, to the start
+               of the instruction following 'pop_s r0' below.  */
+	    output_asm_insn ("add r0,pcl,24", operands);
+	  else
+            /* When loop_start is not NULL_RTX then the start of the loop
+               might be anywhere, we therefore need to load the loop_start
+               address using the label name, not a hard-coded immediate.  */
+	    output_asm_insn ("add r0,pcl,@%4@pcl", operands);
+	  output_asm_insn ("sr r0,[2]; LP_START", operands);
+	  return "add r0,pcl,@.L__GCC__LP%1@pcl\;sr r0,[3]; LP_END\;pop_s r0";
 	}
       output_asm_insn ((size < 2048
 			? "lp .L__GCC__LP%1" : "sr .L__GCC__LP%1,[3]; LP_END"),


### PR DESCRIPTION
In some cases the loop_start label can be NULL_RTX, this is when the
start of the loop immediately follows the doloop_being_i instruction, in
these cases we don't have a code label for the loop start, and so should
not try to generate a '@symbol@pcl' style relocation.  Instead, we
should hard-code the relative location of the start of loop instruction
into the instruction stream.

This commit continues the fix started in commit 20fc569, which
completely removed the hard coded immediate as a result of hitting a
case where the loop_start was a label that did not work with a hard
coded immediate.

gcc/ChangeLog:

```
* config/arc/arc.md (doloop_begin_i): Handle case where
loop_start is NULL_RTX.
```
