### PR TITLE
arcv: fuse LH+LH and LB+LB instruction pairs

### DIFF
--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -8743,35 +8743,64 @@ riscv_fusion_enabled_p(enum riscv_fusion_pairs op)
   return tune_param->fusible_ops & op;
 }
 
+/* Return TRUE if the target microarchitecture supports macro-op
+   fusion for two memory operations of mode MODE (the direction
+   of transfer is determined by the IS_LOAD parameter).  */
+
+static bool
+pair_fusion_mode_allowed_p (machine_mode mode, bool is_load)
+{
+  if (!riscv_is_micro_arch (arcv_rhx100))
+    return true;
+
+  return ((is_load && (mode == SImode
+		     || mode == HImode
+		     || mode == QImode))
+	 || (!is_load && mode == SImode));
+}
+
 /* Return TRUE if two addresses can be fused.  */
 
 static bool
-arcv_fused_addr_p (rtx addr0, rtx addr1)
+arcv_fused_addr_p (rtx addr0, rtx addr1, bool is_load)
 {
   rtx base0, base1, tmp;
   HOST_WIDE_INT off0 = 0, off1 = 0;
 
-  if (GET_CODE (addr0) == PLUS)
+  gcc_assert (MEM_P (addr0) && MEM_P (addr1));
+
+  /* Require the accesses to have the same mode.  */
+  if (GET_MODE (addr0) != GET_MODE (addr1))
+    return false;
+
+  /* Check if the mode is allowed.  */
+  if (!pair_fusion_mode_allowed_p (GET_MODE (addr0), is_load))
+    return false;
+
+  rtx reg0 = XEXP (addr0, 0);
+  rtx reg1 = XEXP (addr1, 0);
+
+  if (GET_CODE (reg0) == PLUS)
     {
-      base0 = XEXP (addr0, 0);
-      tmp = XEXP (addr0, 1);
+      base0 = XEXP (reg0, 0);
+      tmp = XEXP (reg0, 1);
       gcc_assert (CONST_INT_P (tmp));
       off0 = INTVAL (tmp);
     }
-  else if (REG_P (addr0))
-    base0 = addr0;
+  else if (REG_P (reg0))
+    base0 = reg0;
   else
     return false;
 
-  if (GET_CODE (addr1) == PLUS)
+  if (GET_CODE (reg1) == PLUS)
     {
-      base1 = XEXP (addr1, 0);
-      tmp = XEXP (addr1, 1);
+      base1 = XEXP (reg1, 0);
+      tmp = XEXP (reg1, 1);
       gcc_assert (CONST_INT_P (tmp));
       off1 = INTVAL (tmp);
     }
-  else if (REG_P (addr1))
-    base1 = addr1;
+  else if (REG_P (reg1))
+    base1 = reg1;
   else
     return false;
 
@@ -8780,9 +8809,9 @@ arcv_fused_addr_p (rtx addr0, rtx addr1)
   if (REGNO (base0) != REGNO (base1))
     return false;
 
-  /* Offsets have to be aligned to word boundary and adjacent in memory,
-     but the memory operations can be narrower. */
-  if ((off0 % UNITS_PER_WORD == 0) && (abs (off1 - off0) == UNITS_PER_WORD))
+  /* Fuse adjacent aligned addresses.  */
+  if ((off0 % GET_MODE_SIZE (GET_MODE (addr0)).to_constant () == 0)
+      && (abs (off1 - off0) == GET_MODE_SIZE (GET_MODE (addr0)).to_constant ()))
     return true;
 
   return false;
@@ -8926,20 +8955,23 @@ arcv_macro_fusion_pair_p (rtx_insn *prev, rtx_insn *curr)
   if (get_attr_type (prev) == TYPE_LOAD
       && get_attr_type (curr) == TYPE_LOAD)
     {
-      rtx addr0 = XEXP (SET_SRC (prev_set), 0);
-      rtx addr1 = XEXP (SET_SRC (curr_set), 0);
+      rtx addr0 = SET_SRC (prev_set);
+      rtx addr1 = SET_SRC (curr_set);
 
-      if (arcv_fused_addr_p (addr0, addr1))
+      if (GET_CODE (addr0) == SIGN_EXTEND || GET_CODE (addr0) == ZERO_EXTEND)
+	addr0 = XEXP (addr0, 0);
+
+      if (GET_CODE (addr1) == SIGN_EXTEND || GET_CODE (addr1) == ZERO_EXTEND)
+	addr1 = XEXP (addr1, 0);
+
+      if (arcv_fused_addr_p (addr0, addr1, true))
 	return true;
     }
 
   if (get_attr_type (prev) == TYPE_STORE
       && get_attr_type (curr) == TYPE_STORE)
     {
-      rtx addr0 = XEXP (SET_DEST (prev_set), 0);
-      rtx addr1 = XEXP (SET_DEST (curr_set), 0);
-
-      if (arcv_fused_addr_p (addr0, addr1))
+      if (arcv_fused_addr_p (SET_DEST (prev_set), SET_DEST (curr_set), false))
 	return true;
     }
 
@@ -8949,10 +8981,16 @@ arcv_macro_fusion_pair_p (rtx_insn *prev, rtx_insn *curr)
       && get_attr_type (curr) == TYPE_LOAD
       && get_attr_type (next_insn (curr)) == TYPE_LOAD)
   {
-      rtx addr0 = XEXP (SET_SRC (curr_set), 0);
-      rtx addr1 = XEXP (SET_SRC (single_set (next_insn (curr))), 0);
+      rtx addr0 = SET_SRC (curr_set);
+      rtx addr1 = SET_SRC (single_set (next_insn (curr)));
 
-      if (arcv_fused_addr_p (addr0, addr1))
+      if (GET_CODE (addr0) == SIGN_EXTEND || GET_CODE (addr0) == ZERO_EXTEND)
+	addr0 = XEXP (addr0, 0);
+
+      if (GET_CODE (addr1) == SIGN_EXTEND || GET_CODE (addr1) == ZERO_EXTEND)
+	addr1 = XEXP (addr1, 0);
+
+      if (arcv_fused_addr_p (addr0, addr1, true))
 	return false;
   }
 
