### PR TITLE
arc64: implement {push,pop}dl_s instructions

### DIFF
--- a/gcc/config/arc64/arc64.md
+++ b/gcc/config/arc64/arc64.md
@@ -948,14 +948,16 @@ xorl"
 
 ;; move 128bit
 (define_insn_and_split "*mov<mode>_insn"
-  [(set (match_operand:A128 0 "arc64_dest_operand"  "=r,r,Ustor")
-	(match_operand:A128 1 "nonimmediate_operand" "r,m,r"))]
+  [(set (match_operand:A128 0 "arc64_dest_operand"  "=r,r,r,Ustk<,Ustor")
+	(match_operand:A128 1 "nonimmediate_operand" "r,Ustk>,m,r,r"))]
   "TARGET_WIDE_LDST
    && (register_operand (operands[0], <MODE>mode)
        || register_operand (operands[1], <MODE>mode))"
   "@
    #
+   popdl_s\\t%0
    lddl%U1\\t%0,%1
+   pushdl_s\\t%1
    stdl%U0\\t%1,%0"
    "&& reload_completed
     && arc64_split_double_move_p (operands, <MODE>mode)"
@@ -964,8 +966,8 @@ xorl"
     arc64_split_double_move (operands, <MODE>mode);
     DONE;
    }
-  [(set_attr "type" "move,ld,st")
-   (set_attr "length" "8,*,*")])
+  [(set_attr "type" "move,ld,ld,st,st")
+   (set_attr "length" "8,2,*,2,*")])
 ;;
 ;; Short insns: movl_s g,h; movl_s b,u8
 ;; Long insns: movl, stl, ldl

--- a/gcc/config/arc64/constraints.md
+++ b/gcc/config/arc64/constraints.md
@@ -93,7 +93,7 @@
   "@internal
    Stack pre-decrement"
   (and (match_code "mem")
-       (match_test "GET_MODE (op) == Pmode")
+       (match_test "GET_MODE (op) == Pmode || GET_MODE (op) == TImode")
        (match_test "GET_CODE (XEXP (op, 0)) == PRE_DEC")
        (match_test "REG_P (XEXP (XEXP (op, 0), 0))")
        (match_test "REGNO (XEXP (XEXP (op, 0), 0)) == SP_REGNUM")))
@@ -102,7 +102,7 @@
   "@internal
    Stack post-increment"
   (and (match_code "mem")
-       (match_test "GET_MODE (op) == Pmode")
+       (match_test "GET_MODE (op) == Pmode || GET_MODE (op) == TImode")
        (match_test "GET_CODE (XEXP (op, 0)) == POST_INC")
        (match_test "REG_P (XEXP (XEXP (op, 0), 0))")
        (match_test "REGNO (XEXP (XEXP (op, 0), 0)) == SP_REGNUM")))

--- a/gcc/testsuite/gcc.target/arc64/interrupt-5.c
+++ b/gcc/testsuite/gcc.target/arc64/interrupt-5.c
@@ -50,22 +50,22 @@ void isr_0 (void)
 /* 2. hs6x output with double loads and stores.  */
 /* { dg-final { scan-assembler "pushl_s\\s+r58\n"   { target { hs6x && doubleaccess } } } } */
 /* { dg-final { scan-assembler "pushl_s\\s+r30\n"   { target { hs6x && doubleaccess } } } } */
-/* { dg-final { scan-assembler "stdl.a\\s+r12,"     { target { hs6x && doubleaccess } } } } */
-/* { dg-final { scan-assembler "stdl.a\\s+r10,"     { target { hs6x && doubleaccess } } } } */
-/* { dg-final { scan-assembler "stdl.a\\s+r8,"      { target { hs6x && doubleaccess } } } } */
-/* { dg-final { scan-assembler "stdl.a\\s+r6,"      { target { hs6x && doubleaccess } } } } */
-/* { dg-final { scan-assembler "stdl.a\\s+r4,"      { target { hs6x && doubleaccess } } } } */
-/* { dg-final { scan-assembler "stdl.a\\s+r2,"      { target { hs6x && doubleaccess } } } } */
-/* { dg-final { scan-assembler "stdl.a\\s+r0,"      { target { hs6x && doubleaccess } } } } */
+/* { dg-final { scan-assembler "pushdl_s\\s+r12\n"  { target { hs6x && doubleaccess } } } } */
+/* { dg-final { scan-assembler "pushdl_s\\s+r10\n"  { target { hs6x && doubleaccess } } } } */
+/* { dg-final { scan-assembler "pushdl_s\\s+r8\n"   { target { hs6x && doubleaccess } } } } */
+/* { dg-final { scan-assembler "pushdl_s\\s+r6\n"   { target { hs6x && doubleaccess } } } } */
+/* { dg-final { scan-assembler "pushdl_s\\s+r4\n"   { target { hs6x && doubleaccess } } } } */
+/* { dg-final { scan-assembler "pushdl_s\\s+r2\n"   { target { hs6x && doubleaccess } } } } */
+/* { dg-final { scan-assembler "pushdl_s\\s+r0\n"   { target { hs6x && doubleaccess } } } } */
 /* { dg-final { scan-assembler "pushl_s\\s+blink\n" { target { hs6x && doubleaccess } } } } */
 /* { dg-final { scan-assembler "popl_s\\s+blink\n"  { target { hs6x && doubleaccess } } } } */
-/* { dg-final { scan-assembler "lddl.ab\\s+r0,"     { target { hs6x && doubleaccess } } } } */
-/* { dg-final { scan-assembler "lddl.ab\\s+r2,"     { target { hs6x && doubleaccess } } } } */
-/* { dg-final { scan-assembler "lddl.ab\\s+r4,"     { target { hs6x && doubleaccess } } } } */
-/* { dg-final { scan-assembler "lddl.ab\\s+r6,"     { target { hs6x && doubleaccess } } } } */
-/* { dg-final { scan-assembler "lddl.ab\\s+r8,"     { target { hs6x && doubleaccess } } } } */
-/* { dg-final { scan-assembler "lddl.ab\\s+r10,"    { target { hs6x && doubleaccess } } } } */
-/* { dg-final { scan-assembler "lddl.ab\\s+r12,"    { target { hs6x && doubleaccess } } } } */
+/* { dg-final { scan-assembler "popdl_s\\s+r0\n"    { target { hs6x && doubleaccess } } } } */
+/* { dg-final { scan-assembler "popdl_s\\s+r2\n"    { target { hs6x && doubleaccess } } } } */
+/* { dg-final { scan-assembler "popdl_s\\s+r4\n"    { target { hs6x && doubleaccess } } } } */
+/* { dg-final { scan-assembler "popdl_s\\s+r6\n"    { target { hs6x && doubleaccess } } } } */
+/* { dg-final { scan-assembler "popdl_s\\s+r8\n"    { target { hs6x && doubleaccess } } } } */
+/* { dg-final { scan-assembler "popdl_s\\s+r10\n"   { target { hs6x && doubleaccess } } } } */
+/* { dg-final { scan-assembler "popdl_s\\s+r12\n"   { target { hs6x && doubleaccess } } } } */
 /* { dg-final { scan-assembler "popl_s\\s+r30\n"    { target { hs6x && doubleaccess } } } } */
 /* { dg-final { scan-assembler "popl_s\\s+r58\n"    { target { hs6x && doubleaccess } } } } */
 


### PR DESCRIPTION
This commit adds 128-bit forms of push and pop using the movTI_insn pattern and an implicit stack pointer operand. For the needs of these instructions, the Ustk constraints are relaxed to accept TImode operands.