### PR TITLE
libgcc unwind signals

### DIFF
--- a/gcc/config/arc64/arc64.c
+++ b/gcc/config/arc64/arc64.c
@@ -255,6 +255,7 @@ arc64_save_reg_p (int regno)
 {
   bool call_saved;
   bool might_clobber;
+  bool eh_needed;
 
   gcc_assert (regno <= F31_REGNUM);
   gcc_assert (regno >= R0_REGNUM);
@@ -315,7 +316,15 @@ arc64_save_reg_p (int regno)
   call_saved = !global_regs[regno] && !call_used_regs[regno];
   might_clobber = df_regs_ever_live_p (regno) || crtl->saves_all_registers;
 
-  if (call_saved && might_clobber)
+  /* In a frame that calls __builtin_eh_return two data registers are used to
+     pass values back to the exception handler.  Ensure that these registers are
+     spilled to the stack so that the exception throw code can find them, and
+     update the saved values.  The handling code will then consume these
+     reloaded values to handle the exception.  */
+  eh_needed = crtl->calls_eh_return
+    && (EH_RETURN_DATA_REGNO (regno) != INVALID_REGNUM);
+
+  if ((call_saved && might_clobber) || eh_needed)
     return true;
   return false;
 }
@@ -354,7 +363,9 @@ arc64_compute_frame_info (void)
       frame->reg_offset[regno] = -1;
 
   /* Check if we need to save the return address.  */
-  if (!crtl->is_leaf || df_regs_ever_live_p (BLINK_REGNUM))
+  if (!crtl->is_leaf
+      || df_regs_ever_live_p (BLINK_REGNUM)
+      || crtl->calls_eh_return)
     {
       frame->reg_offset[BLINK_REGNUM] = offset;
       offset += UNITS_PER_WORD;
@@ -649,6 +660,16 @@ static bool
 arc64_can_eliminate (const int from ATTRIBUTE_UNUSED, const int to)
 {
   return ((to == HARD_FRAME_POINTER_REGNUM) || (to == STACK_POINTER_REGNUM));
+}
+
+/* We force all frames that call eh_return to require a frame pointer, this will
+   ensure that the previous frame pointer is stored on entry to the function,
+   and will then be reloaded at function exit.  */
+
+static bool
+arc64_frame_pointer_required (void)
+{
+ return cfun->calls_alloca || crtl->calls_eh_return;
 }
 
 /* Giving a symbol, return how it will be addressed.  */
@@ -4211,6 +4232,18 @@ arc64_expand_epilogue (bool sibcall_p)
   if (frame_deallocated != 0)
     frame_stack_add (frame_deallocated);
 
+  /* For frames that use __builtin_eh_return, the register defined by
+     EH_RETURN_STACKADJ_RTX is set to 0 for all standard return paths.
+     On eh_return paths however, the register is set to the value that
+     should be added to the stack pointer in order to restore the
+     correct stack pointer for the exception handling frame.
+
+     For ARC64 we are going to use r4 for EH_RETURN_STACKADJ_RTX, add
+     this onto the stack for eh_return frames.  */
+  if (crtl->calls_eh_return)
+    emit_insn (gen_add2_insn (stack_pointer_rtx,
+			      EH_RETURN_STACKADJ_RTX));
+
   if (!sibcall_p)
     emit_jump_insn (gen_simple_return ());
 }
@@ -5067,6 +5100,9 @@ arc64_use_plt34_p (rtx sym)
 
 #undef TARGET_CAN_ELIMINATE
 #define TARGET_CAN_ELIMINATE arc64_can_eliminate
+
+#undef TARGET_FRAME_POINTER_REQUIRED
+#define TARGET_FRAME_POINTER_REQUIRED arc64_frame_pointer_required
 
 #undef TARGET_LEGITIMATE_ADDRESS_P
 #define TARGET_LEGITIMATE_ADDRESS_P arc64_legitimate_address_p

--- a/libgcc/config.host
+++ b/libgcc/config.host
@@ -445,7 +445,7 @@ arc64-*-elf)
 arc64-*-linux*)
 	tmake_file="${tmake_file} arc64/t-arc64 arc64/t-softfp t-softfp t-softfp-sfdf"
 	tmake_file="${tmake_file} t-slibgcc-libgcc t-slibgcc-nolc-override"
-	#FIXME! add unwind support md_unwind_header=arc64/linux-unwind.h
+	md_unwind_header=arc64/linux-unwind.h
 	;;
 arm-wrs-vxworks7*)
 	tmake_file="$tmake_file arm/t-arm arm/t-elf arm/t-bpabi arm/t-vxworks7"

