### PR TITLE
arc64: add macro to signal Hard-float ABI

### DIFF
--- a/gcc/config/arc64/arc64-c.c
+++ b/gcc/config/arc64/arc64-c.c
@@ -67,6 +67,7 @@ arc64_cpu_cpp_builtins (cpp_reader * pfile)
     {
       builtin_define ("__arc_hard_float__");
       builtin_define ("__ARC_HARD_FLOAT__");
+      builtin_define ("__ARC_FLOAT_ABI_HARD__");
     }
   else
     {


### PR DESCRIPTION
This helps guard code in downstream projects such as glibc
related to hard-float regfile save/restore.

Granted we can do this with existing macros:
|
| #if defined(__ARCV3__) && defined (__ARC_HARD_FLOAT__)
|

keeping it independent of ISA keeps it future safe.

Signed-off-by: Vineet Gupta <vgupta@synopsys.com>