### PR TITLE
JLI Support

### DIFF
--- a/gcc/config/arc/arc-c.c
+++ b/gcc/config/arc/arc-c.c
@@ -106,3 +106,97 @@ arc_cpu_cpp_builtins (cpp_reader * pfile)
     builtin_define ("__big_endian__");
 
 }
+
+void
+arc_pr_jli_call_fixed (struct cpp_reader * pfile ATTRIBUTE_UNUSED)
+{
+  tree x;
+  enum cpp_ttype type;
+  char *symbol;
+  int index;
+
+  type = pragma_lex (&x);
+
+  if (type != CPP_OPEN_PAREN)
+  {
+    error ("expected '(' in #pragma jli_call_fixed");
+
+    return;
+  }
+
+  type = pragma_lex (&x);
+
+  if (type != CPP_NAME)
+  {
+    error ("expected function name in #pragma jli_call_fixed");
+
+    return;
+  }
+
+  symbol = strndup (IDENTIFIER_POINTER (x), 2048);
+
+  type = pragma_lex (&x);
+
+  if (type != CPP_COMMA)
+  {
+    free (symbol);
+
+    error ("expected ',' in #pragma jli_call_fixed");
+
+    return;
+  }
+
+  type = pragma_lex (&x);
+
+  if (type != CPP_NUMBER || TREE_CODE (x) != INTEGER_CST)
+  {
+    free (symbol);
+
+    error ("expected integer JLI index in #pragma jli_call_fixed");
+
+    return;
+  }
+
+  index = TREE_INT_CST_LOW (x);
+
+  if (0 > index || index > 1023)
+  {
+    free (symbol);
+
+    error ("out of range JLI index in #pragma jli_call_fixed");
+
+    return;
+  }
+
+  type = pragma_lex (&x);
+
+  if (type != CPP_CLOSE_PAREN)
+  {
+    free (symbol);
+
+    error ("expected ')' in #pragma jli_call_fixed");
+
+    return;
+  }
+
+  if (jli_table[index] != NULL)
+  {
+    free (jli_table[index]);
+
+    warning (OPT_Wpragmas, "function '%s' is already in the JLI table so the "
+      "index will be replaced with %d", symbol, index);
+  }
+
+  jli_table[index] = symbol;
+}
+
+void
+arc_pr_init (void)
+{
+  int i;
+
+  for(i = 0; i < 1024; ++i)
+  {
+    jli_table[i] = NULL;
+  }
+}

--- a/gcc/config/arc/arc-c.c
+++ b/gcc/config/arc/arc-c.c
@@ -20,10 +20,13 @@ along with GCC; see the file COPYING3.  If not see
 #include "system.h"
 #include "coretypes.h"
 #include "tm.h"
+#include "cpplib.h"
 #include "tree.h"
 #include "tm_p.h"
 #include "cpplib.h"
 #include "c-family/c-common.h"
+#include "c-family/c-pragma.h"
+#include "c-family/c-format.h"
 #include "target.h"
 
 #define builtin_define(TXT) cpp_define (pfile, TXT)

--- a/gcc/config/arc/arc-opts.h
+++ b/gcc/config/arc/arc-opts.h
@@ -82,3 +82,10 @@ enum arc_abi_type
     ARC_ABI_MWABI
   };
 
+enum arc_jli_func_addr_type
+  {
+    ARC_FUNC_ADDR_COMPAT,
+    ARC_FUNC_ADDR_INIT,
+    ARC_FUNC_ADDR_ALWAYS
+  };
+

--- a/gcc/config/arc/arc-protos.h
+++ b/gcc/config/arc/arc-protos.h
@@ -134,6 +134,7 @@ extern bool arc_is_call_to_jli_function (rtx);
 extern const char* arc_gen_call_to_jli_function (rtx);
 extern int arc_jli_fixed_symbol_index (const char *symbol);
 extern int arc_jli_dynamic_symbol_index (const char *symbol);
