### PR TITLE
ARC32: fixes for large mcmodel

### DIFF
--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -1239,16 +1239,23 @@ arc-*-linux* | arceb-*-linux*)
 	# automatically detect that GAS supports it, yet we require it.
 	gcc_cv_initfini_array=yes
 	;;
-arc64-*-elf*)
-	tm_file="dbxelf.h elfos.h newlib-stdint.h arc64/elf.h arc64/elf64.h ${tm_file}"
-	tmake_file="${tmake_file} arc64/t-multilib arc64/t-arc64"
-	;;
 arc32-*-elf*)
 	tm_file="dbxelf.h elfos.h newlib-stdint.h arc64/elf.h arc64/elf32.h ${tm_file}"
 	tmake_file="${tmake_file} arc64/t-multilib32 arc64/t-arc64"
 	;;
+arc64-*-elf*)
+	tm_file="dbxelf.h elfos.h newlib-stdint.h arc64/elf.h arc64/elf64.h ${tm_file}"
+	tmake_file="${tmake_file} arc64/t-multilib arc64/t-arc64"
+	;;
+arc32-*-linux*)
+	tm_file="dbxelf.h elfos.h gnu-user.h linux.h arc64/linux.h arc64/linux32.h linux-android.h glibc-stdint.h ${tm_file}"
+	tmake_file="${tmake_file} arc64/t-arc64"
+	# Force .init_array support.  The configure script cannot always
+	# automatically detect that GAS supports it, yet we require it.
+	gcc_cv_initfini_array=yes
+	;;
 arc64-*-linux*)
-	tm_file="dbxelf.h elfos.h gnu-user.h linux.h arc64/linux.h linux-android.h glibc-stdint.h ${tm_file}"
+	tm_file="dbxelf.h elfos.h gnu-user.h linux.h arc64/linux.h arc64/linux64.h linux-android.h glibc-stdint.h ${tm_file}"
 	tmake_file="${tmake_file} arc64/t-arc64"
 	# Force .init_array support.  The configure script cannot always
 	# automatically detect that GAS supports it, yet we require it.

--- a/gcc/config/arc64/arc64.c
+++ b/gcc/config/arc64/arc64.c
@@ -1388,12 +1388,12 @@ get_arc64_condition_code (rtx comparison)
      'm': output condition code without 'dot'.
      '?': Short instruction suffix.
      'L': Lower 32bit of immediate or symbol.
-     'h': Higher 32bit of an immediate, 64b-register or symbol.
+     'H': Higher 32bit of an immediate, 64b-register or symbol.
      'C': Constant address, switches on/off @plt.
      's': Scalled immediate.
      'S': Scalled immediate, to be used in pair with 's'.
      'N': Negative immediate, to be used in pair with 's'.
-     'H': 2x16b vector immediate, hi lane is zero.
+     'V': 2x16b vector immediate, hi lane is zero.
      'P': Constant address, swithces on/off _s to be used with 'C'
      'A': output aq, rl or aq.rl flags for atomic ops.
 */
@@ -1480,6 +1480,11 @@ arc64_print_operand (FILE *file, rtx x, int code)
 	  fputs ("@u32", file);
 	  break;
 	}
