### PR TITLE
arcv: fix integer multiply and divide costs for RHX-100

### DIFF
--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -561,8 +561,8 @@ static const struct riscv_tune_param rhx_tune_info = {
   {COSTS_N_INSNS (4), COSTS_N_INSNS (5)},	/* fp_add */
   {COSTS_N_INSNS (4), COSTS_N_INSNS (5)},	/* fp_mul */
   {COSTS_N_INSNS (20), COSTS_N_INSNS (20)},	/* fp_div */
-  {COSTS_N_INSNS (1), COSTS_N_INSNS (1)},	/* int_mul */
-  {COSTS_N_INSNS (12), COSTS_N_INSNS (12)},	/* int_div */
+  {COSTS_N_INSNS (4), COSTS_N_INSNS (4)},	/* int_mul */
+  {COSTS_N_INSNS (27), COSTS_N_INSNS (43)},	/* int_div */
   4,						/* issue_rate */
   9,						/* branch_cost */
   2,						/* memory_cost */


### PR DESCRIPTION
Currently, those are set to 1 and 12 cycles, respectively.  This is wrong as it inhibits some important math optimizations.  Reflect the truth by setting costs to 4 for integer multiply and 27/43 for integer divide (the operations' respective worst-case latencies).

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
