### PR TITLE
[ARC] add support for enter_s/leave_s instructions

### DIFF
--- a/gcc/config/arc/arc.opt
+++ b/gcc/config/arc/arc.opt
@@ -130,6 +130,10 @@ mno-millicode
 Target Report Mask(NO_MILLICODE_THUNK_SET)
 Do not generate millicode thunks (needed only with -Os).
 
+mcode-density-frame
+Target Report Mask(CODE_DENSITY_FRAME)
+Enable ENTER_S and LEAVE_S opcodes for ARCv2 (EXPERIMENTAL).
+
 mspfp
 Target Report Mask(SPFP_COMPACT_SET)
 FPX: Generate Single Precision FPX (compact) instructions.


### PR DESCRIPTION
This patch implement the use of enter_s/leave_s opcodes.
It is enabled by -mcode-density-frame.

Cases not implemented yet are: IRQ functions, frame pointer used, exception handler used, non ARCv2 

The only testing done has been manual inspection of the objdump and build/run on two different projects (no idea on how to run automated test suites).

Size change of the text section:
Project 1 (-Os): 108408
                          104072   (->96%)

Project 2 (-Os): 187252
                          175240 (->93.6%)

Project 2 (-O2): 245936
                          219584 (-> 89.3%)

The code in the .md files may be a bit poor. First time I use this syntax and not sure how to cope with parallel rtx.