### PR TITLE
arcv: add next_insn existence checks to some scheduler hooks

### DIFF
--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -8945,7 +8945,8 @@ arcv_macro_fusion_pair_p (rtx_insn *prev, rtx_insn *curr)
 
   /* Look ahead 1 insn to make sure double loads/stores are always
      fused together, even in the presence of other opportunities.  */
-  if (single_set (next_insn (curr)) && get_attr_type (curr) == TYPE_LOAD
+  if (next_insn (curr) && single_set (next_insn (curr))
+      && get_attr_type (curr) == TYPE_LOAD
       && get_attr_type (next_insn (curr)) == TYPE_LOAD)
   {
       rtx addr0 = XEXP (SET_SRC (curr_set), 0);
@@ -8955,7 +8956,8 @@ arcv_macro_fusion_pair_p (rtx_insn *prev, rtx_insn *curr)
 	return false;
   }
 
-  if (single_set (next_insn (curr)) && get_attr_type (curr) == TYPE_STORE
+  if (next_insn (curr) && single_set (next_insn (curr))
+      && get_attr_type (curr) == TYPE_STORE
       && get_attr_type (next_insn (curr)) == TYPE_STORE)
   {
       rtx addr0 = XEXP (SET_DEST (curr_set), 0);
@@ -9397,7 +9399,8 @@ riscv_sched_reorder2 (FILE *file, int verbose, rtx_insn **ready, int *n_readyp, 
 	{
 	  if (recog_memoized (ready[*n_readyp - i]) >= 0
 	     && !SCHED_GROUP_P (ready[*n_readyp - i])
-	     && !SCHED_GROUP_P (next_insn (ready[*n_readyp - i]))
+	     && (!next_insn (ready[*n_readyp - i])
+		 || !SCHED_GROUP_P (next_insn (ready[*n_readyp - i])))
 	     && arcv_macro_fusion_pair_p (last_scheduled_insn, ready[*n_readyp - i]))
 	    {
 	      std::swap (ready[*n_readyp - 1], ready[*n_readyp - i]);
@@ -9419,7 +9422,8 @@ riscv_sched_reorder2 (FILE *file, int verbose, rtx_insn **ready, int *n_readyp, 
 	{
 	  if (recog_memoized (ready[*n_readyp - i]) >= 0
 	     && !SCHED_GROUP_P (ready[*n_readyp - i])
-	     && !SCHED_GROUP_P (next_insn (ready[*n_readyp - i]))
+	     && (!next_insn (ready[*n_readyp - i])
+		 || !SCHED_GROUP_P (next_insn (ready[*n_readyp - i])))
 	     && arcv_macro_fusion_pair_p (last_scheduled_insn, ready[*n_readyp - i]))
 	    {
 	      if (get_attr_type (ready[*n_readyp - i]) == TYPE_LOAD
@@ -9453,13 +9457,15 @@ riscv_sched_reorder2 (FILE *file, int verbose, rtx_insn **ready, int *n_readyp, 
 
     for (int i = 2; i <= *n_readyp; i++)
       {
-	if (recog_memoized (ready[*n_readyp - i]) >= 0
+	if ((recog_memoized (ready[*n_readyp - i]) >= 0
 	    && get_attr_type (ready[*n_readyp - i]) != TYPE_LOAD
 	    && get_attr_type (ready[*n_readyp - i]) != TYPE_STORE
 	    && !SCHED_GROUP_P (ready[*n_readyp - i])
-	    && (!SCHED_GROUP_P (next_insn (ready[*n_readyp - i]))
-	|| (get_attr_type (next_insn (ready[*n_readyp - i])) != TYPE_LOAD
-	    && get_attr_type (next_insn (ready[*n_readyp - i])) != TYPE_STORE)))
+	    && (!next_insn (ready[*n_readyp - i])
+		|| !SCHED_GROUP_P (next_insn (ready[*n_readyp - i]))))
+	|| (next_insn (ready[*n_readyp - i])
+	    && get_attr_type (next_insn (ready[*n_readyp - i])) != TYPE_LOAD
+	    && get_attr_type (next_insn (ready[*n_readyp - i])) != TYPE_STORE))
 	  {
 	    std::swap (ready[*n_readyp - 1], ready[*n_readyp - i]);
 	    alu_pipe_scheduled_p = 1;


### PR DESCRIPTION
In arcv_macro_fusion_pair_p () and riscv_sched_reorder2 (), there is null pointer dereference potential when doing things with next_insn (insn) without first checking that it exists.  Rectify that by adding such checks where necessary.

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
