### PR TITLE
fixup! arcv: Add a separate multilib configuration list

### DIFF
--- a/gcc/config/riscv/t-arcv
+++ b/gcc/config/riscv/t-arcv
@@ -6,33 +6,41 @@ MULTILIB_DIRNAMES =
 MULTILIB_REQUIRED =
 MULTILIB_REUSE =
 
-# Fallaback configurations
-arcv_march_variants  = rv32i
+# Fallback configurations
+arcv_march_variants  = rv32e
+arcv_march_variants += rv32e_zicsr
+arcv_march_variants += rv32i
 arcv_march_variants += rv32i_zicsr
+arcv_march_variants += rv32ic
+arcv_march_variants += rv32ic_zicsr
+arcv_march_variants += rv32ia
+arcv_march_variants += rv32ia_zicsr
 arcv_march_variants += rv32im
 arcv_march_variants += rv32im_zicsr
+arcv_march_variants += rv32iac
+arcv_march_variants += rv32iac_zicsr
 arcv_march_variants += rv32imc
 arcv_march_variants += rv32imc_zicsr
 arcv_march_variants += rv32imac
 arcv_march_variants += rv32imac_zicsr
 arcv_march_variants += rv32imafc
 arcv_march_variants += rv32imafdc
+arcv_march_variants += rv64i
+arcv_march_variants += rv64i_zicsr
 arcv_march_variants += rv64imac
 arcv_march_variants += rv64imac_zicsr
 arcv_march_variants += rv64imafdc
 
 # RMX-100 mini
-arcv_march_variants += rv32e
-arcv_march_variants += rv32e_zicsr
-arcv_march_variants += rv32em_zce_zba_zbb_zbs_zfinx_zdinx_zicsr
-arcv_march_variants += rv32ema_zce_zba_zbb_zbs_zfinx_zdinx_zicsr
+arcv_march_variants += rv32emac_zcb_zcmp_zcmt_zba_zbb_zbs_zfinx_zdinx_zicsr
 
 # RMX-100/500
-arcv_march_variants += rv32i_zce_zba_zbb_zbs_zicsr
-arcv_march_variants += rv32im_zce_zba_zbb_zbs_zicsr
-arcv_march_variants += rv32ima_zce_zba_zbb_zbs_zicsr
-arcv_march_variants += rv32ima_zce_zba_zbb_zbs_zfinx_zicsr
-arcv_march_variants += rv32ima_zce_zba_zbb_zbs_zfinx_zdinx_zicsr
+arcv_march_variants += rv32ic_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr
+arcv_march_variants += rv32im_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr
+arcv_march_variants += rv32imc_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr
+arcv_march_variants += rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr
+arcv_march_variants += rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zfinx_zicsr
+arcv_march_variants += rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zfinx_zdinx_zicsr
 
 # RHX-100
 arcv_march_variants += rv32imac_zcb_zcmp_zba_zbb_zbs_zicsr
@@ -55,45 +63,53 @@ MULTILIB_DIRNAMES   +=       rmx100                     rmx500                  
 MULTILIB_OPTIONS    += mcmodel=medany
 MULTILIB_DIRNAMES   +=         medany
 
-# Fallaback configurations
+# Fallback configurations for general targets
+MULTILIB_REQUIRED   += march=rv32i/mabi=ilp32
+
+# Fallback configurations for RMX-100 mini
+MULTILIB_REQUIRED   += march=rv32e/mabi=ilp32e/mtune=arc-v-rmx-100-series
+
+# Fallback configurations for RMX-100
 MULTILIB_REQUIRED   += march=rv32i/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32i_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32im/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32im_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32imc/mabi=ilp32/mtune=arc-v-rmx-100-series
 MULTILIB_REQUIRED   += march=rv32imc_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32imac/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32iac_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
 MULTILIB_REQUIRED   += march=rv32imac_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32imc/mabi=ilp32/mtune=arc-v-rmx-500-series
+
+# Fallback configurations for RMX-500
+MULTILIB_REQUIRED   += march=rv32i/mabi=ilp32/mtune=arc-v-rmx-500-series
 MULTILIB_REQUIRED   += march=rv32imc_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
-MULTILIB_REQUIRED   += march=rv32imac/mabi=ilp32/mtune=arc-v-rmx-500-series
+MULTILIB_REQUIRED   += march=rv32iac_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
 MULTILIB_REQUIRED   += march=rv32imac_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
+
+# Fallback configurations for RHX-100
+MULTILIB_REQUIRED   += march=rv32i/mabi=ilp32/mtune=arc-v-rhx-100-series
+MULTILIB_REQUIRED   += march=rv32imac_zicsr/mabi=ilp32/mtune=arc-v-rhx-100-series
 MULTILIB_REQUIRED   += march=rv32imafc/mabi=ilp32f/mtune=arc-v-rhx-100-series
 MULTILIB_REQUIRED   += march=rv32imafdc/mabi=ilp32d/mtune=arc-v-rhx-100-series