+extern void arc_add_jli_func_addr_stub (const char *symbol);
 extern void arc_pr_jli_call_fixed (struct cpp_reader *);
 extern void arc_pr_jli_call_always (struct cpp_reader *);
 extern void arc_pr_init (void);

--- a/gcc/config/arc/arc-protos.h
+++ b/gcc/config/arc/arc-protos.h
@@ -132,5 +132,8 @@ extern void arc_cpu_cpp_builtins (cpp_reader *);
 
 extern bool arc_is_call_to_jli_function (rtx);
 extern const char* arc_gen_call_to_jli_function (rtx);
+extern int arc_jli_fixed_symbol_index (const char *symbol);
+extern int arc_jli_dynamic_symbol_index (const char *symbol);
 extern void arc_pr_jli_call_fixed (struct cpp_reader *);
+extern void arc_pr_jli_call_always (struct cpp_reader *);
 extern void arc_pr_init (void);

--- a/gcc/config/arc/arc-protos.h
+++ b/gcc/config/arc/arc-protos.h
@@ -52,6 +52,7 @@ extern unsigned int arc_compute_frame_size ();
 extern bool arc_ccfsm_branch_deleted_p (void);
 extern void arc_ccfsm_record_branch_deleted (void);
 
+void arc_asm_output_int (FILE *, rtx);
 void arc_asm_output_aligned_decl_local (FILE *, tree, const char *,
 					unsigned HOST_WIDE_INT,
 					unsigned HOST_WIDE_INT,

--- a/gcc/config/arc/arc-protos.h
+++ b/gcc/config/arc/arc-protos.h
@@ -129,3 +129,8 @@ extern bool arc_bdr_iscond (rtx);
 
 extern bool insn_is_tls_gd_dispatch (rtx);
 extern void arc_cpu_cpp_builtins (cpp_reader *);
+
+extern bool arc_is_call_to_jli_function (rtx);
+extern const char* arc_gen_call_to_jli_function (rtx);
+extern void arc_pr_jli_call_fixed (struct cpp_reader *);
+extern void arc_pr_init (void);

--- a/gcc/config/arc/arc.c
+++ b/gcc/config/arc/arc.c
@@ -12696,8 +12696,20 @@ arc_add_jli_section (const char *symbol)
 {
   arc_jli_section *sec = arc_jli_sections, *new_section;
 
+  // Don't insert the same symbol twice.
+  if(sec != NULL && strcmp(symbol, sec->name) == 0)
+  {
+    return;
+  }
+
   while (sec != NULL && sec->next != NULL)
   {
+    // Don't insert the same symbol twice.
+    if(strcmp(symbol, sec->name) == 0)
+    {
+      return;
+    }
+
     sec = sec->next;
   }
 

--- a/gcc/config/arc/arc.c
+++ b/gcc/config/arc/arc.c
@@ -5150,10 +5150,11 @@ static void arc_file_end (void)
     fprintf (asm_out_file, "\t.section .text$jlifuncaddr$%s, "
       "\"ax\", @comdat\n", stub->name);
     fprintf (asm_out_file, "\t.align 4\n");
+    fprintf (asm_out_file, ".global __jlifuncaddr.%s\n", stub->name);
     fprintf (asm_out_file, "__jlifuncaddr.%s:\n", stub->name);
     fprintf (asm_out_file, "\tlr r8, [jli_base]\n");
-    fprintf (asm_out_file, "\tadd_jlioff r8, %s\n", stub->name);
-    fprintf (asm_out_file, "\tj [r8]\n", stub->name);
+    fprintf (asm_out_file, "\tadd2_jlioff r8, r8, @%s\n", stub->name);
+    fprintf (asm_out_file, "\tj [r8]\n");
 
     stub = stub->next;
   }

--- a/gcc/config/arc/arc.c
+++ b/gcc/config/arc/arc.c
@@ -12567,4 +12567,64 @@ insn_is_tls_gd_dispatch (rtx insn)
 
 struct gcc_target targetm = TARGET_INITIALIZER;
 
+char *jli_table[1024];
+
+bool
+arc_is_call_to_jli_function (rtx sym_ref)
+{
+  const char *symbol, *jli_symbol;
+  int i;
+
+  if (GET_CODE(sym_ref) == SYMBOL_REF)
+  {
+    symbol = XSTR(sym_ref, 0);
+
+    for(i = 0; i < 1024; ++i)
+    {
+      jli_symbol = jli_table[i];
+
+      if(NULL != jli_symbol && 0 == strcmp(symbol, jli_symbol))
+      {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+const char*
+arc_gen_call_to_jli_function (rtx sym_ref)
+{
+  static char jli_inst[strlen("jli_s 1234")];
+
+  const char *symbol, *jli_symbol;
+  int i;
+
+  if (GET_CODE(sym_ref) == SYMBOL_REF)
+  {
+    symbol = XSTR(sym_ref, 0);
+
+    for(i = 0; i < 1024; ++i)
+    {
+      jli_symbol = jli_table[i];
+
+      if(NULL != jli_symbol && 0 == strcmp(symbol, jli_symbol))
+      {
+        sprintf (jli_inst, "jli_s %d", i);
+
+        return jli_inst;
+      }
+    }
+
+    error ("failed to determine index for JLI function '%s'", symbol);
+  }
+  else
+  {
+    error ("failed to determine JLI function name");
+  }
+
+  return "jli_s 0";
+}
+
 #include "gt-arc.h"

--- a/gcc/config/arc/arc.c
+++ b/gcc/config/arc/arc.c
@@ -5103,8 +5103,8 @@ static void arc_file_end (void)
     fprintf (asm_out_file, "#####################\n");
     fprintf (asm_out_file, "# JLI entry for function '%s'\n", sec->name);
     fprintf (asm_out_file, "#####################\n");
-    fprintf (asm_out_file, "\t.section .jlitab$%s, \"ax\", @comdat\n",
-      sec->name);
+    fprintf (asm_out_file, "\t.section .jlitab$%s, \"axG\", @progbits, "
+      ".jlitab, comdat\n", sec->name);
 
     if(first)
     {
@@ -5129,8 +5129,8 @@ static void arc_file_end (void)
     fprintf (asm_out_file, "# JLI function address stub for function '%s'\n",
       stub->name);
     fprintf (asm_out_file, "#####################\n");
-    fprintf (asm_out_file, "\t.section .text$jlifuncaddr$%s, "
-      "\"ax\", @comdat\n", stub->name);
+    fprintf (asm_out_file, "\t.section .text$jlifuncaddr$%s, \"axG\", "
+      "@progbits, .text$jlifuncaddr, comdat\n", stub->name);
     fprintf (asm_out_file, "\t.align 4\n");
     fprintf (asm_out_file, ".global __jlifuncaddr.%s\n", stub->name);
     fprintf (asm_out_file, "__jlifuncaddr.%s:\n", stub->name);

--- a/gcc/config/arc/arc.c
+++ b/gcc/config/arc/arc.c
@@ -5121,7 +5121,7 @@ static void arc_file_end (void)
     fprintf (asm_out_file, "#####################\n");
     fprintf (asm_out_file, "# JLI entry for function '%s'\n", sec->name);
     fprintf (asm_out_file, "#####################\n");
-    fprintf (asm_out_file, "\t.section .jlitab$%s, \"ax\", @progbits\n",
+    fprintf (asm_out_file, "\t.section .jlitab$%s, \"ax\", @comdat\n",
       sec->name);
 
     if(first)
@@ -5134,6 +5134,7 @@ static void arc_file_end (void)
     fprintf (asm_out_file, "\t.align 4\n");
     fprintf (asm_out_file, "__jli.%s:\n", sec->name);
     fprintf (asm_out_file, "\t.weak __jli.%s\n", sec->name);
+    fprintf (asm_out_file, "\t.weak %s\n", sec->name);
     fprintf (asm_out_file, "\tb %s\n", sec->name);
 
     sec = sec->next;
@@ -5147,8 +5148,7 @@ static void arc_file_end (void)
       stub->name);
     fprintf (asm_out_file, "#####################\n");
     fprintf (asm_out_file, "\t.section .text$jlifuncaddr$%s, "
-      "\"ax\", @progbits\n", stub->name);
-    //fprintf (asm_out_file, ".linkonce same_contents\n");
+      "\"ax\", @comdat\n", stub->name);
     fprintf (asm_out_file, "\t.align 4\n");
     fprintf (asm_out_file, "__jlifuncaddr.%s:\n", stub->name);
     fprintf (asm_out_file, "\tlr r8, [jli_base]\n");

--- a/gcc/config/arc/arc.h
+++ b/gcc/config/arc/arc.h
@@ -1156,19 +1156,7 @@ arc_select_cc_mode (OP, X, Y)
 /* This is how to output an assembler line defining an `int' constant.
    We also handle symbol output here.  Code addresses must be right shifted
    by 2 because that's how the jump instruction wants them.  */
-#define ASM_OUTPUT_INT(FILE, VALUE) \
-do {									\
-  fprintf (FILE, "\t.word\t");						\
-  if (GET_CODE (VALUE) == LABEL_REF)					\
-    {									\
-      fprintf (FILE, "%%st(@");						\
-      output_addr_const (FILE, (VALUE));				\
-      fprintf (FILE, ")");						\
-    }									\
-  else									\
-    output_addr_const (FILE, (VALUE));					\
-  fprintf (FILE, "\n");					                \
-} while (0)
+#define ASM_OUTPUT_INT(FILE, VALUE) arc_asm_output_int(FILE, VALUE);
 
 /* This is how to output an assembler line defining a `float' constant.  */
 #define ASM_OUTPUT_FLOAT(FILE, VALUE) \

--- a/gcc/config/arc/arc.h
+++ b/gcc/config/arc/arc.h
@@ -1705,11 +1705,24 @@ enum
 
 /* Handle pragmas for JLI calls. */
 #define REGISTER_TARGET_PRAGMAS() do {                                  \
-  c_register_pragma (0, "jli_call_fixed", arc_pr_jli_call_fixed);       \
+  c_register_pragma (0, "jli_call_fixed",  arc_pr_jli_call_fixed);      \
+  c_register_pragma (0, "jli_call_always", arc_pr_jli_call_always);     \
   arc_pr_init();                                                        \
 } while (0)
 
-/* List of symbols in the JLI table. */
-extern char *jli_table[1024];
+/** Maximum number of JLI entries. */
+#define ARC_JLI_ENTRIES_MAX (1024)
+
+/** Number of JLI entries in the fixed table. */
+extern int jli_fixed_count;
+
+/* List of fixed symbols in the JLI table. */
+extern char *jli_fixed_table[ARC_JLI_ENTRIES_MAX];
+
+/** Number of JLI entries in the dynamic table. */
+extern int jli_dynamic_count;
+
+/* List of fixed symbols in the JLI table. */
+extern char *jli_dynamic_table[ARC_JLI_ENTRIES_MAX];
 
 #endif /* GCC_ARC_H */

--- a/gcc/config/arc/arc.h
+++ b/gcc/config/arc/arc.h
@@ -1703,4 +1703,13 @@ enum
 			  && (arc_fpu_build == FPX_QK))
 #define TARGET_FP_ASSIST ((arc_fpu_build & FPX_DP) != 0)
 
+/* Handle pragmas for JLI calls. */
+#define REGISTER_TARGET_PRAGMAS() do {                                  \
+  c_register_pragma (0, "jli_call_fixed", arc_pr_jli_call_fixed);       \
+  arc_pr_init();                                                        \
+} while (0)
+
+/* List of symbols in the JLI table. */
+extern char *jli_table[1024];
+
 #endif /* GCC_ARC_H */

--- a/gcc/config/arc/arc.md
+++ b/gcc/config/arc/arc.md
@@ -720,7 +720,7 @@
     ] VUNSPEC_ARC_ADD2_JLIOFF)
   ]
   ""
