### PR TITLE
[FIX] Preserve attribute list for MEM_REF expressions of unaligned types

### DIFF
--- a/gcc/emit-rtl.c
+++ b/gcc/emit-rtl.c
@@ -2440,7 +2440,12 @@ adjust_address_1 (rtx memref, machine_mode mode, poly_int64 offset,
       /* Drop the object if the new left end is not within its bounds.  */
       if (adjust_object && maybe_lt (attrs.offset, 0))
 	{
-	  attrs.expr = NULL_TREE;
+	  /* Make a copy of MEM_REF expression to preserve attribute list.
+	     It might be needed for some arch's */
+	  if (MEM_EXPR (memref) && TREE_CODE (MEM_EXPR (memref)) == MEM_REF)
+	    attrs.expr = copy_node(MEM_EXPR (memref));
+	  else
+	    attrs.expr = NULL_TREE;
 	  attrs.alias = 0;
 	}
     }

--- a/gcc/testsuite/gcc.target/arc/uncached-9.c
+++ b/gcc/testsuite/gcc.target/arc/uncached-9.c
@@ -1,0 +1,19 @@
+/* { dg-do compile } */
+
+#include <stddef.h>
+
+typedef volatile struct {
+  uint32_t a1;
+  uint32_t a2;
+  uint32_t a3;
+  uint32_t a4;
+} __attribute__((packed,uncached)) my_type_t;
+
+uint32_t foo (my_type_t *p)
+{
+  p->a3 = p->a2;
+  return p->a4;
+}
+
+/* { dg-final { scan-assembler-times "stb\.di" 4 } } */
+/* { dg-final { scan-assembler-times "ldb\.di" 12 } } */


### PR DESCRIPTION
[FIX] Propagate uncached type attributes to unaligned types

[ARC] Update tests

gcc/
xxxx-xx-xx  Petro Karashchenko  <petro.karashchenko@ringteam.com>

	* emit-rtl.c (adjust_address_1): Preserve attribute list
        for MEM_REF expressions.

testsuite/
xxxx-xx-xx  Petro Karashchenko  <petro.karashchenko@ringteam.com>

        * gcc.target/arc/uncached-9.c: New file.