--- a/libgcc/config/arc64/linux-unwind.h
+++ b/libgcc/config/arc64/linux-unwind.h
@@ -1,0 +1,146 @@
+/* DWARF2 EH unwinding support for ARC64 Linux.
+   Copyright (C) 2021 Free Software Foundation, Inc.
+
+   This file is part of GCC.
+
+   GCC is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3, or (at your option)
+   any later version.
+
+   GCC is distributed in the hope that it will be useful, but WITHOUT
+   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+   or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+   License for more details.
+
+   Under Section 7 of GPL version 3, you are granted additional
+   permissions described in the GCC Runtime Library Exception, version
+   3.1, as published by the Free Software Foundation.
+
+   You should have received a copy of the GNU General Public License
+   and a copy of the GCC Runtime Library Exception along with this
+   program; see the files COPYING3 and COPYING.RUNTIME respectively.
+   If not, see <http://www.gnu.org/licenses/>.  */
+
+#ifndef inhibit_libc
+/* Do code reading to identify a signal frame, and set the frame
+   state data appropriately.  See unwind-dw2.c for the structs.  */
+
+#include <signal.h>
+#include <asm/unistd.h>
+
+/* The corresponding index in "reg_offset_map".  */
+enum reg_id {
+  REG_RET   = 5,
+  REG_BLINK = 6
+};
+
+#define SKIP (-1)
+
+/* This order is defined by a structure in the kernel, in file
+   arch/arc/kernel/signal.c.  */
+
+const int
+reg_offset_map[] = {
+  SKIP,	/* bta	    */
+  SKIP,	/* lp_start */
+  SKIP,	/* lp_end   */
+  SKIP,	/* lp_count */
+  SKIP,	/* status32 */
+  SKIP,	/* ret	    */
+  31,	/* blink    */
+  27,	/* fp	    */
+  26,	/* gp	    */
+  12,	/* r12	    */
+  11,	/* r11	    */
+  10,	/* r10	    */
+  9,	/* r9	    */
+  8,	/* r8	    */
+  7,	/* r7	    */
+  6,	/* r6	    */
+  5,	/* r5	    */
+  4,	/* r4	    */
+  3,	/* r3	    */
+  2,	/* r2	    */
+  1,	/* r1	    */
+  0,	/* r0	    */
+  28	/* sp	    */
+};
+
+const size_t
+reg_offset_map_size = sizeof (reg_offset_map) / sizeof (reg_offset_map[0]);
+
+#define MOV_R8_139	  0x12c2208a
+#define TRAP_S_0	  0x781e
+#define J_S_BLINK	  0x7ee0
+
+#define MD_FALLBACK_FRAME_STATE_FOR arc_fallback_frame_state
+
+static __attribute__((noinline)) _Unwind_Reason_Code
+arc_fallback_frame_state (struct _Unwind_Context *context,
+			  _Unwind_FrameState *fs)
+{
+  /* The kernel creates an rt_sigframe on the stack immediately prior
+     to delivering a signal.
+
+     This structure must have the same shape as the linux kernel
+     equivalent.  */
+  struct rt_sigframe {
+    siginfo_t info;
+    ucontext_t uc;
+    unsigned int sigret_magic;
+  };
+
+  struct rt_sigframe *rt_;
+  u_int16_t *pc = (u_int16_t *) context->ra;
+  struct sigcontext *sc;
+  _Unwind_Ptr new_cfa;
+  size_t i;
+
+
+  /* A signal frame will have a return address pointing to
+     __default_sa_restorer. This code is hardwired as:
+
+  <__default_rt_sa_restorer>:
+     208a 12c2           	mov	r8,139
+     781e                	trap_s	0
+     7ee0                	j_s	[blink]
+  */
+  if (pc[0] != (u_int16_t)MOV_R8_139 || pc[1] != (u_int16_t)(MOV_R8_139 >> 16)
+      || pc[2] != TRAP_S_0 || pc[3] != J_S_BLINK)
+    return _URC_END_OF_STACK;
+
+  rt_ = context->cfa;
+  sc = (struct sigcontext *)&rt_->uc.uc_mcontext;
+
+  new_cfa = (_Unwind_Ptr)sc;
+  fs->regs.cfa_how = CFA_REG_OFFSET;
+  fs->regs.cfa_reg = __LIBGCC_STACK_POINTER_REGNUM__;
+  fs->regs.cfa_offset = new_cfa - (_Unwind_Ptr)context->cfa;
+
+  unsigned long *regs = &sc->regs.scratch.bta;
+  for (i = 0; i < reg_offset_map_size; ++i)
+    {
+      if (reg_offset_map[i] == SKIP)
+	continue;
+      fs->regs.reg[reg_offset_map[i]].how = REG_SAVED_OFFSET;
+      fs->regs.reg[reg_offset_map[i]].loc.offset
+	= ((_Unwind_Ptr)&(regs[i])) - new_cfa;
+    }
+
+  /* Special case for handling blink: blink <--> ret.  */
+  fs->regs.reg[reg_offset_map[REG_BLINK]].how = REG_SAVED_VAL_OFFSET;
+  fs->regs.reg[reg_offset_map[REG_BLINK]].loc.offset
+    = ((_Unwind_Ptr)(regs[REG_RET])) - new_cfa;
+
+  fs->retaddr_column = reg_offset_map[REG_BLINK];
+
+  return _URC_NO_REASON;
+}
+
+#endif	  /* ifndef inhibit_libc */
+
+/* TODO: There was once an arc_frob_update_context () dwelling here.
+   Check if it is still needed. "cleanup" tests are fine without it.
+   glibc tests (nptl/tst-* and debug/tst-backtrace*) should shed more
+   light on it.  */


### PR DESCRIPTION
There are two patches here. The first one from @claziss adds the EH builtin support for gcc. The second is the libgcc unwinding support for signals. After these 2 patches all the `cleanup` tests in GCC pass.