+      else if (REG_P (x))
+	{
+	  asm_fprintf (file, "%s", reg_names [REGNO (x)]);
+	  break;
+	}
       else if (!CONST_INT_P (x))
 	{
 	  output_operand_lossage ("invalid operand for %%L code");
@@ -1490,7 +1495,7 @@ arc64_print_operand (FILE *file, rtx x, int code)
       fprintf (file,"0x%08" PRIx32, (uint32_t) ival);
       break;
 
-    case 'h':
+    case 'H':
       if (GET_CODE (x) == SYMBOL_REF
 	  || GET_CODE (x) == LABEL_REF
 	  || GET_CODE (x) == UNSPEC)
@@ -1508,15 +1513,15 @@ arc64_print_operand (FILE *file, rtx x, int code)
 	asm_fprintf (file, "%s", reg_names [REGNO (x) + 1]);
       else
 	{
-	  output_operand_lossage ("invalid operand for %%h code");
+	  output_operand_lossage ("invalid operand for %%H code");
 	  return;
 	}
       break;
 
-    case 'H':
+    case 'V':
       if (!CONST_INT_P (x))
 	{
-	  output_operand_lossage ("invalid operand for %%H code");
+	  output_operand_lossage ("invalid operand for %%V code");
 	  return;
 	}
       ival = INTVAL (x);

--- a/gcc/config/arc64/arc64.c
+++ b/gcc/config/arc64/arc64.c
@@ -708,7 +708,7 @@ arc64_get_symbol_type (rtx x)
       case ARC64_CMODEL_MEDIUM:
 	return ARC64_LO32;
       case ARC64_CMODEL_LARGE:
-	return is_local ? ARC64_PCREL : ARC64_MAYBE_LARGE;
+	return ARC64_MAYBE_LARGE;
       default:
 	gcc_unreachable ();
       }
@@ -2000,7 +2000,7 @@ arc64_legitimize_address_1 (rtx x, rtx scratch)
     case LABEL_REF:
       t1 = can_create_pseudo_p () ? gen_reg_rtx (Pmode) : scratch;
       gcc_assert (t1);
-      if (!flag_pic && !is_local)
+      if (!flag_pic)
 	{
 	  switch (arc64_cmodel_var)
 	    {

--- a/gcc/config/arc64/arc64.c
+++ b/gcc/config/arc64/arc64.c
@@ -3977,6 +3977,12 @@ arc64_is_long_call_p (rtx sym)
 {
   arc64_symb symb_t = arc64_get_symbol_type (sym);
 
+  /* No subtleties for the time being, if user asks for large memory model,
+     everything goes via regs.  */
+  if (!TARGET_64BIT
+      && (arc64_cmodel_var == ARC64_CMODEL_LARGE))
+    return true;
+
   switch (symb_t)
     {
     case ARC64_UNK:

--- a/gcc/config/arc64/arc64.md
+++ b/gcc/config/arc64/arc64.md
@@ -842,10 +842,10 @@ vpack, vsub, xbfu, xor, xorl"
 	 (match_operand:DI 1 "arc64_immediate_or_pic" "S12S0,SymIm,SymIm,SyPic")))]
   ""
   "@
-   movhl\\t%0,%h1
-   movhl_s\\t%0,%h1
-   movhl\\t%0,%h1
-   addhl\\t%0,pcl,%h1"
+   movhl\\t%0,%H1
+   movhl_s\\t%0,%H1
+   movhl\\t%0,%H1
+   addhl\\t%0,pcl,%H1"
   [(set_attr "type" "move")
    (set_attr "length" "4,6,8,8")])
 

--- a/gcc/config/arc64/arc64.md
+++ b/gcc/config/arc64/arc64.md
@@ -707,14 +707,14 @@ vpack, vsub, xbfu, xor, xorl"
 
 (define_insn "*arc64_movsi"
   [(set
-    (match_operand:SI 0 "arc64_dest_operand"      "=qh,r,    q,    r,    r,h,r,    q,Ustms,Ustor,Ucnst, r,Ustor")
-    (match_operand:SI 1 "arc64_movl_operand"  "qhS03MV,r,U08S0,S12S0,SyPic,i,i,Uldms,    q,S06S0,    i, m,    r"))
+    (match_operand:SI 0 "arc64_dest_operand"      "=qh,r,    q,    r,    r,         h,         r,    q,Ustms,Ustor,Ucnst, r,Ustor")
+    (match_operand:SI 1 "arc64_movl_operand"  "qhS03MV,r,U08S0,S12S0,SyPic,U32S0SymMV,U32S0SymMV,Uldms,    q,S06S0,U32S0, m,    r"))
    ]
   "register_operand (operands[0], SImode)
    || register_operand (operands[1], SImode)
    || (satisfies_constraint_S06S0 (operands[1])
        && memory_operand (operands[0], SImode))
