### PR TITLE
ARC64 Revert back to aligned data accesses only for now

### DIFF
--- a/gcc/config/arc64/arc64.h
+++ b/gcc/config/arc64/arc64.h
@@ -91,7 +91,7 @@
 
 /* Default unaligned accesses.  */
 #ifndef UNALIGNED_ACCESS_DEFAULT
-#define UNALIGNED_ACCESS_DEFAULT 1
+#define UNALIGNED_ACCESS_DEFAULT 0
 #endif
 
 /* Layout of Source Language Data Types.  */


### PR DESCRIPTION
It seems hardware at this point is not mature enough (performance wise
atleast) for unaligned accesses.

With -mno-unaligned-access hackbench on FPGA improves by more than 10%:
115.959 secs to 93.095

More importantly there's still unresolved issue of gcc generating an invalid
load promption to word (vs. byte) for glibc test-suite string/test-strcmp.
So better to keep this disabled for now and stabalize software stack in
general before cranking up optimization.

Signed-off-by: Vineet Gupta <vgupta@synopsys.com>