### PR TITLE
Set GNU AS & GNU LD as default GCC Driver Configuration for ARC Toolchain

### DIFF
--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -1288,10 +1288,14 @@ arc-*-linux* | arceb-*-linux*)
 arc32-*-elf*)
 	tm_file="elfos.h newlib-stdint.h arc64/elf.h arc64/elf32.h ${tm_file}"
 	tmake_file="${tmake_file} arc64/t-multilib32 arc64/t-arc64"
+	gnu_ld=yes
+	gas=yes
 	;;
 arc64-*-elf*)
 	tm_file="elfos.h newlib-stdint.h arc64/elf.h arc64/elf64.h ${tm_file}"
 	tmake_file="${tmake_file} arc64/t-multilib arc64/t-arc64"
+	gnu_ld=yes
+	gas=yes
 	;;
 arc32-*-linux*)
 	tm_file="elfos.h gnu-user.h linux.h arc64/linux.h arc64/linux32.h linux-android.h glibc-stdint.h ${tm_file}"
@@ -1299,6 +1303,8 @@ arc32-*-linux*)
 	# Force .init_array support.  The configure script cannot always
 	# automatically detect that GAS supports it, yet we require it.
 	gcc_cv_initfini_array=yes
+	gnu_ld=yes
+	gas=yes
 	;;
 arc64-*-linux*)
 	tm_file="elfos.h gnu-user.h linux.h arc64/linux.h arc64/linux64.h linux-android.h glibc-stdint.h ${tm_file}"
@@ -1306,6 +1312,8 @@ arc64-*-linux*)
 	# Force .init_array support.  The configure script cannot always
 	# automatically detect that GAS supports it, yet we require it.
 	gcc_cv_initfini_array=yes
+	gnu_ld=yes
+	gas=yes
 	;;
 arm-wrs-vxworks7*)
 	# We only support VxWorks 7 now on ARM, post SR600.  Pre SR600

--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -1243,6 +1243,8 @@ arc-*-elf* | arceb-*-elf*)
 	if test "x$with_cpu" != x; then
 		tm_defines="${tm_defines} TARGET_CPU_BUILD=PROCESSOR_$with_cpu"
 	fi
+	gnu_ld=yes
+	gas=yes
 	if test x${with_endian} = x; then
 		case ${target} in
 		arc*be-*-* | arc*eb-*-*)	with_endian=big ;;
@@ -1264,6 +1266,8 @@ arc-*-linux* | arceb-*-linux*)
 	if test "x$with_cpu" != x; then
 		tm_defines="${tm_defines} TARGET_CPU_BUILD=PROCESSOR_$with_cpu"
 	fi
+	gnu_ld=yes
+	gas=yes
 	if test x${with_endian} = x; then
 		case ${target} in
 		arc*be-*-* | arc*eb-*-*)	with_endian=big ;;


### PR DESCRIPTION
Configured GCC driver to set GNU AS and GNU LD as
default assembler and linker.

Issue: https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/issues/421
ARC-GNU-TOOLCHAIN PR: https://github.com/foss-for-synopsys-dwc-arc-processors/arc-gnu-toolchain/pull/31