-   || (CONST_INT_P (operands[1])
+   || (satisfies_constraint_U32S0 (operands[1])
        && satisfies_constraint_Ucnst (operands[0]))"
    "@
     mov_s\\t%0,%1

--- a/gcc/config/arc64/arc64.md
+++ b/gcc/config/arc64/arc64.md
@@ -2846,13 +2846,13 @@ vpack, vsub, xbfu, xor, xorl"
 
 
 ;; For thread pointer builtins
-(define_expand "get_thread_pointerdi"
-  [(set (match_operand:DI 0 "register_operand") (match_dup 1))]
+(define_expand "get_thread_pointer<mode>"
+  [(set (match_operand:P 0 "register_operand") (match_dup 1))]
  ""
  "operands[1] = gen_rtx_REG (Pmode, R30_REGNUM);")
 
-(define_expand "set_thread_pointerdi"
-  [(set (match_dup 1) (match_operand:DI 0 "register_operand"))]
+(define_expand "set_thread_pointer<mode>"
+  [(set (match_dup 1) (match_operand:P 0 "register_operand"))]
  ""
  "operands[1] = gen_rtx_REG (Pmode, R30_REGNUM);")
 

--- a/gcc/config/arc64/arith.md
+++ b/gcc/config/arc64/arith.md
@@ -1366,7 +1366,7 @@
   "TARGET_SIMD"
   "@
    dmach\\t%0,%1,%2
-   dmach\\t%0,%1,%H2@u32
+   dmach\\t%0,%1,%V2@u32
    #"
   "&& reload_completed
    && (CONST_INT_P (operands[3]) || (REGNO (operands[3]) != R58_REGNUM))"
@@ -1386,7 +1386,7 @@
  "TARGET_SIMD"
  "@
   dmach\\t0,%0,%1
-  dmach\\t0,%0,%H1@u32"
+  dmach\\t0,%0,%V1@u32"
  [(set_attr "length" "4,8")
   (set_attr "type" "mac")])
 
@@ -2513,7 +2513,7 @@
 	  (parallel [(const_int 1)])
 	  )))]
   "ARC64_VFP_128"
-  "vf<sfxtab>rep\\t%0,%h1"
+  "vf<sfxtab>rep\\t%0,%H1"
   [(set_attr "length" "4")
    (set_attr "type" "vfrep")])
 

--- a/gcc/config/arc64/arith.md
+++ b/gcc/config/arc64/arith.md
@@ -540,14 +540,14 @@
    (set_attr "type"       "<optab><sfxtab>")])
 
 ;; To be merged into adddi3
