### PR TITLE
arcv: Add a separate multilib configuration list

### DIFF
--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -2554,7 +2554,16 @@ riscv*-*-elf* | riscv*-*-rtems*)
 	  if test "x${with_multilib_generator}" = xdefault; then
 		  case "x${enable_multilib}" in
 		  xno) ;;
-		  xyes) tmake_file="${tmake_file} riscv/t-elf-multilib" ;;
+		  xyes)
+			case ${target} in
+			*-snps-*)
+			  tmake_file="${tmake_file} riscv/t-arcv"
+			  ;;
+			*)
+			  tmake_file="${tmake_file} riscv/t-elf-multilib"
+			  ;;
+			esac
+			;;
 		  *) echo "Unknown value for enable_multilib"; exit 1
 		  esac
 	  fi

--- a/gcc/config/riscv/t-arcv
+++ b/gcc/config/riscv/t-arcv
@@ -1,0 +1,107 @@
+empty =
+space = $(empty) $(empty)
+
+MULTILIB_OPTIONS =
+MULTILIB_DIRNAMES =
+MULTILIB_REQUIRED =
+MULTILIB_REUSE =
+
+# Fallaback configurations
+arcv_march_variants  = rv32i
+arcv_march_variants += rv32i_zicsr
+arcv_march_variants += rv32im
+arcv_march_variants += rv32im_zicsr
+arcv_march_variants += rv32imc
+arcv_march_variants += rv32imc_zicsr
+arcv_march_variants += rv32imac
+arcv_march_variants += rv32imac_zicsr
+arcv_march_variants += rv32imafc
+arcv_march_variants += rv32imafdc
+arcv_march_variants += rv64imac
+arcv_march_variants += rv64imac_zicsr
+arcv_march_variants += rv64imafdc
+
+# RMX-100 mini
+arcv_march_variants += rv32e
+arcv_march_variants += rv32e_zicsr
+arcv_march_variants += rv32em_zce_zba_zbb_zbs_zfinx_zdinx_zicsr
+arcv_march_variants += rv32ema_zce_zba_zbb_zbs_zfinx_zdinx_zicsr
+
+# RMX-100/500
+arcv_march_variants += rv32i_zce_zba_zbb_zbs_zicsr
+arcv_march_variants += rv32im_zce_zba_zbb_zbs_zicsr
+arcv_march_variants += rv32ima_zce_zba_zbb_zbs_zicsr
+arcv_march_variants += rv32ima_zce_zba_zbb_zbs_zfinx_zicsr
+arcv_march_variants += rv32ima_zce_zba_zbb_zbs_zfinx_zdinx_zicsr
+
+# RHX-100
+arcv_march_variants += rv32imac_zcb_zcmp_zba_zbb_zbs_zicsr
+arcv_march_variants += rv32imafc_zcb_zcmp_zba_zbb_zbs_zicsr
+arcv_march_variants += rv32imafd_zca_zcb_zcmp_zba_zbb_zbs_zicsr
+
+# RPX-100
+arcv_march_variants += rv64imac_zcb_zba_zbb_zbs_zicsr
+arcv_march_variants += rv64imafdc_zcb_zba_zbb_zbs_zicsr
+
+MULTILIB_OPTIONS    += $(subst $(space),/,$(patsubst %,march=%,$(arcv_march_variants)))
+MULTILIB_DIRNAMES   += $(arcv_march_variants)
+
+MULTILIB_OPTIONS    += mabi=ilp32e/mabi=ilp32/mabi=ilp32f/mabi=ilp32d/mabi=lp64/mabi=lp64d
+MULTILIB_DIRNAMES   +=      ilp32e      ilp32      ilp32f      ilp32d      lp64      lp64d
+
+MULTILIB_OPTIONS    += mtune=arc-v-rmx-100-series/mtune=arc-v-rmx-500-series/mtune=arc-v-rhx-100-series
+MULTILIB_DIRNAMES   +=       rmx100                     rmx500                     rhx100
+
+MULTILIB_OPTIONS    += mcmodel=medany
+MULTILIB_DIRNAMES   +=         medany
+
+# Fallaback configurations
+MULTILIB_REQUIRED   += march=rv32i/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32i_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32im/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32im_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32imc/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32imc_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32imac/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32imac_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32imc/mabi=ilp32/mtune=arc-v-rmx-500-series
+MULTILIB_REQUIRED   += march=rv32imc_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
+MULTILIB_REQUIRED   += march=rv32imac/mabi=ilp32/mtune=arc-v-rmx-500-series
+MULTILIB_REQUIRED   += march=rv32imac_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
+MULTILIB_REQUIRED   += march=rv32imafc/mabi=ilp32f/mtune=arc-v-rhx-100-series
+MULTILIB_REQUIRED   += march=rv32imafdc/mabi=ilp32d/mtune=arc-v-rhx-100-series
+MULTILIB_REQUIRED   += march=rv64imac_zicsr/mabi=lp64
+MULTILIB_REQUIRED   += march=rv64imac_zicsr/mabi=lp64/mcmodel=medany
+MULTILIB_REQUIRED   += march=rv64imafdc/mabi=lp64d
+MULTILIB_REQUIRED   += march=rv64imafdc/mabi=lp64d/mcmodel=medany
+
+# RMX-100 mini
+MULTILIB_REQUIRED   += march=rv32e/mabi=ilp32e/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32e_zicsr/mabi=ilp32e/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32em_zce_zba_zbb_zbs_zfinx_zdinx_zicsr/mabi=ilp32e/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32ema_zce_zba_zbb_zbs_zfinx_zdinx_zicsr/mabi=ilp32e/mtune=arc-v-rmx-100-series
+
+# RMX-100
+MULTILIB_REQUIRED   += march=rv32i_zce_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32im_zce_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32ima_zce_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32ima_zce_zba_zbb_zbs_zfinx_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32ima_zce_zba_zbb_zbs_zfinx_zdinx_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
+
+# RMX-500
+MULTILIB_REQUIRED   += march=rv32i_zce_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
+MULTILIB_REQUIRED   += march=rv32im_zce_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
+MULTILIB_REQUIRED   += march=rv32ima_zce_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
+MULTILIB_REQUIRED   += march=rv32ima_zce_zba_zbb_zbs_zfinx_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
+MULTILIB_REQUIRED   += march=rv32ima_zce_zba_zbb_zbs_zfinx_zdinx_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
+
+# RHX-100
+MULTILIB_REQUIRED   += march=rv32imac_zcb_zcmp_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rhx-100-series
+MULTILIB_REQUIRED   += march=rv32imafc_zcb_zcmp_zba_zbb_zbs_zicsr/mabi=ilp32f/mtune=arc-v-rhx-100-series
+MULTILIB_REQUIRED   += march=rv32imafd_zca_zcb_zcmp_zba_zbb_zbs_zicsr/mabi=ilp32d/mtune=arc-v-rhx-100-series
+
+# RPX-100
+MULTILIB_REQUIRED   += march=rv64imac_zcb_zba_zbb_zbs_zicsr/mabi=lp64
+MULTILIB_REQUIRED   += march=rv64imac_zcb_zba_zbb_zbs_zicsr/mabi=lp64/mcmodel=medany
+MULTILIB_REQUIRED   += march=rv64imafdc_zcb_zba_zbb_zbs_zicsr/mabi=lp64d
+MULTILIB_REQUIRED   += march=rv64imafdc_zcb_zba_zbb_zbs_zicsr/mabi=lp64d/mcmodel=medany


