### PR TITLE
arcv: add a multilib config without Zc* for RMX-100

### DIFF
--- a/gcc/config/riscv/t-arcv
+++ b/gcc/config/riscv/t-arcv
@@ -38,6 +38,7 @@ arcv_march_variants += rv32emac_zcb_zcmp_zcmt_zba_zbb_zbs_zfinx_zdinx_zicsr
 # RMX-100/500
 arcv_march_variants += rv32ic_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr
 arcv_march_variants += rv32im_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr
+arcv_march_variants += rv32im_zba_zbb_zbs_zicsr
 arcv_march_variants += rv32imc_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr
 arcv_march_variants += rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr
 arcv_march_variants += rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zfinx_zicsr
@@ -101,6 +102,7 @@ MULTILIB_REQUIRED   += march=rv64imafdc/mabi=lp64d/mtune=arc-v-rmx-100-series/mc
 MULTILIB_REQUIRED   += march=rv32emac_zcb_zcmp_zcmt_zba_zbb_zbs_zfinx_zdinx_zicsr/mabi=ilp32e/mtune=arc-v-rmx-100-series
 
 # RMX-100
+MULTILIB_REQUIRED   += march=rv32im_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
 MULTILIB_REQUIRED   += march=rv32ic_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
 MULTILIB_REQUIRED   += march=rv32im_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
 MULTILIB_REQUIRED   += march=rv32imc_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series


### PR DESCRIPTION
Since compressed instructions are no longer efficient on the RMX-100, add a rv32im_zb*_zicsr fallback configuration for that core.

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