-MULTILIB_REQUIRED   += march=rv64imac_zicsr/mabi=lp64
-MULTILIB_REQUIRED   += march=rv64imac_zicsr/mabi=lp64/mcmodel=medany
-MULTILIB_REQUIRED   += march=rv64imafdc/mabi=lp64d
-MULTILIB_REQUIRED   += march=rv64imafdc/mabi=lp64d/mcmodel=medany
+
+# Fallback configurations for RPX-100
+MULTILIB_REQUIRED   += march=rv64i/mabi=lp64/mtune=arc-v-rmx-100-series/mcmodel=medany
+MULTILIB_REQUIRED   += march=rv64imac_zicsr/mabi=lp64/mtune=arc-v-rmx-100-series/mcmodel=medany
+MULTILIB_REQUIRED   += march=rv64imafdc/mabi=lp64d/mtune=arc-v-rmx-100-series/mcmodel=medany
 
 # RMX-100 mini
-MULTILIB_REQUIRED   += march=rv32e/mabi=ilp32e/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32e_zicsr/mabi=ilp32e/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32em_zce_zba_zbb_zbs_zfinx_zdinx_zicsr/mabi=ilp32e/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32ema_zce_zba_zbb_zbs_zfinx_zdinx_zicsr/mabi=ilp32e/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32emac_zcb_zcmp_zcmt_zba_zbb_zbs_zfinx_zdinx_zicsr/mabi=ilp32e/mtune=arc-v-rmx-100-series
 
 # RMX-100
-MULTILIB_REQUIRED   += march=rv32i_zce_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32im_zce_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32ima_zce_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32ima_zce_zba_zbb_zbs_zfinx_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32ima_zce_zba_zbb_zbs_zfinx_zdinx_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32ic_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32im_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32imc_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zfinx_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zfinx_zdinx_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
 
 # RMX-500
-MULTILIB_REQUIRED   += march=rv32i_zce_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
-MULTILIB_REQUIRED   += march=rv32im_zce_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
-MULTILIB_REQUIRED   += march=rv32ima_zce_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
-MULTILIB_REQUIRED   += march=rv32ima_zce_zba_zbb_zbs_zfinx_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
-MULTILIB_REQUIRED   += march=rv32ima_zce_zba_zbb_zbs_zfinx_zdinx_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
+MULTILIB_REQUIRED   += march=rv32ic_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
+MULTILIB_REQUIRED   += march=rv32im_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
+MULTILIB_REQUIRED   += march=rv32imc_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
+MULTILIB_REQUIRED   += march=rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
+MULTILIB_REQUIRED   += march=rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zfinx_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
+MULTILIB_REQUIRED   += march=rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zfinx_zdinx_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
 
 # RHX-100
 MULTILIB_REQUIRED   += march=rv32imac_zcb_zcmp_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rhx-100-series
@@ -101,7 +117,5 @@ MULTILIB_REQUIRED   += march=rv32imafc_zcb_zcmp_zba_zbb_zbs_zicsr/mabi=ilp32f/mt
 MULTILIB_REQUIRED   += march=rv32imafd_zca_zcb_zcmp_zba_zbb_zbs_zicsr/mabi=ilp32d/mtune=arc-v-rhx-100-series
 
 # RPX-100
-MULTILIB_REQUIRED   += march=rv64imac_zcb_zba_zbb_zbs_zicsr/mabi=lp64
-MULTILIB_REQUIRED   += march=rv64imac_zcb_zba_zbb_zbs_zicsr/mabi=lp64/mcmodel=medany
-MULTILIB_REQUIRED   += march=rv64imafdc_zcb_zba_zbb_zbs_zicsr/mabi=lp64d
-MULTILIB_REQUIRED   += march=rv64imafdc_zcb_zba_zbb_zbs_zicsr/mabi=lp64d/mcmodel=medany
+MULTILIB_REQUIRED   += march=rv64imac_zcb_zba_zbb_zbs_zicsr/mabi=lp64/mtune=arc-v-rmx-100-series/mcmodel=medany
+MULTILIB_REQUIRED   += march=rv64imafdc_zcb_zba_zbb_zbs_zicsr/mabi=lp64d/mtune=arc-v-rmx-100-series/mcmodel=medany


### PR DESCRIPTION
Replace zce by c_zcb_zcmp_zcmt for better compatibility with MetaWare tools. It's necessary because there is a bug in GCC that prevents matching -march strings where one of them contains "c" extension and another one doesn't.

Remove unnecessary configurations to decrease build time including medlow variants for RV64 targets - they are reasonable only with medany model.

Simplify fallback configurations to make them more general for covering all possible configurations.