### PR TITLE
Fix implications rules for C extension

### DIFF
--- a/gcc/common/config/riscv/riscv-common.cc
+++ b/gcc/common/config/riscv/riscv-common.cc
@@ -190,7 +190,7 @@ static const riscv_implied_info_t riscv_implied_info[] =
   {"zcmp", "zca"},
   {"zcmt", "zca"},
   {"zcmt", "zicsr"},
-  {"zcf", "f",
+  {"zce", "zcf",
    [] (const riscv_subset_list *subset_list) -> bool
    {
      return subset_list->xlen () == 32 && subset_list->lookup ("f");

--- a/gcc/common/config/riscv/riscv-common.cc
+++ b/gcc/common/config/riscv/riscv-common.cc
@@ -195,6 +195,22 @@ static const riscv_implied_info_t riscv_implied_info[] =
    {
      return subset_list->xlen () == 32 && subset_list->lookup ("f");
    }},
+  {"zca", "c",
+   [] (const riscv_subset_list *subset_list) -> bool
+   {
+     if (subset_list->xlen () == 32) {
+       if (subset_list->lookup ("d"))
+         return subset_list->lookup ("zcf") && subset_list->lookup ("zcd");
+
+       if (subset_list->lookup ("f"))
+         return subset_list->lookup ("zcf");
+
+       return true;
+     }
+
+     if (subset_list->lookup ("d"))
+       return subset_list->lookup ("zcd");
+   }},
 
   {"smaia", "ssaia"},
   {"smstateen", "ssstateen"},

--- a/gcc/common/config/riscv/riscv-common.cc
+++ b/gcc/common/config/riscv/riscv-common.cc
@@ -79,6 +79,18 @@ static const riscv_implied_info_t riscv_implied_info[] =
   {"f", "zicsr"},
   {"d", "zicsr"},
 
+  {"c", "zca"},
+  {"c", "zcf",
+   [] (const riscv_subset_list *subset_list) -> bool
+   {
+     return subset_list->xlen () == 32 && subset_list->lookup ("f");
+   }},
+  {"c", "zcd",
+   [] (const riscv_subset_list *subset_list) -> bool
+   {
+     return subset_list->lookup ("d");
+   }},
+
   {"zdinx", "zfinx"},
   {"zfinx", "zicsr"},
   {"zdinx", "zicsr"},

--- a/gcc/testsuite/gcc.target/riscv/arch-39.c
+++ b/gcc/testsuite/gcc.target/riscv/arch-39.c
@@ -1,0 +1,7 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv64idc_zcmt -mabi=lp64d" } */
+int
+foo ()
+{}
+
+/* { dg-error "zcd conflicts with zcmt" "" { target *-*-* } 0 } */

--- a/gcc/testsuite/gcc.target/riscv/arch-40.c
+++ b/gcc/testsuite/gcc.target/riscv/arch-40.c
@@ -1,0 +1,7 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv64idc_zcmp -mabi=lp64d" } */
+int
+foo ()
+{}
+
+/* { dg-error "zcd conflicts with zcmp" "" { target *-*-* } 0 } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-15.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-15.c
@@ -3,4 +3,4 @@
 int foo()
 {
 }
-/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p0_m2p0_a2p0_f2p0_d2p0_c2p0\"" } } */
+/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p0_m2p0_a2p0_f2p0_d2p0_c2p0_zca1p0_zcd1p0_zcf1p0\"" } } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-16.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-16.c
@@ -3,4 +3,4 @@
 int foo()
 {
 }
-/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p1_m2p0_a2p0_f2p2_d2p2_c2p0_zicsr2p0" } } */
+/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p1_m2p0_a2p0_f2p2_d2p2_c2p0_zicsr2p0_zca1p0_zcd1p0_zcf1p0\"" } } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-17.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-17.c
@@ -3,4 +3,4 @@
 int foo()
 {
 }
-/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_zicsr2p0" } } */
+/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_zicsr2p0_zca1p0_zcd1p0_zcf1p0\"" } } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-18.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-18.c
@@ -1,4 +1,4 @@
 /* { dg-do compile } */
 /* { dg-options "-mriscv-attribute -march=rv64imafdc -mabi=lp64d -misa-spec=2.2" } */
 int foo() {}
-/* { dg-final { scan-assembler ".attribute arch, \"rv64i2p0_m2p0_a2p0_f2p0_d2p0_c2p0\"" } } */
+/* { dg-final { scan-assembler ".attribute arch, \"rv64i2p0_m2p0_a2p0_f2p0_d2p0_c2p0_zca1p0_zcd1p0\"" } } */

--- a/gcc/testsuite/gcc.target/riscv/pr110696.c
+++ b/gcc/testsuite/gcc.target/riscv/pr110696.c
@@ -4,4 +4,4 @@ int foo()
 {
 }
 
-/* { dg-final { scan-assembler ".attribute arch, \"rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_v1p0_zicsr2p0_zifencei2p0_zve32f1p0_zve32x1p0_zve64d1p0_zve64f1p0_zve64x1p0_zvl1024b1p0_zvl128b1p0_zvl2048b1p0_zvl256b1p0_zvl32b1p0_zvl4096b1p0_zvl512b1p0_zvl64b1p0\"" } } */
+/* { dg-final { scan-assembler ".attribute arch, \"rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_v1p0_zicsr2p0_zifencei2p0_zca1p0_zcd1p0_zve32f1p0_zve32x1p0_zve64d1p0_zve64f1p0_zve64x1p0_zvl1024b1p0_zvl128b1p0_zvl2048b1p0_zvl256b1p0_zvl32b1p0_zvl4096b1p0_zvl512b1p0_zvl64b1p0\"" } } */