-  "add2_jlioff %0, %0, %1"
+  "add2 %0, %0, %1@jli"
   [(set_attr "type" "unary")
   (set_attr "iscompact" "true")
   (set_attr "predicable" "yes")

--- a/gcc/config/arc/arc.md
+++ b/gcc/config/arc/arc.md
@@ -3978,6 +3978,31 @@
    (set_attr "iscompact" "true")
    (set_attr "cond" "nocond")])
 
+(define_insn "jli_s"
+  [(match_operand:SI 0 "immediate_operand" "L")]
+  ""
+  "jli_s %0"
+  [(set_attr "type" "call")
+  (set_attr "iscompact" "true")
+  (set_attr "predicable" "yes")
+  (set_attr "length" "2")])
+
+(define_insn "*call_value_i_jli"
+  [
+    (set
+      (match_operand 0 "dest_reg_operand" "=w")
+      (call (mem:SI (match_operand:SI 1 "call_jli_operand" "Cbr"))
+        (match_operand 2 "" ""))
+    )
+    (clobber (reg:SI 31))
+  ]
+  ""
+  "*return arc_gen_call_to_jli_function (operands[1]);"
+  [(set_attr "type" "call")
+   (set_attr "iscompact" "*")
+   (set_attr "predicable" "no")
+   (set_attr "length" "2")])
+
 (define_expand "call"
   ;; operands[1] is stack_size_rtx
   ;; operands[2] is next_arg_register

--- a/gcc/config/arc/arc.md
+++ b/gcc/config/arc/arc.md
@@ -757,7 +757,7 @@
    {
      const char *jli_symbol = XSTR (operands[1], 0);
 
-     switch(arc_jli_func_addr)
+     switch (arc_jli_func_addr)
      {
        // -mjli-func-addr=compat
        case ARC_FUNC_ADDR_COMPAT:
@@ -792,7 +792,7 @@
          char *symbol = (char*) xmalloc (strlen (\"__jli.\") +
            strlen (jli_symbol) + 1);
 
-         sprintf(symbol, \"__jli.%s\", jli_symbol);
+         sprintf (symbol, \"__jli.%s\", jli_symbol);
 
          emit_insn (gen_movsi_jli (
            operands[0],
@@ -812,14 +812,14 @@
          char *symbol = (char*) xmalloc (strlen (\"__jlifuncaddr.\") +
            strlen (jli_symbol) + 1);
 
-         sprintf(symbol, \"__jlifuncaddr.%s\", jli_symbol);
+         sprintf (symbol, \"__jlifuncaddr.%s\", jli_symbol);
 
          emit_insn (gen_movsi (
            operands[0],
            gen_rtx_SYMBOL_REF (Pmode, symbol)
          ));
 
-         arc_add_jli_func_addr_stub(jli_symbol);
+         arc_add_jli_func_addr_stub (jli_symbol);
 
          DONE; is_done = true;
 

--- a/gcc/config/arc/arc.md
+++ b/gcc/config/arc/arc.md
@@ -161,6 +161,7 @@
   VUNSPEC_ARC_CAS
   VUNSPEC_ARC_SC
   VUNSPEC_ARC_LL
+  VUNSPEC_ARC_MOVSI_JLI
   VUNSPEC_ARC_ADD2_JLIOFF
 ])
 
@@ -726,10 +727,10 @@
   (set_attr "length" "4")])
 
 (define_insn_and_split "movsi_jli"
-  [(set
+  [(unspec_volatile [
     (match_operand:SI 0 "move_dest_operand" "")
     (match_operand:SI 1 "symbolic_operand" "")
-   )
+   ] VUNSPEC_ARC_MOVSI_JLI)
    (clobber (match_scratch:SI 2 "=r"))
   ]
   ""

--- a/gcc/config/arc/arc.md
+++ b/gcc/config/arc/arc.md
@@ -3987,11 +3987,25 @@
   (set_attr "predicable" "yes")
   (set_attr "length" "2")])
 
-(define_insn "*call_value_i_jli"
+(define_insn "*call_jli"
+  [
+    (parallel [
+      (call (match_operand:SI 0 "call_jli_operand" "") (match_operand 1 "" ""))
+      (clobber (reg:SI 31))
+    ])
+  ]
+  ""
+  "*return arc_gen_call_to_jli_function (XEXP (operands[0], 0));"
+  [(set_attr "type" "call")
+   (set_attr "iscompact" "*")
+   (set_attr "predicable" "no")
+   (set_attr "length" "2")])
+
+(define_insn "*call_value_jli"
   [
     (set
       (match_operand 0 "dest_reg_operand" "=w")
-      (call (mem:SI (match_operand:SI 1 "call_jli_operand" "Cbr"))
+      (call (mem:SI (match_operand:SI 1 "call_jli_address_operand" ""))
         (match_operand 2 "" ""))
     )
     (clobber (reg:SI 31))

--- a/gcc/config/arc/arc.md
+++ b/gcc/config/arc/arc.md
@@ -161,6 +161,7 @@
   VUNSPEC_ARC_CAS
   VUNSPEC_ARC_SC
   VUNSPEC_ARC_LL
+  VUNSPEC_ARC_ADD_JLIOFF
 ])
 
 (define_constants
@@ -207,6 +208,7 @@
    (ILINK1_REGNUM 29)
    (ILINK2_REGNUM 30)
    (RETURN_ADDR_REGNUM 31)
+   (JLI_BASE 38)
    (MUL64_OUT_REG 58)
    (ARCV2_ACC 58)
 
@@ -709,11 +711,136 @@
    (set_attr "predicable" "yes,no,yes,no,yes,no,yes,yes,yes,no,no,no,no,no,no,no")
    (set_attr "cpu_facility" "*,*,arcv1,em,*,*,*,*,*,*,*,*,*,*,em,*")])
 
+(define_insn "add_jlioff"
+  [
+    (unspec_volatile [
+      (match_operand:SI 0 "move_dest_operand" "")
+      (match_operand:SI 1 "symbolic_jli_operand" "")
+    ] VUNSPEC_ARC_ADD_JLIOFF)
+  ]
+  ""
+  "add_jlioff %0, %1"
+  [(set_attr "type" "unary")
+  (set_attr "iscompact" "true")
+  (set_attr "predicable" "yes")
+  (set_attr "length" "2")])
+
+(define_insn_and_split "movsi_jli"
+  [(set
+    (match_operand:SI 0 "move_dest_operand" "")
+    (match_operand:SI 1 "symbolic_jli_operand" "")
+   )
+  ]
+  ""
+  "lr %0, [%1]
+   add_jlioff %0, %1"
+  "reload_completed"
+  [
+    (set (match_dup 0) (unspec_volatile:SI [(reg:SI JLI_BASE)] VUNSPEC_ARC_LR))
+    (unspec_volatile:SI [(match_dup 0) (match_dup 1)] VUNSPEC_ARC_ADD_JLIOFF)
+  ]
+  "")
+
 (define_expand "movsi"
   [(set (match_operand:SI 0 "move_dest_operand" "")
 	(match_operand:SI 1 "general_operand" ""))]
   ""
-  "if (prepare_move_operands (operands, SImode)) DONE;")
+  "// Use this to determine if the default action should be taken.
+   bool is_done = false;
+
+   // Check if the function is a JLI function first.
+   if (arc_is_call_to_jli_function (operands[1]))
+   {
+     const char *jli_symbol = XSTR (operands[1], 0);
+
+     switch(arc_jli_func_addr)
+     {
+       // -mjli-func-addr=compat
+       case ARC_FUNC_ADDR_COMPAT:
+       {
+         // jli_call_always uses the address of the JLI entry and
+         // jli_call_fixed uses the address of the function itself.
+         if (0 <= arc_jli_dynamic_symbol_index (jli_symbol))
+         {
+           // I have no idea when you are allowed to free this string...
+           // I just know I can't do it inside this block of code.
+           char *symbol = (char*) xmalloc (strlen (\"__jli.\") +
+             strlen (jli_symbol) + 1);
+
+           sprintf(symbol, \"__jli.%s\", jli_symbol);
+
+           emit_insn (gen_movsi (
+             operands[0],
+             gen_rtx_SYMBOL_REF (Pmode, symbol)
+           ));
+
+           DONE; is_done = true;
+         }
+
+         break;
+       }
+
+       // -mjli-func-addr=init
+       case ARC_FUNC_ADDR_INIT:
+       {
+         /*
+         rtx dest;
+
+         if (REG_P (operands[0]))
+         {
+           printf(\"no scratch\\n\");
+           dest = operands[0];
+         }
+         else
+         {
+           printf(\"make scratch: %s\\n\", jli_symbol);
+           dest = operands[2];
+         }
+
+         // For some reason this doesn't seem to keep the scratch register.
+         emit_insn (gen_lr (dest, gen_rtx_REG (SImode, JLI_BASE)));
+
+         if (!REG_P (operands[0]))
+         {
+           emit_move_insn(operands[0], dest);
+         }
+         */
+
+         emit_insn (gen_movsi_jli (operands[0], operands[1]));
+
+         DONE; is_done = true;
+
+         break;
+       }
+
+       // -mjli-func-addr=always
+       case ARC_FUNC_ADDR_ALWAYS:
+       {
+         // I have no idea when you are allowed to free this string...
+         // I just know I can't do it inside this block of code.
+         char *symbol = (char*) xmalloc (strlen (\"__jlifuncaddr.\") +
+           strlen (jli_symbol) + 1);
+
+         sprintf(symbol, \"__jlifuncaddr.%s\", jli_symbol);
+
+         emit_insn (gen_movsi (
+           operands[0],
+           gen_rtx_SYMBOL_REF (Pmode, symbol)
+         ));
+
+         arc_add_jli_func_addr_stub(jli_symbol);
+
+         DONE; is_done = true;
+
+         break;
+       }
+     }
+   }
+
+   if (!is_done && prepare_move_operands (operands, SImode))
+   {
+     DONE;
+   }")
 
 ; In order to allow the ccfsm machinery to do its work, the leading compact
 ; alternatives say 'canuse' - there is another alternative that will match

--- a/gcc/config/arc/arc.opt
+++ b/gcc/config/arc/arc.opt
@@ -102,6 +102,25 @@ Same as -mcpu=archs
 ; END backward-compatibility aliases, translated by DRIVER_SELF_SPECS
 
 TargetVariable
+unsigned int arc_jli_func_addr = 0
+
+mjli-func-addr=
+Target RejectNegative Joined Var(arc_jli_func_addr) Enum(arc_jli_func_addr_type) Init(ARC_FUNC_ADDR_COMPAT)
+Specify the way the address of a function in the JLI table is obtained. Option 'compat' will use the Metaware method (jli_call_always will use the address of the function and jli_call_dynamic will use the address of the JLI entry). Option 'init' will use the address of the JLI entry using the jli_base register when the function pointer is saved. Option 'always' will use a stub function to call the JLI entry relative to the jli_base register upon calling the function pointed to.
+
+Enum
+Name(arc_jli_func_addr_type) Type(enum arc_jli_func_addr_type)
+
+EnumValue
+Enum(arc_jli_func_addr_type) String(compat) Value(ARC_FUNC_ADDR_COMPAT)
+
+EnumValue
+Enum(arc_jli_func_addr_type) String(init) Value(ARC_FUNC_ADDR_INIT)
+
+EnumValue
+Enum(arc_jli_func_addr_type) String(always) Value(ARC_FUNC_ADDR_ALWAYS)
+
+TargetVariable
 unsigned int arc_mpy_option = 0
 
 mmpy-option=

--- a/gcc/config/arc/predicates.md
+++ b/gcc/config/arc/predicates.md
@@ -56,12 +56,24 @@
   (match_code "symbol_ref, label_ref, const")
 )
 
+;; Returns 1 if OP is a symbol reference.
+(define_predicate "symbolic_jli_operand"
+  (match_code "symbol_ref")
+  {
+    return arc_is_call_to_jli_function (op);
+  }
+)
+
 ;; Acceptable arguments to the call insn.
 (define_predicate "call_address_operand"
   (ior (match_code "const_int, reg")
        (match_operand 0 "symbolic_operand")
        (match_test "CONSTANT_P (op)
 		    && arc_legitimate_constant_p (VOIDmode, op)"))
+)
+
+(define_predicate "call_jli_operand"
+  (match_operand 0 "symbolic_jli_operand")
 )
 
 (define_predicate "call_operand"

--- a/gcc/config/arc/predicates.md
+++ b/gcc/config/arc/predicates.md
@@ -72,13 +72,18 @@
 		    && arc_legitimate_constant_p (VOIDmode, op)"))
 )
 
-(define_predicate "call_jli_operand"
+(define_predicate "call_jli_address_operand"
   (match_operand 0 "symbolic_jli_operand")
 )
 
 (define_predicate "call_operand"
   (and (match_code "mem")
        (match_test "call_address_operand (XEXP (op, 0), mode)"))
+)
+
+(define_predicate "call_jli_operand"
+  (and (match_code "mem")
+       (match_test "call_jli_address_operand (XEXP (op, 0), mode)"))
 )
 
 ;; Return true if OP is a unsigned 6-bit immediate (u6) value.


### PR DESCRIPTION
This change adds JLI support to GCC. This will accept the jli_call_fixed and jli_call_always pragmas used by Metaware. This implementation should be binary compatible with Metaware (if using the default option -mjli-func-addr=compat).

There are three approaches to obtaining the address of a function inside the JLI table:
1. -mjli-func-addr=compat will use a Metaware compatible mode. When using jli_call_fixed this will use the address of the function originally placed into the table at compile time. When using jli_call_always this will use the address of the JLI entry. The JLI table may not be moved when using jli_call_always with this method.
2. -mjli-func-addr=init will read the jli_base AUX register and offset it to determine the address of the JLI entry. This address will be stored in the desired variable. If the variable is constant or otherwise ends up in the .rodata section, the address of the .jlitab section will be used in place of the jli_base AUX register. This will emit an ARC_32_JLI relocation entry that may be used to perform the proper relocation utilizing the jli_base AUX register during loading. This method requires the call be made in kernel mode (because of the AUX register read).
3. -mjli-func-addr=always will create a stub function that reads the jli_base AUX register and offset to determine the address of the JLI entry. The address of the stub function will be stored in the desired variable so the JLI table may be moved after the variable has been set with the function address. This method requires the call be made in kernel mode (because of the AUX register read).

The following relocation types were added to GCC/binutils:
1. ARC_JLI_SECTOFF is a relocation type in Metaware that is now used by GCC as well to adjust the index of function calls to functions defined with #pragma jli_call_always during linking.
2. ARC_JLI_SECTOFF_SIMM12 is used to add the appropriate offset to the address when using -mjli-func-addr=init to get an address for a function in the JLI table during code execution.
3. ARC_JLI_32 is used to add the appropriate offset to the address when using -mjli-func-addr=init to get an address for a function in the JLI table during program load.

This implementation of the JLI feature will allow the use of both jli_call_fixed and jli_call_always as long as all jli_call_fixed functions are using the continuous block starting at index 0 and are linked before all other JLI entries. This can be done with the default linker script if the object file that contains the jli_call_fixed entries matches the object filename pattern "jlitab*.o".
