### PR TITLE
arcv: Remove mtune=arc-v-rmx-100-series from t-arcv config list

### DIFF
--- a/gcc/config/riscv/t-arcv
+++ b/gcc/config/riscv/t-arcv
@@ -58,24 +58,21 @@ MULTILIB_DIRNAMES   += $(arcv_march_variants)
 MULTILIB_OPTIONS    += mabi=ilp32e/mabi=ilp32/mabi=ilp32f/mabi=ilp32d/mabi=lp64/mabi=lp64d
 MULTILIB_DIRNAMES   +=      ilp32e      ilp32      ilp32f      ilp32d      lp64      lp64d
 
-MULTILIB_OPTIONS    += mtune=arc-v-rmx-100-series/mtune=arc-v-rmx-500-series/mtune=arc-v-rhx-100-series
-MULTILIB_DIRNAMES   +=       rmx100                     rmx500                     rhx100
+MULTILIB_OPTIONS    += mtune=arc-v-rmx-500-series/mtune=arc-v-rhx-100-series
+MULTILIB_DIRNAMES   +=       rmx500                     rhx100
 
 MULTILIB_OPTIONS    += mcmodel=medany
 MULTILIB_DIRNAMES   +=         medany
 
-# Fallback configurations for general targets
-MULTILIB_REQUIRED   += march=rv32i/mabi=ilp32
-
 # Fallback configurations for RMX-100 mini
-MULTILIB_REQUIRED   += march=rv32e/mabi=ilp32e/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32e/mabi=ilp32e
 
 # Fallback configurations for RMX-100
-MULTILIB_REQUIRED   += march=rv32i/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32ia/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32imc_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32iac_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32imac_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32i/mabi=ilp32
+MULTILIB_REQUIRED   += march=rv32ia/mabi=ilp32
+MULTILIB_REQUIRED   += march=rv32imc_zicsr/mabi=ilp32
+MULTILIB_REQUIRED   += march=rv32iac_zicsr/mabi=ilp32
+MULTILIB_REQUIRED   += march=rv32imac_zicsr/mabi=ilp32
 
 # Fallback configurations for RMX-500
 MULTILIB_REQUIRED   += march=rv32i/mabi=ilp32/mtune=arc-v-rmx-500-series
@@ -92,21 +89,21 @@ MULTILIB_REQUIRED   += march=rv32imafc/mabi=ilp32f/mtune=arc-v-rhx-100-series
 MULTILIB_REQUIRED   += march=rv32imafdc/mabi=ilp32d/mtune=arc-v-rhx-100-series
 
 # Fallback configurations for RPX-100
-MULTILIB_REQUIRED   += march=rv64i/mabi=lp64/mtune=arc-v-rmx-100-series/mcmodel=medany
-MULTILIB_REQUIRED   += march=rv64ia/mabi=lp64/mtune=arc-v-rmx-100-series/mcmodel=medany
-MULTILIB_REQUIRED   += march=rv64imac_zicsr/mabi=lp64/mtune=arc-v-rmx-100-series/mcmodel=medany
-MULTILIB_REQUIRED   += march=rv64imafdc/mabi=lp64d/mtune=arc-v-rmx-100-series/mcmodel=medany
+MULTILIB_REQUIRED   += march=rv64i/mabi=lp64/mcmodel=medany
+MULTILIB_REQUIRED   += march=rv64ia/mabi=lp64/mcmodel=medany
+MULTILIB_REQUIRED   += march=rv64imac_zicsr/mabi=lp64/mcmodel=medany
+MULTILIB_REQUIRED   += march=rv64imafdc/mabi=lp64d/mcmodel=medany
 
 # RMX-100 mini
-MULTILIB_REQUIRED   += march=rv32emac_zcb_zcmp_zcmt_zba_zbb_zbs_zfinx_zdinx_zicsr/mabi=ilp32e/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32emac_zcb_zcmp_zcmt_zba_zbb_zbs_zfinx_zdinx_zicsr/mabi=ilp32e
 
 # RMX-100
-MULTILIB_REQUIRED   += march=rv32ic_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32im_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32imc_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zfinx_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zfinx_zdinx_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32ic_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32
+MULTILIB_REQUIRED   += march=rv32im_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32
+MULTILIB_REQUIRED   += march=rv32imc_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32
+MULTILIB_REQUIRED   += march=rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32
+MULTILIB_REQUIRED   += march=rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zfinx_zicsr/mabi=ilp32
+MULTILIB_REQUIRED   += march=rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zfinx_zdinx_zicsr/mabi=ilp32
 
 # RMX-500
 MULTILIB_REQUIRED   += march=rv32ic_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
@@ -122,5 +119,5 @@ MULTILIB_REQUIRED   += march=rv32imafc_zcb_zcmp_zba_zbb_zbs_zicsr/mabi=ilp32f/mt
 MULTILIB_REQUIRED   += march=rv32imafd_zca_zcb_zcmp_zba_zbb_zbs_zicsr/mabi=ilp32d/mtune=arc-v-rhx-100-series
 
 # RPX-100
-MULTILIB_REQUIRED   += march=rv64imac_zcb_zba_zbb_zbs_zicsr/mabi=lp64/mtune=arc-v-rmx-100-series/mcmodel=medany
-MULTILIB_REQUIRED   += march=rv64imafdc_zcb_zba_zbb_zbs_zicsr/mabi=lp64d/mtune=arc-v-rmx-100-series/mcmodel=medany
+MULTILIB_REQUIRED   += march=rv64imac_zcb_zba_zbb_zbs_zicsr/mabi=lp64/mcmodel=medany
+MULTILIB_REQUIRED   += march=rv64imafdc_zcb_zba_zbb_zbs_zicsr/mabi=lp64d/mcmodel=medany


### PR DESCRIPTION
If GCC is built with --with-mtune=arc-v-rmx-100-series and mtune=arc-v-rmx-100-series is mentioned in MULTILIB_OPTIONS list of multilib options, then GCC cannot link an application properly in these cases:

1. When GCC is used without any multilib options with default options only.
2. When a multilib configuration does not involve mtune, e.g. march=rv64imafdc/mabi=lp64d/mcmodel=medany.

In both cases -mtune=arc-v-rmx-100-series is passed explicitly, but the corresponding configuration cannot be chosen since mtune=arc-v-rmx-100-series is not mentioned in t-arcv for them.

Since arc-v-rmx-100-series is a default -mtune value for ARC-V, then mtune=arc-v-rmx-100-series maybe omitted in t-arc and assumed to be a default -mtune value for all configurations without mtune=... field.

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.

This PR fixes https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/issues/656.