### PR TITLE
arc64: Change modifier %h to %H, and %H to %V

### DIFF
--- a/gcc/config/arc64/arc64.c
+++ b/gcc/config/arc64/arc64.c
@@ -1388,12 +1388,12 @@ get_arc64_condition_code (rtx comparison)
      'm': output condition code without 'dot'.
      '?': Short instruction suffix.
      'L': Lower 32bit of immediate or symbol.
-     'h': Higher 32bit of an immediate, 64b-register or symbol.
+     'H': Higher 32bit of an immediate, 64b-register or symbol.
      'C': Constant address, switches on/off @plt.
      's': Scalled immediate.
      'S': Scalled immediate, to be used in pair with 's'.
      'N': Negative immediate, to be used in pair with 's'.
-     'H': 2x16b vector immediate, hi lane is zero.
+     'V': 2x16b vector immediate, hi lane is zero.
      'P': Constant address, swithces on/off _s to be used with 'C'
      'A': output aq, rl or aq.rl flags for atomic ops.
 */
@@ -1480,6 +1480,11 @@ arc64_print_operand (FILE *file, rtx x, int code)
 	  fputs ("@u32", file);
 	  break;
 	}
+      else if (REG_P (x))
+	{
+	  asm_fprintf (file, "%s", reg_names [REGNO (x)]);
+	  break;
+	}
       else if (!CONST_INT_P (x))
 	{
 	  output_operand_lossage ("invalid operand for %%L code");
@@ -1490,7 +1495,7 @@ arc64_print_operand (FILE *file, rtx x, int code)
       fprintf (file,"0x%08" PRIx32, (uint32_t) ival);
       break;
 
-    case 'h':
+    case 'H':
       if (GET_CODE (x) == SYMBOL_REF
 	  || GET_CODE (x) == LABEL_REF
 	  || GET_CODE (x) == UNSPEC)
@@ -1508,15 +1513,15 @@ arc64_print_operand (FILE *file, rtx x, int code)
 	asm_fprintf (file, "%s", reg_names [REGNO (x) + 1]);
       else
 	{
-	  output_operand_lossage ("invalid operand for %%h code");
+	  output_operand_lossage ("invalid operand for %%H code");
 	  return;
 	}
       break;
 
-    case 'H':
+    case 'V':
       if (!CONST_INT_P (x))
 	{
-	  output_operand_lossage ("invalid operand for %%H code");
+	  output_operand_lossage ("invalid operand for %%V code");
 	  return;
 	}
       ival = INTVAL (x);

--- a/gcc/config/arc64/arc64.md
+++ b/gcc/config/arc64/arc64.md
@@ -842,10 +842,10 @@ vpack, vsub, xbfu, xor, xorl"
 	 (match_operand:DI 1 "arc64_immediate_or_pic" "S12S0,SymIm,SymIm,SyPic")))]
   ""
   "@
-   movhl\\t%0,%h1
-   movhl_s\\t%0,%h1
-   movhl\\t%0,%h1
-   addhl\\t%0,pcl,%h1"
+   movhl\\t%0,%H1
+   movhl_s\\t%0,%H1
+   movhl\\t%0,%H1
+   addhl\\t%0,pcl,%H1"
   [(set_attr "type" "move")
    (set_attr "length" "4,6,8,8")])
 

--- a/gcc/config/arc64/arith.md
+++ b/gcc/config/arc64/arith.md
@@ -1366,7 +1366,7 @@
   "TARGET_SIMD"
   "@
    dmach\\t%0,%1,%2
-   dmach\\t%0,%1,%H2@u32
+   dmach\\t%0,%1,%V2@u32
    #"
   "&& reload_completed
    && (CONST_INT_P (operands[3]) || (REGNO (operands[3]) != R58_REGNUM))"
@@ -1386,7 +1386,7 @@
  "TARGET_SIMD"
  "@
   dmach\\t0,%0,%1
-  dmach\\t0,%0,%H1@u32"
+  dmach\\t0,%0,%V1@u32"
  [(set_attr "length" "4,8")
   (set_attr "type" "mac")])
 
@@ -2513,7 +2513,7 @@
 	  (parallel [(const_int 1)])
 	  )))]
   "ARC64_VFP_128"
-  "vf<sfxtab>rep\\t%0,%h1"
+  "vf<sfxtab>rep\\t%0,%H1"
   [(set_attr "length" "4")
    (set_attr "type" "vfrep")])
 


### PR DESCRIPTION
Hi @shahab-vahedi , @cupertinomiranda 

I have been working on Buldroot for arc32. Buildroot for arc64 uses arc64 branches for gcc/binutils/glibc. Following arc-gnu-toolchain scripts I used arc32 branches for arc32. That works fine, the only missing thing for now is this gcc commit by Claudiu.
Having this commit in arc32 branch simplifies the work on Linux bring-up for HS5x CPU: in certain cases we can use the same generic inline assembly across HS4x/HS5x/HS6x targets.

Regards,
Sergey