### PR DESCRIPTION
When GCC is built for `riscv*-snps-*` targets, a separate multilib configuration list must be used to make all configurations close to basic ARC-V profiles as much as possible. To achieve that it is necessary to build libraries not only for `march/mabi` combinations, but rather for `march/mabi/mtune` triplets.

Here is a list of ARC-V targets supported by this configuration list:

* RMX-100 mini
* RMX-100 with variations
* RHX with variations
* RPX with variations

Note that RPX (rv64) configurations are built without `mtune` option since it is not implemented yet for RPX.

Here is a list of multilib configurations after building the toolchain:

```
$ riscv64-snps-elf-gcc -print-multi-lib
.;
rv32e/ilp32e/rmx100;@march=rv32e@mabi=ilp32e@mtune=rmx100
rv32i/ilp32/rmx100;@march=rv32i@mabi=ilp32@mtune=rmx100
rv32i/ilp32/rmx500;@march=rv32i@mabi=ilp32@mtune=rmx500
rv32i/ilp32/rhx;@march=rv32i@mabi=ilp32@mtune=rhx
rv32ic_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/ilp32/rmx100;@march=rv32ic_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr@mabi=ilp32@mtune=rmx100
rv32imc_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/ilp32/rmx100;@march=rv32imc_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr@mabi=ilp32@mtune=rmx100
rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/ilp32/rmx100;@march=rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr@mabi=ilp32@mtune=rmx100
rv32imac_zcb_zcmp_zba_zbb_zbs_zicsr/ilp32/rhx;@march=rv32imac_zcb_zcmp_zba_zbb_zbs_zicsr@mabi=ilp32@mtune=rhx
rv32imafc_zcb_zcmp_zba_zbb_zbs_zicsr/ilp32f/rhx;@march=rv32imafc_zcb_zcmp_zba_zbb_zbs_zicsr@mabi=ilp32f@mtune=rhx
rv32imafd_zca_zcb_zcmp_zba_zbb_zbs_zicsr/ilp32d/rhx;@march=rv32imafd_zca_zcb_zcmp_zba_zbb_zbs_zicsr@mabi=ilp32d@mtune=rhx
rv64imac_zcb_zba_zbb_zbs_zicsr/lp64;@march=rv64imac_zcb_zba_zbb_zbs_zicsr@mabi=lp64
rv64imac_zcb_zba_zbb_zbs_zicsr/lp64/medany;@march=rv64imac_zcb_zba_zbb_zbs_zicsr@mabi=lp64@mcmodel=medany
rv64imafdc_zcb_zba_zbb_zbs_zicsr/lp64d;@march=rv64imafdc_zcb_zba_zbb_zbs_zicsr@mabi=lp64d
rv64imafdc_zcb_zba_zbb_zbs_zicsr/lp64d/medany;@march=rv64imafdc_zcb_zba_zbb_zbs_zicsr@mabi=lp64d@mcmodel=medany
```