### PR TITLE
arc: Fix testcase for 9000727530 for newlib 2.2

### DIFF
--- a/gcc/ChangeLog.ARC
+++ b/gcc/ChangeLog.ARC
@@ -1,3 +1,6 @@
+2015-10-06  Anton Kolesov  <Anton.Kolesov@synopsys.com>
+	* testsuite/gcc.target/arc/pr9000727530.c: Include time.h
+
 2015-09-29  Andrew Burgess  <andrew.burgess@embecosm.com>
 
 	* config/arc/arc.md (doloop_begin_i): Handle case where

--- a/gcc/testsuite/gcc.target/arc/pr9000727530.c
+++ b/gcc/testsuite/gcc.target/arc/pr9000727530.c
@@ -6,6 +6,7 @@
    when checking the instruction constrains. */
 
 #include "stdio.h"
+#include "time.h"
 
 char *outfile;
 


### PR DESCRIPTION
Test case for STAR 9000727530 includes stdio.h and uses "struct timespec".
In newlib 2.0 "struct timespec" used to be defined in sys/types.h and
therefore was available through inclusion of stdio.h. In newlib 2.2, however
definition of timespec has been moved to separate file sys/timespec.h which
is not included by stdio.h and hence this test fail to compile with newlib
2.2, as "struct timespec" is unknown.

This patch fixes this by inclusion of time.h - this is a backward compatible
way, so test case continue to work for both newlib 2.0 and 2.2.

Signed-off-by: Anton Kolesov Anton.Kolesov@synopsys.com
