### PR TITLE
[RFC]  arc: libgcc: fix unwind after signal handler

### DIFF
--- a/libgcc/config/arc/linux-unwind.h
+++ b/libgcc/config/arc/linux-unwind.h
@@ -120,10 +120,10 @@ arc_fallback_frame_state (struct _Unwind_Context *context,
 	= ((_Unwind_Ptr) &(regs[i])) - new_cfa;
     }
 
-  fs->regs.reg[31].how = REG_SAVED_VAL_OFFSET;
-  fs->regs.reg[31].loc.offset = ((_Unwind_Ptr) (regs[ret])) - new_cfa;
+  fs->regs.reg[29].how = REG_SAVED_VAL_OFFSET;
+  fs->regs.reg[29].loc.offset = ((_Unwind_Ptr) (regs[ret])) - new_cfa;
 
-  fs->retaddr_column = 31;
+  fs->retaddr_column = 29;
 
   return _URC_NO_REASON;
 }


### PR DESCRIPTION
ARC specific MD_FALLBACK_FRAME_STATE_FOR handler in libgcc unwind code stores return address in the 31st column of regs array in the frame state structure. However by doing so it rewrites restored blink register value of the function interrupted by a signal. As a result, libgcc may fail to unwind beyond the interrupted function. Usually it does not happen since most functions keep blink value on stack. So libgcc unwinder obtains that value from FDE record later on. However if blink is not on FDE, unwinder fails to locate the next function in the callstack. Moreover, if FDE is empty, unwinder starts to loop over the same function and never completes. Suchb example with uClibc pthreads cancellation is provided further.

This problem affects both ARC700 and ARCv2. However for ARCv2 it is hidden by another issue with __default_rt_sa_restorer implementation in uClibc: see https://github.com/foss-for-synopsys-dwc-arc-processors/uClibc/pull/6

Because of that issue, libgcc unwinder fail to recognize signal frame correclty and completes too early, before it stumbles upon the issue in question.

Suggested fix is to store the return address from signal handler not in blink register position. But keep it in any other register position that is not used in Linux by both ARC700 and ARCv2. This change suggests to use 29 (ilink) for this purpose.

Here is an example where libgcc unwinder ends up in the endless loop. Consider the following simple worker thread:

```
static void* thread_loop(void* args)
{
        for (i = 0; ; i++) {
                printf("worker: loop %d\n", i);
                sleep(1);
        }
}
```

In the case of uClibc, nanosleep syscall is called from the following function:

```
000155a8 <__nanosleep_nocancel>:
   155a8:       208a 1941               mov     r8,101
   155ac:       226f 003f               trap0
   155b0:       208c 8030               cmp     r0,-1024
   155b4:       20e0 07ce               jls     [blink]
   155b8:       1cfc b7c8               st.aw   blink,[sp,-4]
   155bc:       0c2e ffcf               bl      -980    ;151e8 <__syscall_error>
   155c0:       1404 341f               ld.ab   blink,[sp,4]
   155c4:       7ee0                    j_s     [blink]
   155c6:       78e0                    nop_s
```

Its FDE record looks as follows:

```
000001a0 00000010 000001a4 FDE cie=00000000 pc=000155a8..000155c6
  DW_CFA_nop
  DW_CFA_nop
  DW_CFA_nop
```

When main thread attempts to cancel this worker thread, NPTL uClibc code sends SIGCANCEL signal. In its turn signal handler calls libgcc function _Unwind_ForcedUnwind. However libgcc unwinder fails to pass further than __nanosleep_nocancel function. As a result main thread waits forever on pthread_join.

Regards,
Sergey