@@ -8960,10 +8998,8 @@ arcv_macro_fusion_pair_p (rtx_insn *prev, rtx_insn *curr)
       && get_attr_type (curr) == TYPE_STORE
       && get_attr_type (next_insn (curr)) == TYPE_STORE)
   {
-      rtx addr0 = XEXP (SET_DEST (curr_set), 0);
-      rtx addr1 = XEXP (SET_DEST (single_set (next_insn (curr))), 0);
-
-      if (arcv_fused_addr_p (addr0, addr1))
+      if (arcv_fused_addr_p (SET_DEST (curr_set),
+			SET_DEST (single_set (next_insn (curr))), false))
 	return false;
   }
 
@@ -9236,7 +9272,8 @@ riscv_macro_fusion_pair_p (rtx_insn *prev, rtx_insn *curr)
    otherwise return FALSE.  */
 
 static bool
-fusion_load_store (rtx_insn *insn, rtx *base, rtx *offset, bool *is_load)
+fusion_load_store (rtx_insn *insn, rtx *base, rtx *offset, machine_mode *mode,
+		   bool *is_load)
 {
   rtx x, dest, src;
 
@@ -9247,15 +9284,22 @@ fusion_load_store (rtx_insn *insn, rtx *base, rtx *offset, bool *is_load)
 
   src = SET_SRC (x);
   dest = SET_DEST (x);
+
+  if ((GET_CODE (src) == SIGN_EXTEND || GET_CODE (src) == ZERO_EXTEND)
+      && MEM_P (XEXP (src, 0)))
+    src = XEXP (src, 0);
+
   if (REG_P (src) && MEM_P (dest))
     {
       *is_load = false;
-      extract_base_offset_in_addr (dest, base, offset);
+      if (extract_base_offset_in_addr (dest, base, offset))
+	*mode = GET_MODE (dest);
     }
   else if (MEM_P (src) && REG_P (dest))
     {
       *is_load = true;
-      extract_base_offset_in_addr (src, base, offset);
+      if (extract_base_offset_in_addr (src, base, offset))
+	*mode = GET_MODE (src);
     }
   else
     return false;
@@ -9270,11 +9314,13 @@ riscv_sched_fusion_priority (rtx_insn *insn, int max_pri, int *fusion_pri,
   int tmp, off_val;
   bool is_load;
   rtx base, offset;
+  machine_mode mode;
 
   gcc_assert (INSN_P (insn));
 
   tmp = max_pri - 1;
-  if (!fusion_load_store (insn, &base, &offset, &is_load))
+  if (!fusion_load_store (insn, &base, &offset, &mode, &is_load)
+      || !pair_fusion_mode_allowed_p (mode, is_load))
     {
       *pri = tmp;
       *fusion_pri = tmp;
@@ -9282,6 +9328,11 @@ riscv_sched_fusion_priority (rtx_insn *insn, int max_pri, int *fusion_pri,
     }
 
   tmp /= 2;
+
+  if (mode == HImode)
+    tmp /= 2;
+  else if (mode == QImode)
+    tmp /= 4;
 
   /* INSN with smaller base register goes first.  */
   tmp -= ((REGNO (base) & 0xff) << 20);
@@ -9291,7 +9342,9 @@ riscv_sched_fusion_priority (rtx_insn *insn, int max_pri, int *fusion_pri,
 
   /* Put loads/stores operating on adjacent words into the same
    * scheduling group.  */
-  *fusion_pri = tmp - ((off_val / (UNITS_PER_WORD * 2)) << 1) + is_load;
+  *fusion_pri = tmp
+		- ((off_val / (GET_MODE_SIZE (mode).to_constant () * 2)) << 1)
+		+ is_load;
 
   if (off_val >= 0)
     tmp -= (off_val & 0xfffff);


### PR DESCRIPTION
In addition to the LW+LW and SW+SW pairs that are already being recognized as macro-op-fusable, add support for 8-bit and naturally aligned 16-bit loads operating on adjacent memory locations.  To that end, introduce the new microarch-specific pair_fusion_mode_allowed_p () predicate, and call it from fusion_load_store () during sched_fusion, and from arcv_macro_fusion_pair_p () during regular scheduling passes.

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
