### PR TITLE
[arc64] Fix removing active instruction

### DIFF
--- a/gcc/config/arc64/arc64.cc
+++ b/gcc/config/arc64/arc64.cc
@@ -3210,7 +3210,11 @@ arc64_reorg (void)
 	}
 
       gcc_assert (REGNO (SET_DEST (PATTERN (insn))) == R58_REGNUM);
-      rtx_insn *nxt = next_real_insn (insn);
+      rtx_insn *nxt = next_nonnote_nondebug_insn_bb (insn);
+
+      /* Sanity check: is it a real instruction?  */
+      if (nxt == 0 || !INSN_P (nxt))
+	continue;
 
       /* 2nd Check if it is a move instruction.  */
       tmp = PATTERN (nxt);

--- a/gcc/testsuite/gcc.target/arc64/mac-move-optimize.c
+++ b/gcc/testsuite/gcc.target/arc64/mac-move-optimize.c
@@ -1,0 +1,31 @@
+/* { dg-do compile } */
+/* { dg-options "-Os" } */
+
+
+/* Check if MACH is removing the last accumulator to R0 move.  */
+int bug()
+{
+        int bcnt;
+        int cur_size = 0;
+        int i, j;
+
+        for (i = 10; i > 0; i -= 1) {
+                bcnt = i;
+
+                if (i > 5) {
+                        cur_size += i * i;
+                        continue;
+                }
+
+                for (j = 10; j > 0; j -= 1) {
+                         bcnt += j;
+                }
+
+                cur_size += bcnt * i;
+        }
+
+        return cur_size;
+}
+
+/* { dg-final { scan-assembler "mov\\s+r0,r58" } } */
+/* { dg-final { scan-assembler-times "mac\\s+0," 2 } } */


### PR DESCRIPTION
Can we backport that commit to `arc-2023.09`? I've verified Issues related to that commit and found that it fixes them:

1. https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/issues/594
2. https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/issues/596
3. https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/issues/597

So, customers will be able to build Buildroot images and test it out of the box.