### PR TITLE
[ARC] Disable test for bare-metal.

### DIFF
--- a/gcc/testsuite/gcc.dg/tree-prof/time-profiler-2.c
+++ b/gcc/testsuite/gcc.dg/tree-prof/time-profiler-2.c
@@ -1,5 +1,5 @@
 /* { dg-options "-O2 -fdump-ipa-profile" } */
-/* { dg-skip-if "" { "arc-*-elf*" } { "*" } { "" } } */
+/* { dg-skip-if "" { "arc*-*-elf*" } { "*" } { "" } } */
 
 #include <unistd.h>
 


### PR DESCRIPTION
* gcc.dg/tree-prof/time-profiler-2.c: Disable test for big endian
too.