### PR TITLE
arc64: do not emit custom C++ thunks under large code model

### DIFF
--- a/gcc/config/arc64/arc64.cc
+++ b/gcc/config/arc64/arc64.cc
@@ -2766,6 +2766,17 @@ check_short_insn_constant_p (rtx op, machine_mode mode)
   return false;
 }
 
+
+/* Can output mi_thunk for all cases except the large code model. */
+static bool
+arc64_can_output_mi_thunk (const_tree, HOST_WIDE_INT, HOST_WIDE_INT, const_tree)
+{
+  if (arc64_cmodel_var == ARC64_CMODEL_LARGE)
+    return false;
+
+  return true;
+}
+
 /* Output code to add DELTA to the first argument, and then jump to
    FUNCTION.  Used for C++ multiple inheritance.  */
 
@@ -6699,8 +6710,7 @@ arc64_expand_vector_init (rtx target, rtx vals)
 #define TARGET_ASM_ALIGNED_SI_OP "\t.word\t"
 
 #undef  TARGET_ASM_CAN_OUTPUT_MI_THUNK
-#define TARGET_ASM_CAN_OUTPUT_MI_THUNK \
-  hook_bool_const_tree_hwi_hwi_const_tree_true
+#define TARGET_ASM_CAN_OUTPUT_MI_THUNK arc64_can_output_mi_thunk
 
 #undef TARGET_ASM_OUTPUT_MI_THUNK
 #define TARGET_ASM_OUTPUT_MI_THUNK arc64_output_mi_thunk

--- a/gcc/testsuite/gcc.target/arc64/cmodel-large-cpp-thunk.cpp
+++ b/gcc/testsuite/gcc.target/arc64/cmodel-large-cpp-thunk.cpp
@@ -1,0 +1,24 @@
+/* Check that post-reload thunk generation does not try to create new pseudos. */
+/* { dg-do compile } */
+/* { dg-options "-O -mcmodel=large" } */
+
+#include <cstddef>
+
+#define NO_INLINE __attribute__((noinline))
+
+class A {
+  virtual void foo() = 0;
+};
+class B {
+  virtual void bar() = 0;
+};
+class C : public A, public B {
+  NO_INLINE void foo() {}
+  NO_INLINE void bar() {}
+};
+
+C c;
+
+int main() {
+
+}


### PR DESCRIPTION
Currently, under -mcmodel=large, arc64_output_mi_thunk () always tries to create a new pseudo to accommodate a long call, which leads to a post-reload crash even for a very simple diamond inheritance pattern.  To fix this, define arc64_can_output_mi_thunk () returning false in this scenario, resulting in default machinery being used as opposed to target-specific thunks. Additionally, create a new gcc.target testcase checking that this patch fixes the issue.

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
