### PR TITLE
Update skip test verification for "-mcpu=" flag

### DIFF
--- a/gcc/testsuite/gcc.target/arc/ashrsi-1.c
+++ b/gcc/testsuite/gcc.target/arc/ashrsi-1.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=hs" } } */
 /* { dg-options "-O2 -mcpu=hs" } */
 
 int ashr1(int x) { return x >> 1; }

--- a/gcc/testsuite/gcc.target/arc/ashrsi-2.c
+++ b/gcc/testsuite/gcc.target/arc/ashrsi-2.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=em" } } */
 /* { dg-options "-O2 -mcpu=em" } */
 
 int foo(int x) { return x >> 1; }

--- a/gcc/testsuite/gcc.target/arc/ashrsi-3.c
+++ b/gcc/testsuite/gcc.target/arc/ashrsi-3.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=em" } } */
 /* { dg-options "-O2 -mcpu=em" } */
 
 int foo(int x, int y) { return y >> 1; }

--- a/gcc/testsuite/gcc.target/arc/ashrsi-4.c
+++ b/gcc/testsuite/gcc.target/arc/ashrsi-4.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=em" } } */
 /* { dg-options "-O2 -mcpu=em" } */
 
 int foo(int x) { return x >> 2; }

--- a/gcc/testsuite/gcc.target/arc/ashrsi-5.c
+++ b/gcc/testsuite/gcc.target/arc/ashrsi-5.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=em" } } */
 /* { dg-options "-O2 -mcpu=em" } */
 
 int foo(int x, int y) { return y >> 2; }

--- a/gcc/testsuite/gcc.target/arc/cmem-bit-1.c
+++ b/gcc/testsuite/gcc.target/arc/cmem-bit-1.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=nps400" } } */
 /* { dg-options "-mcpu=nps400 -mcmem -O2" } */
 
 struct strange_bool

--- a/gcc/testsuite/gcc.target/arc/cmem-bit-2.c
+++ b/gcc/testsuite/gcc.target/arc/cmem-bit-2.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=nps400" } } */
 /* { dg-options "-mcpu=nps400 -mcmem -O2" } */
 
 struct strange_bool

--- a/gcc/testsuite/gcc.target/arc/cmem-bit-3.c
+++ b/gcc/testsuite/gcc.target/arc/cmem-bit-3.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=nps400" } } */
 /* { dg-options "-mcpu=nps400 -mcmem -O2" } */
 
 struct strange_bool

--- a/gcc/testsuite/gcc.target/arc/cmem-bit-4.c
+++ b/gcc/testsuite/gcc.target/arc/cmem-bit-4.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=nps400" } } */
 /* { dg-options "-mcpu=nps400 -mcmem -O2" } */
 
 struct strange_bool

--- a/gcc/testsuite/gcc.target/arc/extvsi-1.c
+++ b/gcc/testsuite/gcc.target/arc/extvsi-1.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=em" } } */
 /* { dg-options "-O2 -mcpu=em" } */
 struct S { int a : 5; };
 

--- a/gcc/testsuite/gcc.target/arc/extvsi-2.c
+++ b/gcc/testsuite/gcc.target/arc/extvsi-2.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=em" } } */
 /* { dg-options "-O2 -mcpu=em" } */
 
 int foo(int x)

--- a/gcc/testsuite/gcc.target/arc/lshrsi-1.c
+++ b/gcc/testsuite/gcc.target/arc/lshrsi-1.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=hs" } } */
 /* { dg-options "-O2 -mcpu=hs" } */
 
 unsigned int lshr1(unsigned int x) { return x >> 1; }

--- a/gcc/testsuite/gcc.target/arc/lshrsi-2.c
+++ b/gcc/testsuite/gcc.target/arc/lshrsi-2.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=em" } } */
 /* { dg-options "-O2 -mcpu=em" } */
 
 unsigned int foo(unsigned int x) { return x >> 1; }

--- a/gcc/testsuite/gcc.target/arc/lshrsi-3.c
+++ b/gcc/testsuite/gcc.target/arc/lshrsi-3.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=em" } } */
 /* { dg-options "-O2 -mcpu=em" } */
 
 unsigned int foo(unsigned int x, unsigned int y){ return y >> 1; }

--- a/gcc/testsuite/gcc.target/arc/lshrsi-4.c
+++ b/gcc/testsuite/gcc.target/arc/lshrsi-4.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=em" } } */
 /* { dg-options "-O2 -mcpu=em" } */
 
 unsigned int foo(unsigned int x) { return x >> 2; }

