### PR TITLE
libstdc++: Check for fenv.h and complex.h earlier

### DIFF
--- a/libstdc++-v3/configure
+++ b/libstdc++-v3/configure
@@ -16585,6 +16585,24 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+# Check for fenv.h and complex.h before GLIBCXX_CHECK_C99_TR1
+# and GLIBCXX_ENABLE_C99 so that the check is done with the C compiler
+# (not C++). Checking with C++ can break a canadian cross build if either
+# file does not exist in C but does in C++.
+for ac_header in fenv.h complex.h
+do :
+  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
+if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
+_ACEOF
+
+fi
+
+done
+
+
 # Enable all the variable C++ runtime options that don't require linking.
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for underlying I/O to use" >&5
@@ -20508,24 +20526,6 @@ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
-
-
-# Check for fenv.h and complex.h before GLIBCXX_CHECK_C99_TR1
-# so that the check is done with the C compiler (not C++).
-# Checking with C++ can break a canadian cross build if either
-# file does not exist in C but does in C++.
-for ac_header in fenv.h complex.h
-do :
-  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
-ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
-if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
-  cat >>confdefs.h <<_ACEOF
-#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
-_ACEOF
-
-fi
-
-done
 
 
 # For C99 support to TR1.

--- a/libstdc++-v3/configure.ac
+++ b/libstdc++-v3/configure.ac
@@ -179,6 +179,12 @@ fi
 # Checks for compiler support that doesn't require linking.
 GLIBCXX_CHECK_COMPILER_FEATURES
 
+# Check for fenv.h and complex.h before GLIBCXX_CHECK_C99_TR1
+# and GLIBCXX_ENABLE_C99 so that the check is done with the C compiler
+# (not C++). Checking with C++ can break a canadian cross build if either
+# file does not exist in C but does in C++.
+AC_CHECK_HEADERS(fenv.h complex.h)
+
 # Enable all the variable C++ runtime options that don't require linking.
 GLIBCXX_ENABLE_CSTDIO
 GLIBCXX_ENABLE_CLOCALE
@@ -214,12 +220,6 @@ GLIBCXX_CHECK_S_ISREG_OR_S_IFREG
 # For xsputn_2().
 AC_CHECK_HEADERS(sys/uio.h)
 GLIBCXX_CHECK_WRITEV
-
-# Check for fenv.h and complex.h before GLIBCXX_CHECK_C99_TR1
-# so that the check is done with the C compiler (not C++).
-# Checking with C++ can break a canadian cross build if either
-# file does not exist in C but does in C++.
-AC_CHECK_HEADERS(fenv.h complex.h)
 
 # For C99 support to TR1.
 GLIBCXX_CHECK_C99_TR1


### PR DESCRIPTION
Initially this check was performed before `GLIBCXX_CHECK_C99_TR1` to prevent detecting `fenv.h` and `complex.h` from C++ headers. But since GCC 14 `GLIBCXX_ENABLE_C99` also tries to check `fenv.h` and finds it C++ headers even if it is not presented in `libc`. Thus, the check must be performed earlier.