### PR TITLE
arcv: adjust scheduling priority for load/store pairs

### DIFF
--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -9427,6 +9427,26 @@ riscv_sched_adjust_cost (rtx_insn *insn, int dep_type, rtx_insn *dep_insn, int c
   return new_cost;
 }
 
+static int
+riscv_sched_adjust_priority (rtx_insn *insn, int priority)
+{
+  if (!riscv_is_micro_arch (arcv_rhx100))
+    return priority;
+
+  /* Bump the priority of fused load-store pairs for easier
+     scheduling of the memory pipe.  The specific increase
+     value is determined empirically.  */
+  if (next_insn (insn) && SCHED_GROUP_P (next_insn (insn))
+      && ((get_attr_type (insn) == TYPE_STORE
+	   && get_attr_type (next_insn (insn)) == TYPE_STORE)
+	 || (get_attr_type (insn) == TYPE_LOAD
+	     && get_attr_type (next_insn (insn)) == TYPE_LOAD)))
+    return priority + 1;
+
+  return priority;
+}
+
+
 static void
 riscv_sched_init (FILE *file, int verbose, int max_ready)
 {
@@ -12017,6 +12037,9 @@ expand_reversed_crc_using_clmul (rtx *operands)
 
 #undef  TARGET_SCHED_ADJUST_COST
 #define TARGET_SCHED_ADJUST_COST riscv_sched_adjust_cost
+
+#undef  TARGET_SCHED_ADJUST_PRIORITY
+#define TARGET_SCHED_ADJUST_PRIORITY riscv_sched_adjust_priority
 
 #undef  TARGET_SCHED_REORDER2
 #define TARGET_SCHED_REORDER2 riscv_sched_reorder2


### PR DESCRIPTION
This patch implements riscv_sched_adjust_priority () for the RHX-100 microarchitecture by slightly bumping the priority of load/store pairs.  As a consequence of this change, it becomes easier for riscv_sched_reorder2 () to schedule instructions in the memory pipe.

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
