### PR TITLE
Fix shift operation with direct memory access.

### DIFF
--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -9870,6 +9870,11 @@ riscv_override_options_internal (struct gcc_options *opts)
   else if (!TARGET_MUL_OPTS_P (opts) && TARGET_DIV_OPTS_P (opts))
     error ("%<-mdiv%> requires %<-march%> to subsume the %<M%> extension");
 
+  /* We might use a multiplication to calculate the scalable vector length at
+     runtime.  Therefore, require the M extension.  */
+  if (TARGET_VECTOR && !TARGET_MUL)
+    sorry ("GCC's current %<V%> implementation requires the %<M%> extension");
+
   /* Likewise floating-point division and square root.  */
   if ((TARGET_HARD_FLOAT_OPTS_P (opts) || TARGET_ZFINX_OPTS_P (opts))
       && ((target_flags_explicit & MASK_FDIV) == 0))

--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -2406,6 +2406,7 @@ mem_shadd_or_shadd_rtx_p (rtx x)
 {
   return ((GET_CODE (x) == ASHIFT
 	   || GET_CODE (x) == MULT)
+	  && register_operand (XEXP (x, 0), GET_MODE (x))
 	  && CONST_INT_P (XEXP (x, 1))
 	  && ((GET_CODE (x) == ASHIFT && IN_RANGE (INTVAL (XEXP (x, 1)), 1, 3))
 	      || (GET_CODE (x) == MULT

--- a/gcc/testsuite/gcc.target/riscv/arch-31.c
+++ b/gcc/testsuite/gcc.target/riscv/arch-31.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32i_zvfbfmin -mabi=ilp32f" } */
+/* { dg-options "-march=rv32im_zvfbfmin -mabi=ilp32f" } */
 int foo()
 {
 }

--- a/gcc/testsuite/gcc.target/riscv/arch-32.c
+++ b/gcc/testsuite/gcc.target/riscv/arch-32.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv64iv_zvfbfmin -mabi=lp64d" } */
+/* { dg-options "-march=rv64imv_zvfbfmin -mabi=lp64d" } */
 int foo()
 {
 }

--- a/gcc/testsuite/gcc.target/riscv/compare-debug-1.c
+++ b/gcc/testsuite/gcc.target/riscv/compare-debug-1.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-O -fno-tree-ch --param=max-completely-peel-times=0 -march=rv64iv -mabi=lp64d -fcompare-debug" } */
+/* { dg-options "-O -fno-tree-ch --param=max-completely-peel-times=0 -march=rv64imv -mabi=lp64d -fcompare-debug" } */
 
 
 void

--- a/gcc/testsuite/gcc.target/riscv/compare-debug-2.c
+++ b/gcc/testsuite/gcc.target/riscv/compare-debug-2.c
@@ -1,3 +1,3 @@
 /* { dg-do compile } */
-/* { dg-options "-O -fno-tree-ch --param=max-completely-peel-times=0 -march=rv64iv -mabi=lp64d -fno-dce -fschedule-insns -fcompare-debug" } */
+/* { dg-options "-O -fno-tree-ch --param=max-completely-peel-times=0 -march=rv64imv -mabi=lp64d -fno-dce -fschedule-insns -fcompare-debug" } */
 #include "compare-debug-1.c"

--- a/gcc/testsuite/gcc.target/riscv/pr115142.c
+++ b/gcc/testsuite/gcc.target/riscv/pr115142.c
@@ -1,0 +1,10 @@
+/* { dg-do compile } */
+/* { dg-options "-O0 -ftree-ter" } */
+
+long a;
+char b;
+void e() {
+  char f[8][1];
+  b = f[a][a];
+}
+

--- a/gcc/testsuite/gcc.target/riscv/predef-14.c
+++ b/gcc/testsuite/gcc.target/riscv/predef-14.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv32iv -mabi=ilp32 -mcmodel=medlow -misa-spec=2.2" } */
+/* { dg-options "-march=rv32imv -mabi=ilp32 -mcmodel=medlow -misa-spec=2.2" } */
 
 int main () {
 
@@ -27,8 +27,8 @@ int main () {
 #error "__riscv_a"
 #endif
 
-#if defined(__riscv_m)
-#error "__riscv_m"
+#if !defined(__riscv_mul)
+#error "__riscv_mul"
 #endif
 
 #if !defined(__riscv_f)

--- a/gcc/testsuite/gcc.target/riscv/predef-15.c
+++ b/gcc/testsuite/gcc.target/riscv/predef-15.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv64iv_zvl512b -mabi=lp64 -mcmodel=medlow -misa-spec=2.2" } */
+/* { dg-options "-march=rv64imv_zvl512b -mabi=lp64 -mcmodel=medlow -misa-spec=2.2" } */
 
 int main () {
 
@@ -27,7 +27,7 @@ int main () {
 #error "__riscv_a"
 #endif
 
-#if defined(__riscv_m)
+#if !defined(__riscv_m)
 #error "__riscv_m"
 #endif
 

--- a/gcc/testsuite/gcc.target/riscv/predef-16.c
+++ b/gcc/testsuite/gcc.target/riscv/predef-16.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv64i_zve64f -mabi=lp64 -mcmodel=medlow -misa-spec=2.2" } */
+/* { dg-options "-march=rv64im_zve64f -mabi=lp64 -mcmodel=medlow -misa-spec=2.2" } */
 
 int main () {
 
@@ -27,7 +27,7 @@ int main () {
 #error "__riscv_a"
 #endif
 
-#if defined(__riscv_m)
+#if !defined(__riscv_m)
 #error "__riscv_m"
 #endif
 

--- a/gcc/testsuite/gcc.target/riscv/predef-26.c
+++ b/gcc/testsuite/gcc.target/riscv/predef-26.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-O2 -march=rv64i_zvfhmin -mabi=lp64f -mcmodel=medlow -misa-spec=20191213" } */
+/* { dg-options "-O2 -march=rv64im_zvfhmin -mabi=lp64f -mcmodel=medlow -misa-spec=20191213" } */
 
 int main () {
 
@@ -13,6 +13,10 @@ int main () {
 
 #if !defined(__riscv_i)
 #error "__riscv_i"
+#endif
+
+#if !defined(__riscv_m)
+#error "__riscv_m"
 #endif
 
 #if !defined(__riscv_f)

--- a/gcc/testsuite/gcc.target/riscv/predef-27.c
+++ b/gcc/testsuite/gcc.target/riscv/predef-27.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-O2 -march=rv64i_zvfh -mabi=lp64f -mcmodel=medlow -misa-spec=20191213" } */
+/* { dg-options "-O2 -march=rv64im_zvfh -mabi=lp64f -mcmodel=medlow -misa-spec=20191213" } */
 
 int main () {
 
@@ -13,6 +13,10 @@ int main () {
 
 #if !defined(__riscv_i)
 #error "__riscv_i"
+#endif
+
+#if !defined(__riscv_m)
+#error "__riscv_m"
 #endif
 
 #if !defined(__riscv_f)

--- a/gcc/testsuite/gcc.target/riscv/predef-32.c
+++ b/gcc/testsuite/gcc.target/riscv/predef-32.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-O2 -march=rv32i_zvfbfmin -mabi=ilp32f -mcmodel=medlow -misa-spec=20191213" } */
+/* { dg-options "-O2 -march=rv32im_zvfbfmin -mabi=ilp32f -mcmodel=medlow -misa-spec=20191213" } */
 
 int main () {
 
@@ -13,6 +13,10 @@ int main () {
 
 #if !defined(__riscv_i)
 #error "__riscv_i"
+#endif
+
+#if !defined(__riscv_m)
+#error "__riscv_m"
 #endif
 
 #if !defined(__riscv_f)

--- a/gcc/testsuite/gcc.target/riscv/predef-33.c
+++ b/gcc/testsuite/gcc.target/riscv/predef-33.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-O2 -march=rv64iv_zvfbfmin -mabi=lp64d -mcmodel=medlow -misa-spec=20191213" } */
+/* { dg-options "-O2 -march=rv64imv_zvfbfmin -mabi=lp64d -mcmodel=medlow -misa-spec=20191213" } */
 
 int main () {
 
@@ -13,6 +13,10 @@ int main () {
 
 #if !defined(__riscv_i)
 #error "__riscv_i"
+#endif
+
+#if !defined(__riscv_m)
+#error "__riscv_m"
 #endif
 
 #if !defined(__riscv_f)

--- a/gcc/testsuite/gcc.target/riscv/rvv/autovec/pr111486.c
+++ b/gcc/testsuite/gcc.target/riscv/rvv/autovec/pr111486.c
@@ -1,5 +1,5 @@
 /* { dg-do compile } */
-/* { dg-options "-march=rv64iv -mabi=lp64d -O2" } */
+/* { dg-options "-march=rv64imv -mabi=lp64d -O2" } */
 
 typedef char __attribute__((__vector_size__ (1))) V;
 

--- a/gcc/testsuite/gcc.target/riscv/rvv/base/pr116036.c
+++ b/gcc/testsuite/gcc.target/riscv/rvv/base/pr116036.c
@@ -1,0 +1,11 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv64idv -mabi=lp64d -O3" } */
+
+int a[15][15];
+void init() {
+  for (int i_0 ; i_0 < 15 ; ++i_0)
+    for (int i_1 = 0; i_1 < 15; ++i_1)
+      a[i_0][i_1] = 1;
+}
+
+/* { dg-excess-errors "sorry, unimplemented: GCC's current 'V' implementation requires the 'M' extension" } */


### PR DESCRIPTION
Do not create invalidate shift operations.
Mandatory M extension when using V extension.