--- a/gcc/testsuite/gcc.target/arc/lshrsi-5.c
+++ b/gcc/testsuite/gcc.target/arc/lshrsi-5.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=em" } } */
 /* { dg-options "-O2 -mcpu=em" } */
 
 unsigned int foo(unsigned int x, unsigned int y){ return y >> 2; }

--- a/gcc/testsuite/gcc.target/arc/lsl16-1.c
+++ b/gcc/testsuite/gcc.target/arc/lsl16-1.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=em" } } */
 /* { dg-options "-O2 -mcpu=em -mswap" } */
 
 int foo(int x)

--- a/gcc/testsuite/gcc.target/arc/lsr16-1.c
+++ b/gcc/testsuite/gcc.target/arc/lsr16-1.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=em" } } */
 /* { dg-options "-O2 -mcpu=em -mswap" } */
 
 unsigned int foo(unsigned int x)

--- a/gcc/testsuite/gcc.target/arc/nps400-cpu-flag.c
+++ b/gcc/testsuite/gcc.target/arc/nps400-cpu-flag.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=nps400" } } */
 /* { dg-options "-mcpu=nps400" } */
 
 /* { dg-final { scan-assembler ".cpu NPS400" } } */

--- a/gcc/testsuite/gcc.target/arc/pr101955.c
+++ b/gcc/testsuite/gcc.target/arc/pr101955.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=em" } } */
 /* { dg-options "-O2 -mcpu=em" } */
 
 int f(int a)

--- a/gcc/testsuite/gcc.target/arc/scc-ltu.c
+++ b/gcc/testsuite/gcc.target/arc/scc-ltu.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=em" } } */
 /* { dg-options "-O2 -mcpu=em" } */
 
 unsigned int foo(unsigned int x, unsigned int y)

--- a/gcc/testsuite/gcc.target/arc/shlsi-1.c
+++ b/gcc/testsuite/gcc.target/arc/shlsi-1.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=hs" } } */
 /* { dg-options "-O2 -mcpu=hs" } */
 
 unsigned int shl1(unsigned int x) { return x << 1; }

--- a/gcc/testsuite/gcc.target/arc/shlsi-2.c
+++ b/gcc/testsuite/gcc.target/arc/shlsi-2.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=em" } } */
 /* { dg-options "-O2 -mcpu=em" } */
 
 unsigned int foo(unsigned int x) { return x << 1; }

--- a/gcc/testsuite/gcc.target/arc/shlsi-3.c
+++ b/gcc/testsuite/gcc.target/arc/shlsi-3.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=em" } } */
 /* { dg-options "-O2 -mcpu=em" } */
 
 unsigned int foo(unsigned int x, unsigned int y) { return y << 1; }

--- a/gcc/testsuite/gcc.target/arc/shlsi-4.c
+++ b/gcc/testsuite/gcc.target/arc/shlsi-4.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=em" } } */
 /* { dg-options "-O2 -mcpu=em" } */
 
 unsigned int foo(unsigned int x) { return x << 2; }

--- a/gcc/testsuite/gcc.target/arc/shlsi-5.c
+++ b/gcc/testsuite/gcc.target/arc/shlsi-5.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=em" } } */
 /* { dg-options "-O2 -mcpu=em" } */
 
 unsigned int foo(unsigned int x, unsigned int y) { return y << 2; }

--- a/gcc/testsuite/gcc.target/arc/swap-1.c
+++ b/gcc/testsuite/gcc.target/arc/swap-1.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=em" } } */
 /* { dg-options "-O2 -mcpu=em -mswap" } */
 
 int foo(int x)

--- a/gcc/testsuite/gcc.target/arc/swap-2.c
+++ b/gcc/testsuite/gcc.target/arc/swap-2.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=em" } } */
 /* { dg-options "-O2 -mcpu=em -mswap" } */
 
 int foo(int x)

--- a/gcc/testsuite/gcc.target/arc/tumaddsidi4.c
+++ b/gcc/testsuite/gcc.target/arc/tumaddsidi4.c
@@ -1,4 +1,5 @@
 /* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=archs" } } */
 /* { dg-options "-mcpu=archs -O2 -mmpy-option=plus_dmpy -w" } */
 
 /* Check how we generate umaddsidi4 patterns.  */


### PR DESCRIPTION
A DejaGNU directive has been added to skip the test case if the GCC options include any "-mcpu=" flag other than the test requirements.

- arc: Update skip test verification for "-mcpu=archs"
- arc: Update skip test verification for "-mcpu=nps400"
- arc: Update skip test verification for "-mcpu=em"
- arc: Update skip test verification for "-mcpu=hs"