### PR TITLE
arcv: introduce --param=arcv-ld-cycles

### DIFF
--- a/gcc/config/riscv/arcv-rmx100.md
+++ b/gcc/config/riscv/arcv-rmx100.md
@@ -54,7 +54,12 @@
 
 (define_insn_reservation "arcv_rmx100_load_insn" 3
   (and (eq_attr "tune" "arcv_rmx100")
-       (eq_attr "type" "load,fpload"))
+       (eq_attr "type" "load"))
+  "arcv_rmx100_DMP,nothing*2")
+
+(define_insn_reservation "arcv_rmx100_fpload_insn" 3
+  (and (eq_attr "tune" "arcv_rmx100")
+       (eq_attr "type" "fpload"))
   "arcv_rmx100_DMP,nothing*2")
 
 (define_insn_reservation "arcv_rmx100_store_insn" 1
@@ -109,3 +114,6 @@
 
 (define_bypass 9 "arcv_rmx100_div_insn" "arcv_rmx100_*" "arcv_mpy_1c_bypass_p")
 (define_bypass 9 "arcv_rmx100_div_insn" "arcv_rmx100_*" "arcv_mpy_2c_bypass_p")
+
+(define_bypass 1 "arcv_rmx100_load_insn" "arcv_rmx100_*" "arcv_ld_1c_bypass_p")
+(define_bypass 2 "arcv_rmx100_load_insn" "arcv_rmx100_*" "arcv_ld_2c_bypass_p")

--- a/gcc/config/riscv/riscv-protos.h
+++ b/gcc/config/riscv/riscv-protos.h
@@ -156,6 +156,8 @@ extern bool riscv_store_data_bypass_p (rtx_insn *, rtx_insn *);
 extern bool arcv_mpy_1c_bypass_p (rtx_insn *, rtx_insn *);
 extern bool arcv_mpy_2c_bypass_p (rtx_insn *, rtx_insn *);
 extern bool arcv_mpy_10c_bypass_p (rtx_insn *, rtx_insn *);
+extern bool arcv_ld_1c_bypass_p (rtx_insn *, rtx_insn *);
+extern bool arcv_ld_2c_bypass_p (rtx_insn *, rtx_insn *);
 extern rtx riscv_gen_gpr_save_insn (struct riscv_frame_info *);
 extern bool riscv_gpr_save_operation_p (rtx);
 extern void riscv_reinit (void);

--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -8461,6 +8461,20 @@ arcv_mpy_10c_bypass_p (rtx_insn *out_insn ATTRIBUTE_UNUSED,
   return arcv_mpy_option == ARCV_MPY_OPTION_10C;
 }
 
+bool
+arcv_ld_1c_bypass_p (rtx_insn *out_insn ATTRIBUTE_UNUSED,
+		      rtx_insn *in_insn ATTRIBUTE_UNUSED)
+{
+  return arcv_ld_cycles == 1;
+}
+
+bool
+arcv_ld_2c_bypass_p (rtx_insn *out_insn ATTRIBUTE_UNUSED,
+		      rtx_insn *in_insn ATTRIBUTE_UNUSED)
+{
+  return arcv_ld_cycles == 2;
+}
+
 /* Implement TARGET_SECONDARY_MEMORY_NEEDED.
 
    When floating-point registers are wider than integer ones, moves between

--- a/gcc/config/riscv/riscv.opt
+++ b/gcc/config/riscv/riscv.opt
@@ -638,6 +638,10 @@ Enum(arcv_mpy_option) String(10c) Value(ARCV_MPY_OPTION_10C)
 Target RejectNegative Joined Enum(arcv_mpy_option) Var(arcv_mpy_option) Init(ARCV_MPY_OPTION_2C)
 The type of MPY unit used by the RMX-100 core (to be used in combination with -mtune=rmx100) (default: 2c).
 
+-param=arcv-ld-cycles=
+Target Joined UInteger Var(arcv_ld_cycles) Init(3) IntegerRange(1, 3) Param
+A number of cycles that a word-size integer load operation takes (1-3) (default: 3).
+
 mlong-double-64
 Target RejectNegative Negative(mlong-double-128) Mask(LONG_DOUBLE_64)
 Use 64-bit long double.


### PR DESCRIPTION
Since it is critical to scheduling for the RMX-100 core, allow setting load latency via a newly create target-specific arcv-ld-cycles parameter. The worst case latency is 3, and so is the parameter's default value.

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
