### PR TITLE
[Question] How to send change request to GCC mainline?

### DIFF
--- a/gcc/testsuite/gcc.target/arc/uncached-9.c
+++ b/gcc/testsuite/gcc.target/arc/uncached-9.c
@@ -1,0 +1,19 @@
+/* { dg-do compile } */
+
+#include <stddef.h>
+
+typedef volatile struct {
+  uint32_t a1;
+  uint32_t a2;
+  uint32_t a3;
+  uint32_t a4;
+} __attribute__((packed,uncached)) my_type_t;
+
+uint32_t foo (my_type_t *p)
+{
+  p->a3 = p->a2;
+  return p->a4;
+}
+
+/* { dg-final { scan-assembler-times "stb\.di" 4 } } */
+/* { dg-final { scan-assembler-times "ldb\.di" 12 } } */


### PR DESCRIPTION
[FIX] Correct check of object bounds during address adjustment

[FIX] Propagate uncached type attributes to unaligned types

[ARC] Update tests

gcc/
xxxx-xx-xx  Petro Karashchenko  <petro.karashchenko@ringteam.com>

	* emit-rtl.c (adjust_address_1): Use size of record or
        union instead of memory size attribute for record or
        union type expressions.

testsuite/
xxxx-xx-xx  Petro Karashchenko  <petro.karashchenko@ringteam.com>

        * gcc.target/arc/uncached-9.c: New file.