--- a/gcc/testsuite/gcc.target/riscv/rvv/base/abi-callee-saved-1-zcmp.c
+++ b/gcc/testsuite/gcc.target/riscv/rvv/base/abi-callee-saved-1-zcmp.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-O1 -march=rv64gcv_zfh_zca_zcmp -mabi=lp64d -fno-shrink-wrap-separate" } */
+/* { dg-options "-O1 -march=rv64gv_zfh_zca_zcmp -mabi=lp64d -fno-shrink-wrap-separate" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <riscv_vector.h>

--- a/gcc/testsuite/gcc.target/riscv/rvv/base/abi-callee-saved-2-zcmp.c
+++ b/gcc/testsuite/gcc.target/riscv/rvv/base/abi-callee-saved-2-zcmp.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-O1 -march=rv64gcv_zfh_zca_zcmp -mabi=lp64d -fno-shrink-wrap-separate" } */
+/* { dg-options "-O1 -march=rv64gv_zfh_zca_zcmp -mabi=lp64d -fno-shrink-wrap-separate" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <riscv_vector.h>

--- a/gcc/testsuite/gcc.target/riscv/rvv/base/pr114352-1.c
+++ b/gcc/testsuite/gcc.target/riscv/rvv/base/pr114352-1.c
@@ -54,5 +54,5 @@ test_3 (int *a, int *b, int *out, unsigned count)
     out[i] = a[i] + b[i];
 }
 
-/* { dg-final { scan-assembler ".attribute arch, \"rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_zicsr2p0_zifencei2p0\"" } } */
-/* { dg-final { scan-assembler ".option arch, rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_v1p0_zicsr2p0_zifencei2p0_zve32f1p0_zve32x1p0_zve64d1p0_zve64f1p0_zve64x1p0_zvl128b1p0_zvl32b1p0_zvl64b1p0" } } */
+/* { dg-final { scan-assembler ".attribute arch, \"rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_zicsr2p0_zifencei2p0_zca1p0_zcd1p0\"" } } */
+/* { dg-final { scan-assembler ".option arch, rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_v1p0_zicsr2p0_zifencei2p0_zca1p0_zcd1p0_zve32f1p0_zve32x1p0_zve64d1p0_zve64f1p0_zve64x1p0_zvl128b1p0_zvl32b1p0_zvl64b1p0" } } */

--- a/gcc/testsuite/gcc.target/riscv/rvv/base/pr114352-3.c
+++ b/gcc/testsuite/gcc.target/riscv/rvv/base/pr114352-3.c
@@ -107,7 +107,7 @@ test_6 (_Float16 *a, _Float16 *b, _Float16 *out, unsigned count)
     out[i] = a[i] + b[i];
 }
 
-/* { dg-final { scan-assembler ".attribute arch, \"rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_zicsr2p0_zifencei2p0\"" } } */
-/* { dg-final { scan-assembler ".option arch, rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_v1p0_zicsr2p0_zifencei2p0_zve32f1p0_zve32x1p0_zve64d1p0_zve64f1p0_zve64x1p0_zvl128b1p0_zvl32b1p0_zvl64b1p0" } } */
-/* { dg-final { scan-assembler ".option arch, rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_zicsr2p0_zifencei2p0_zbb1p0" } } */
-/* { dg-final { scan-assembler ".option arch, rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_zicsr2p0_zifencei2p0_zfh1p0_zfhmin1p0" } } */
+/* { dg-final { scan-assembler ".attribute arch, \"rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_zicsr2p0_zifencei2p0_zca1p0_zcd1p0\"" } } */
+/* { dg-final { scan-assembler ".option arch, rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_v1p0_zicsr2p0_zifencei2p0_zca1p0_zcd1p0_zve32f1p0_zve32x1p0_zve64d1p0_zve64f1p0_zve64x1p0_zvl128b1p0_zvl32b1p0_zvl64b1p0" } } */
+/* { dg-final { scan-assembler ".option arch, rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_zicsr2p0_zifencei2p0_zca1p0_zcd1p0_zbb1p0" } } */
+/* { dg-final { scan-assembler ".option arch, rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_zicsr2p0_zifencei2p0_zfh1p0_zfhmin1p0_zca1p0_zcd1p0" } } */


### PR DESCRIPTION
The motivation for these patches was fixing this issue: https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/issues/653. The problem is that there is no support of implying `zc*` from `c` extension and vice versa in `arc-2024.12` branch. This may confuse users in cases when for example `rv32im_ze` is not compatible with `rv32imc` and incorrect multilib configuration is chosen.

First patch is just a cherry pick of an original patch from upstream. It makes `c` to imply `zca`, `zcf` and `zcd`. The second one fixes a typo in `ze` to `zcf` rule for RV32. And the last one introduces rules for a reversed implication like `rv32i_zca` to `rv32ic`.