-(define_insn "*add_tls_off"
-  [(set (match_operand:DI 0 "register_operand" "=r")
-	(plus:DI (match_operand:DI 1 "register_operand" "r")
-		 (unspec:DI [(match_operand 2 "" "")]
+(define_insn "*add_tls_off<mode>"
+  [(set (match_operand:P 0 "register_operand" "=r")
+	(plus:P (match_operand:P 1 "register_operand" "r")
+		(unspec:P [(match_operand 2 "" "")]
 			    ARC64_UNSPEC_TLS_OFF)))]
   ""
-  "addl\\t%0,%1,%2@tpoff"
-  [(set_attr "type" "addl")
+  "add<sfxtab>\\t%0,%1,%2@tpoff"
+  [(set_attr "type" "add<sfxtab>")
    (set_attr "length" "8")]
   )
 

--- a/gcc/config/arc64/constraints.md
+++ b/gcc/config/arc64/constraints.md
@@ -110,7 +110,8 @@
 (define_constraint "BLsym"
   "@internal
   is a symbol reference allowed by the BL instruction"
-  (match_code "symbol_ref"))
+  (and (match_code "symbol_ref")
+       (match_test "!arc64_is_long_call_p (op)")))
 
 (define_constraint "U06M1"
   "@internal

--- a/gcc/config/arc64/elf.h
+++ b/gcc/config/arc64/elf.h
@@ -1,6 +1,6 @@
-/* Target macros for arc64-elf targets.
+/* Target macros for arc*-elf targets.
 
-   Copyright (C) 2020 Free Software Foundation, Inc.
+   Copyright (C) 2021 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/gcc/config/arc64/elf64.h
+++ b/gcc/config/arc64/elf64.h
@@ -1,6 +1,6 @@
 /* Target macros for arc64-elf targets.
 
-   Copyright (C) 2020 Free Software Foundation, Inc.
+   Copyright (C) 2021 Free Software Foundation, Inc.
 
 This file is part of GCC.
 

--- a/gcc/config/arc64/linux.h
+++ b/gcc/config/arc64/linux.h
@@ -1,6 +1,6 @@
-/* Target macros for arc64-*-linux targets.
+/* Target macros for arc*-*-linux targets.
 
-   Copyright (C) 2020 Free Software Foundation, Inc.
+   Copyright (C) 2021 Free Software Foundation, Inc.
 
 This file is part of GCC.
 
@@ -28,20 +28,6 @@ along with GCC; see the file COPYING3.  If not see
       GNU_USER_TARGET_OS_CPP_BUILTINS ();	\
     }						\
   while (0)
-
-#define GLIBC_DYNAMIC_LINKER   "/lib/ld-linux-arc64.so.2"
-
-/* Note that the default is to link against dynamic libraries, if they are
-   available.  Override with -static.  */
-#undef LINK_SPEC
-#define LINK_SPEC "%{h*} \
-  %{static:-Bstatic} \
-  %{shared:-shared} \
-  %{symbolic:-Bsymbolic} \
-  %{!static: \
-    %{rdynamic:-export-dynamic} \
-    %{!shared:-dynamic-linker " GNU_USER_DYNAMIC_LINKER "}} \
-  -X "
 
 #undef STARTFILE_SPEC
 #define STARTFILE_SPEC							\
@@ -100,6 +86,3 @@ along with GCC; see the file COPYING3.  If not see
    fun = gen_rtx_SYMBOL_REF (Pmode, "_mcount");			\
    emit_library_call (fun, LCT_NORMAL, VOIDmode, rt, Pmode);	\
   }
-
-#undef ARC64_64BIT_DEFAULT
-#define ARC64_64BIT_DEFAULT 1

--- a/gcc/config/arc64/linux32.h
+++ b/gcc/config/arc64/linux32.h
@@ -1,4 +1,4 @@
-/* Target macros for arc32-elf targets.
+/* Target macros for arc32-*-linux targets.
 
    Copyright (C) 2021 Free Software Foundation, Inc.
 
@@ -18,13 +18,20 @@ You should have received a copy of the GNU General Public License
 along with GCC; see the file COPYING3.  If not see
 <http://www.gnu.org/licenses/>.  */
 
-#undef  LINK_SPEC
+#define GLIBC_DYNAMIC_LINKER "/lib/ld-linux-arc32.so.2"
+
+/* Note that the default is to link against dynamic libraries, if they are
+   available.  Override with -static.  */
+#undef LINK_SPEC
 #define LINK_SPEC "%{h*} \
-   %{static:-Bstatic}				\
-   %{shared:-shared}				\
-   %{symbolic:-Bsymbolic}			\
-   %{!static:%{rdynamic:-export-dynamic}}	\
-   %{mcpu=hs6*:-m arc64elf64}"
+  %{static:-Bstatic}					    \
+  %{shared:-shared}					    \
+  %{symbolic:-Bsymbolic}				    \
+  %{!static:						    \
+    %{rdynamic:-export-dynamic}				    \
+    %{!shared:-dynamic-linker " GNU_USER_DYNAMIC_LINKER "}} \
+  %{mcpu=hs6*:-m arc64linux64}				    \
+  -X "
 
 #undef ARC64_64BIT_DEFAULT
 #define ARC64_64BIT_DEFAULT 0

--- a/gcc/config/arc64/linux64.h
+++ b/gcc/config/arc64/linux64.h
@@ -1,4 +1,4 @@
-/* Target macros for arc32-elf targets.
+/* Target macros for arc64-*-linux targets.
 
    Copyright (C) 2021 Free Software Foundation, Inc.
 
@@ -18,13 +18,20 @@ You should have received a copy of the GNU General Public License
 along with GCC; see the file COPYING3.  If not see
 <http://www.gnu.org/licenses/>.  */
 
-#undef  LINK_SPEC
+#define GLIBC_DYNAMIC_LINKER "/lib/ld-linux-arc64.so.2"
+
+/* Note that the default is to link against dynamic libraries, if they are
+   available.  Override with -static.  */
+#undef LINK_SPEC
 #define LINK_SPEC "%{h*} \
-   %{static:-Bstatic}				\
-   %{shared:-shared}				\
-   %{symbolic:-Bsymbolic}			\
-   %{!static:%{rdynamic:-export-dynamic}}	\
-   %{mcpu=hs6*:-m arc64elf64}"
+  %{static:-Bstatic}					    \
+  %{shared:-shared}					    \
+  %{symbolic:-Bsymbolic}				    \
+  %{!static:						    \
+    %{rdynamic:-export-dynamic}				    \
+    %{!shared:-dynamic-linker " GNU_USER_DYNAMIC_LINKER "}} \
+  %{mcpu=hs5*:-m arc64linux32}				    \
+  -X "
 
 #undef ARC64_64BIT_DEFAULT
-#define ARC64_64BIT_DEFAULT 0
+#define ARC64_64BIT_DEFAULT 1

--- a/gcc/testsuite/gcc.target/arc64/cmodel-1.c
+++ b/gcc/testsuite/gcc.target/arc64/cmodel-1.c
@@ -1,0 +1,14 @@
+/* Check if the call is made using JL instruction.  */
+/* { dg-do compile } */
+/* { dg-options "-O -mcmodel=large" } */
+
+extern int long_call(int a);
+
+int test (int a)
+{
+  return 3 * long_call(a + 1);
+}
+
+/* { dg-final { scan-assembler "movhl" } } */
+/* { dg-final { scan-assembler "orl" } } */
+/* { dg-final { scan-assembler "jl_s.*\[r\d+\]" } } */

--- a/libgcc/config.host
+++ b/libgcc/config.host
@@ -442,7 +442,12 @@ arc-*-linux* | arceb-*-linux*)
 arc32-*-elf | arc64-*-elf)
 	tmake_file="${tmake_file} arc64/t-arc64 arc64/t-softfp t-softfp t-softfp-sfdf"
 	;;
-arc32-*-linux* | arc64-*-linux*)
+arc32-*-linux*)
+	tmake_file="${tmake_file} arc64/t-softfp t-softfp t-softfp-sfdf"
+	tmake_file="${tmake_file} t-slibgcc-libgcc t-slibgcc-nolc-override"
+	md_unwind_header=arc64/linux-unwind.h
+	;;
+arc64-*-linux*)
 	tmake_file="${tmake_file} arc64/t-arc64 arc64/t-softfp t-softfp t-softfp-sfdf"
 	tmake_file="${tmake_file} t-slibgcc-libgcc t-slibgcc-nolc-override"
 	md_unwind_header=arc64/linux-unwind.h

--- a/libgcc/config.host
+++ b/libgcc/config.host
@@ -439,10 +439,10 @@ arc-*-linux* | arceb-*-linux*)
 	extra_parts="$extra_parts crttls.o"
 	md_unwind_header=arc/linux-unwind.h
 	;;
-arc[6432]*-*-elf)
+arc32-*-elf | arc64-*-elf)
 	tmake_file="${tmake_file} arc64/t-arc64 arc64/t-softfp t-softfp t-softfp-sfdf"
 	;;
-arc64-*-linux*)
+arc32-*-linux* | arc64-*-linux*)
 	tmake_file="${tmake_file} arc64/t-arc64 arc64/t-softfp t-softfp t-softfp-sfdf"
 	tmake_file="${tmake_file} t-slibgcc-libgcc t-slibgcc-nolc-override"
 	md_unwind_header=arc64/linux-unwind.h


### PR DESCRIPTION
Cherry-pick fixes for large mcmodel from arc64 branch to arc32 branch. With these changes we now have working Linux kernel modules on HS5x. 