### PR TITLE
arcv: simplify multilib configurations and cover more cases

### DIFF
--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -4910,6 +4910,18 @@ case "${target}" in
 				exit 1
 			esac
 		fi
+
+		# Handle --with-tune.
+		if test "x${with_tune}" = xdefault; then
+			case ${target} in
+			*-snps-*)
+				# Use a default mtune for Synopsys ARC-V.
+				with_tune=arc-v-rmx-100-series
+				;;
+			*)
+				;;
+			esac
+		fi
 		;;
 
 	mips*-*-*)

--- a/gcc/config/riscv/t-arcv
+++ b/gcc/config/riscv/t-arcv
@@ -59,41 +59,41 @@ MULTILIB_DIRNAMES   += $(arcv_march_variants)
 MULTILIB_OPTIONS    += mabi=ilp32e/mabi=ilp32/mabi=ilp32f/mabi=ilp32d/mabi=lp64/mabi=lp64d
 MULTILIB_DIRNAMES   +=      ilp32e      ilp32      ilp32f      ilp32d      lp64      lp64d
 
-MULTILIB_OPTIONS    += mtune=arc-v-rmx-100-series/mtune=arc-v-rmx-500-series/mtune=arc-v-rhx-100-series/mtune=arc-v-rpx-100-series
-MULTILIB_DIRNAMES   +=       rmx100                     rmx500                     rhx100                     rpx100
+MULTILIB_OPTIONS    += mtune=arc-v-rmx-500-series/mtune=arc-v-rhx-100-series/mtune=arc-v-rpx-100-series
+MULTILIB_DIRNAMES   +=       rmx500                     rhx100                     rpx100
 
 MULTILIB_OPTIONS    += mcmodel=medany
 MULTILIB_DIRNAMES   +=         medany
 
 # Configurations for RMX-100 mini
-MULTILIB_REQUIRED   += march=rv32e/mabi=ilp32e/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32em/mabi=ilp32e/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32ea/mabi=ilp32e/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32ema/mabi=ilp32e/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32emac_zcb_zba_zbb_zbs_zfinx_zdinx/mabi=ilp32e/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32e/mabi=ilp32e
+MULTILIB_REQUIRED   += march=rv32em/mabi=ilp32e
+MULTILIB_REQUIRED   += march=rv32ea/mabi=ilp32e
+MULTILIB_REQUIRED   += march=rv32ema/mabi=ilp32e
+MULTILIB_REQUIRED   += march=rv32emac_zcb_zba_zbb_zbs_zfinx_zdinx/mabi=ilp32e
 
 # Configurations for RMX-100 - general
-MULTILIB_REQUIRED   += march=rv32i/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32ic/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32im/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32ia/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32ima/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32iac/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32imac/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32i/mabi=ilp32
+MULTILIB_REQUIRED   += march=rv32ic/mabi=ilp32
+MULTILIB_REQUIRED   += march=rv32im/mabi=ilp32
+MULTILIB_REQUIRED   += march=rv32ia/mabi=ilp32
+MULTILIB_REQUIRED   += march=rv32ima/mabi=ilp32
+MULTILIB_REQUIRED   += march=rv32iac/mabi=ilp32
+MULTILIB_REQUIRED   += march=rv32imac/mabi=ilp32
 
 # Configurations for RMX-100 - optimized
-MULTILIB_REQUIRED   += march=rv32ic_zcb_zba_zbb_zbs/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32imc_zcb_zba_zbb_zbs/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32imac_zcb_zba_zbb_zbs/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32imac_zcb_zba_zbb_zbs_zfinx/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32imac_zcb_zba_zbb_zbs_zfinx_zdinx/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32ic_zcb_zba_zbb_zbs/mabi=ilp32
+MULTILIB_REQUIRED   += march=rv32imc_zcb_zba_zbb_zbs/mabi=ilp32
+MULTILIB_REQUIRED   += march=rv32imac_zcb_zba_zbb_zbs/mabi=ilp32
+MULTILIB_REQUIRED   += march=rv32imac_zcb_zba_zbb_zbs_zfinx/mabi=ilp32
+MULTILIB_REQUIRED   += march=rv32imac_zcb_zba_zbb_zbs_zfinx_zdinx/mabi=ilp32
 
 # Configurations for RMX-100 - optimized (without C and Zc*)
-MULTILIB_REQUIRED   += march=rv32i_zba_zbb_zbs/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32im_zba_zbb_zbs/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32ima_zba_zbb_zbs/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32ima_zba_zbb_zbs_zfinx/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32ima_zba_zbb_zbs_zfinx_zdinx/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32i_zba_zbb_zbs/mabi=ilp32
+MULTILIB_REQUIRED   += march=rv32im_zba_zbb_zbs/mabi=ilp32
+MULTILIB_REQUIRED   += march=rv32ima_zba_zbb_zbs/mabi=ilp32
+MULTILIB_REQUIRED   += march=rv32ima_zba_zbb_zbs_zfinx/mabi=ilp32
+MULTILIB_REQUIRED   += march=rv32ima_zba_zbb_zbs_zfinx_zdinx/mabi=ilp32
 
 # Configurations for RMX-500 - general
 MULTILIB_REQUIRED   += march=rv32i/mabi=ilp32/mtune=arc-v-rmx-500-series

--- a/gcc/config/riscv/t-arcv
+++ b/gcc/config/riscv/t-arcv
@@ -8,7 +8,9 @@ MULTILIB_REUSE =
 
 # -march multilib options for RMX-100 mini
 arcv_march_variants  = rv32e
+arcv_march_variants += rv32em
 arcv_march_variants += rv32ea
+arcv_march_variants += rv32ema
 arcv_march_variants += rv32emac_zcb_zba_zbb_zbs_zfinx_zdinx
 
 # -march multilib options for RMX-100 and RMX-500
@@ -65,7 +67,9 @@ MULTILIB_DIRNAMES   +=         medany
 
 # Configurations for RMX-100 mini
 MULTILIB_REQUIRED   += march=rv32e/mabi=ilp32e/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32em/mabi=ilp32e/mtune=arc-v-rmx-100-series
 MULTILIB_REQUIRED   += march=rv32ea/mabi=ilp32e/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32ema/mabi=ilp32e/mtune=arc-v-rmx-100-series
 MULTILIB_REQUIRED   += march=rv32emac_zcb_zba_zbb_zbs_zfinx_zdinx/mabi=ilp32e/mtune=arc-v-rmx-100-series
 
 # Configurations for RMX-100 - general

--- a/gcc/config/riscv/t-arcv
+++ b/gcc/config/riscv/t-arcv
@@ -6,52 +6,50 @@ MULTILIB_DIRNAMES =
 MULTILIB_REQUIRED =
 MULTILIB_REUSE =
 
-# Fallback configurations
+# -march multilib options for RMX-100 mini
 arcv_march_variants  = rv32e
-arcv_march_variants += rv32e_zicsr
+arcv_march_variants += rv32ea
+arcv_march_variants += rv32emac_zcb_zba_zbb_zbs_zfinx_zdinx
+
+# -march multilib options for RMX-100 and RMX-500
 arcv_march_variants += rv32i
-arcv_march_variants += rv32i_zicsr
 arcv_march_variants += rv32ic
-arcv_march_variants += rv32ic_zicsr
-arcv_march_variants += rv32ia
-arcv_march_variants += rv32ia_zicsr
 arcv_march_variants += rv32im
-arcv_march_variants += rv32im_zicsr
-arcv_march_variants += rv32iac
-arcv_march_variants += rv32iac_zicsr
 arcv_march_variants += rv32imc
-arcv_march_variants += rv32imc_zicsr
+arcv_march_variants += rv32ia
+arcv_march_variants += rv32ima
+arcv_march_variants += rv32iac
 arcv_march_variants += rv32imac
-arcv_march_variants += rv32imac_zicsr
+arcv_march_variants += rv32ic_zcb_zba_zbb_zbs
+arcv_march_variants += rv32imc_zcb_zba_zbb_zbs
+arcv_march_variants += rv32imac_zcb_zba_zbb_zbs
+arcv_march_variants += rv32imac_zcb_zba_zbb_zbs_zfinx
+arcv_march_variants += rv32imac_zcb_zba_zbb_zbs_zfinx_zdinx
+arcv_march_variants += rv32i_zba_zbb_zbs
+arcv_march_variants += rv32im_zba_zbb_zbs
+arcv_march_variants += rv32ima_zba_zbb_zbs
+arcv_march_variants += rv32ima_zba_zbb_zbs_zfinx
+arcv_march_variants += rv32ima_zba_zbb_zbs_zfinx_zdinx
+
+# -march multilib options for RHX-100 (basic combinations are covered
+# in RMX-100  and RMX-500 list)
 arcv_march_variants += rv32imafc
-arcv_march_variants += rv32imafdc
+arcv_march_variants += rv32imafd_zca
+arcv_march_variants += rv32imafc_zcb_zba_zbb_zbs
+arcv_march_variants += rv32imafd_zca_zcb_zba_zbb_zbs
+
+# -march multilib options for RPX-100
 arcv_march_variants += rv64i
-arcv_march_variants += rv64i_zicsr
+arcv_march_variants += rv64ic
+arcv_march_variants += rv64im
+arcv_march_variants += rv64imc
 arcv_march_variants += rv64ia
+arcv_march_variants += rv64ima
+arcv_march_variants += rv64iac
 arcv_march_variants += rv64imac
-arcv_march_variants += rv64imac_zicsr
 arcv_march_variants += rv64imafdc
-
-# RMX-100 mini
-arcv_march_variants += rv32emac_zcb_zcmp_zcmt_zba_zbb_zbs_zfinx_zdinx_zicsr
-
-# RMX-100/500
-arcv_march_variants += rv32ic_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr
-arcv_march_variants += rv32im_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr
-arcv_march_variants += rv32im_zba_zbb_zbs_zicsr
-arcv_march_variants += rv32imc_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr
-arcv_march_variants += rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr
-arcv_march_variants += rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zfinx_zicsr
-arcv_march_variants += rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zfinx_zdinx_zicsr
-
-# RHX-100
-arcv_march_variants += rv32imac_zcb_zcmp_zba_zbb_zbs_zicsr
-arcv_march_variants += rv32imafc_zcb_zcmp_zba_zbb_zbs_zicsr
-arcv_march_variants += rv32imafd_zca_zcb_zcmp_zba_zbb_zbs_zicsr
-
-# RPX-100
-arcv_march_variants += rv64imac_zcb_zba_zbb_zbs_zicsr
-arcv_march_variants += rv64imafdc_zcb_zba_zbb_zbs_zicsr
+arcv_march_variants += rv64imac_zcb_zba_zbb_zbs
+arcv_march_variants += rv64imafdc_zcb_zba_zbb_zbs
 
 MULTILIB_OPTIONS    += $(subst $(space),/,$(patsubst %,march=%,$(arcv_march_variants)))
 MULTILIB_DIRNAMES   += $(arcv_march_variants)
@@ -65,64 +63,77 @@ MULTILIB_DIRNAMES   +=       rmx100                     rmx500                  
 MULTILIB_OPTIONS    += mcmodel=medany
 MULTILIB_DIRNAMES   +=         medany
 
-# Fallback configurations for general targets
-MULTILIB_REQUIRED   += march=rv32i/mabi=ilp32
-
-# Fallback configurations for RMX-100 mini
+# Configurations for RMX-100 mini
 MULTILIB_REQUIRED   += march=rv32e/mabi=ilp32e/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32ea/mabi=ilp32e/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32emac_zcb_zba_zbb_zbs_zfinx_zdinx/mabi=ilp32e/mtune=arc-v-rmx-100-series
 
-# Fallback configurations for RMX-100
+# Configurations for RMX-100 - general
 MULTILIB_REQUIRED   += march=rv32i/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32ic/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32im/mabi=ilp32/mtune=arc-v-rmx-100-series
 MULTILIB_REQUIRED   += march=rv32ia/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32imc_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32iac_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32imac_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32ima/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32iac/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32imac/mabi=ilp32/mtune=arc-v-rmx-100-series
 
-# Fallback configurations for RMX-500
+# Configurations for RMX-100 - optimized
+MULTILIB_REQUIRED   += march=rv32ic_zcb_zba_zbb_zbs/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32imc_zcb_zba_zbb_zbs/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32imac_zcb_zba_zbb_zbs/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32imac_zcb_zba_zbb_zbs_zfinx/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32imac_zcb_zba_zbb_zbs_zfinx_zdinx/mabi=ilp32/mtune=arc-v-rmx-100-series
+
+# Configurations for RMX-100 - optimized (without C and Zc*)
+MULTILIB_REQUIRED   += march=rv32i_zba_zbb_zbs/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32im_zba_zbb_zbs/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32ima_zba_zbb_zbs/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32ima_zba_zbb_zbs_zfinx/mabi=ilp32/mtune=arc-v-rmx-100-series
+MULTILIB_REQUIRED   += march=rv32ima_zba_zbb_zbs_zfinx_zdinx/mabi=ilp32/mtune=arc-v-rmx-100-series
+
+# Configurations for RMX-500 - general
 MULTILIB_REQUIRED   += march=rv32i/mabi=ilp32/mtune=arc-v-rmx-500-series
+MULTILIB_REQUIRED   += march=rv32ic/mabi=ilp32/mtune=arc-v-rmx-500-series
+MULTILIB_REQUIRED   += march=rv32im/mabi=ilp32/mtune=arc-v-rmx-500-series
 MULTILIB_REQUIRED   += march=rv32ia/mabi=ilp32/mtune=arc-v-rmx-500-series
-MULTILIB_REQUIRED   += march=rv32imc_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
-MULTILIB_REQUIRED   += march=rv32iac_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
-MULTILIB_REQUIRED   += march=rv32imac_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
+MULTILIB_REQUIRED   += march=rv32ima/mabi=ilp32/mtune=arc-v-rmx-500-series
+MULTILIB_REQUIRED   += march=rv32iac/mabi=ilp32/mtune=arc-v-rmx-500-series
+MULTILIB_REQUIRED   += march=rv32imac/mabi=ilp32/mtune=arc-v-rmx-500-series
 
-# Fallback configurations for RHX-100
+# Configurations for RMX-500 - optimized
+MULTILIB_REQUIRED   += march=rv32ic_zcb_zba_zbb_zbs/mabi=ilp32/mtune=arc-v-rmx-500-series
+MULTILIB_REQUIRED   += march=rv32imc_zcb_zba_zbb_zbs/mabi=ilp32/mtune=arc-v-rmx-500-series
+MULTILIB_REQUIRED   += march=rv32imac_zcb_zba_zbb_zbs/mabi=ilp32/mtune=arc-v-rmx-500-series
+MULTILIB_REQUIRED   += march=rv32imac_zcb_zba_zbb_zbs_zfinx/mabi=ilp32/mtune=arc-v-rmx-500-series
+MULTILIB_REQUIRED   += march=rv32imac_zcb_zba_zbb_zbs_zfinx_zdinx/mabi=ilp32/mtune=arc-v-rmx-500-series
+
+# Configurations for RHX-100 - general
 MULTILIB_REQUIRED   += march=rv32i/mabi=ilp32/mtune=arc-v-rhx-100-series
+MULTILIB_REQUIRED   += march=rv32ic/mabi=ilp32/mtune=arc-v-rhx-100-series
+MULTILIB_REQUIRED   += march=rv32im/mabi=ilp32/mtune=arc-v-rhx-100-series
 MULTILIB_REQUIRED   += march=rv32ia/mabi=ilp32/mtune=arc-v-rhx-100-series
-MULTILIB_REQUIRED   += march=rv32imac_zicsr/mabi=ilp32/mtune=arc-v-rhx-100-series
+MULTILIB_REQUIRED   += march=rv32ima/mabi=ilp32/mtune=arc-v-rhx-100-series
+MULTILIB_REQUIRED   += march=rv32iac/mabi=ilp32/mtune=arc-v-rhx-100-series
+MULTILIB_REQUIRED   += march=rv32imac/mabi=ilp32/mtune=arc-v-rhx-100-series
 MULTILIB_REQUIRED   += march=rv32imafc/mabi=ilp32f/mtune=arc-v-rhx-100-series
-MULTILIB_REQUIRED   += march=rv32imafdc/mabi=ilp32d/mtune=arc-v-rhx-100-series
+MULTILIB_REQUIRED   += march=rv32imafd_zca/mabi=ilp32d/mtune=arc-v-rhx-100-series
 
-# Fallback configurations for RPX-100
+# Configurations for RHX-100 - optimized
+MULTILIB_REQUIRED   += march=rv32imac_zcb_zba_zbb_zbs/mabi=ilp32/mtune=arc-v-rhx-100-series
+MULTILIB_REQUIRED   += march=rv32imafc_zcb_zba_zbb_zbs/mabi=ilp32f/mtune=arc-v-rhx-100-series
+MULTILIB_REQUIRED   += march=rv32imafd_zca_zcb_zba_zbb_zbs/mabi=ilp32d/mtune=arc-v-rhx-100-series
+
+# Configurations for RPX-100 - general
 MULTILIB_REQUIRED   += march=rv64i/mabi=lp64/mtune=arc-v-rpx-100-series/mcmodel=medany
+MULTILIB_REQUIRED   += march=rv64ic/mabi=lp64/mtune=arc-v-rpx-100-series/mcmodel=medany
+MULTILIB_REQUIRED   += march=rv64im/mabi=lp64/mtune=arc-v-rpx-100-series/mcmodel=medany
+MULTILIB_REQUIRED   += march=rv64imc/mabi=lp64/mtune=arc-v-rpx-100-series/mcmodel=medany
 MULTILIB_REQUIRED   += march=rv64ia/mabi=lp64/mtune=arc-v-rpx-100-series/mcmodel=medany
-MULTILIB_REQUIRED   += march=rv64imac_zicsr/mabi=lp64/mtune=arc-v-rpx-100-series/mcmodel=medany
+MULTILIB_REQUIRED   += march=rv64ima/mabi=lp64/mtune=arc-v-rpx-100-series/mcmodel=medany
+MULTILIB_REQUIRED   += march=rv64iac/mabi=lp64/mtune=arc-v-rpx-100-series/mcmodel=medany
+MULTILIB_REQUIRED   += march=rv64imac/mabi=lp64/mtune=arc-v-rpx-100-series/mcmodel=medany
 MULTILIB_REQUIRED   += march=rv64imafdc/mabi=lp64d/mtune=arc-v-rpx-100-series/mcmodel=medany
 
-# RMX-100 mini
-MULTILIB_REQUIRED   += march=rv32emac_zcb_zcmp_zcmt_zba_zbb_zbs_zfinx_zdinx_zicsr/mabi=ilp32e/mtune=arc-v-rmx-100-series
-
-# RMX-100
-MULTILIB_REQUIRED   += march=rv32im_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32ic_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32im_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32imc_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zfinx_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
-MULTILIB_REQUIRED   += march=rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zfinx_zdinx_zicsr/mabi=ilp32/mtune=arc-v-rmx-100-series
-
-# RMX-500
-MULTILIB_REQUIRED   += march=rv32ic_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
-MULTILIB_REQUIRED   += march=rv32im_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
-MULTILIB_REQUIRED   += march=rv32imc_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
-MULTILIB_REQUIRED   += march=rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
-MULTILIB_REQUIRED   += march=rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zfinx_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
-MULTILIB_REQUIRED   += march=rv32imac_zcb_zcmp_zcmt_zba_zbb_zbs_zfinx_zdinx_zicsr/mabi=ilp32/mtune=arc-v-rmx-500-series
-
-# RHX-100
-MULTILIB_REQUIRED   += march=rv32imac_zcb_zcmp_zba_zbb_zbs_zicsr/mabi=ilp32/mtune=arc-v-rhx-100-series
-MULTILIB_REQUIRED   += march=rv32imafc_zcb_zcmp_zba_zbb_zbs_zicsr/mabi=ilp32f/mtune=arc-v-rhx-100-series
-MULTILIB_REQUIRED   += march=rv32imafd_zca_zcb_zcmp_zba_zbb_zbs_zicsr/mabi=ilp32d/mtune=arc-v-rhx-100-series
-
-# RPX-100
-MULTILIB_REQUIRED   += march=rv64imac_zcb_zba_zbb_zbs_zicsr/mabi=lp64/mtune=arc-v-rpx-100-series/mcmodel=medany
-MULTILIB_REQUIRED   += march=rv64imafdc_zcb_zba_zbb_zbs_zicsr/mabi=lp64d/mtune=arc-v-rpx-100-series/mcmodel=medany
+# Configurations for RPX-100 - optimized
+MULTILIB_REQUIRED   += march=rv64imac_zcb_zba_zbb_zbs/mabi=lp64/mtune=arc-v-rpx-100-series/mcmodel=medany
+MULTILIB_REQUIRED   += march=rv64imafdc_zcb_zba_zbb_zbs/mabi=lp64d/mtune=arc-v-rpx-100-series/mcmodel=medany


### PR DESCRIPTION
# List of changes

1. Remove `Zicsr` from all configurations. It's not necessary anymore since `crt0` in Newlib and Picolibc is built with `Zicsr` extension explicitly.
2. Remove `Zcmp` from all configurations. It may reduce performance significantly but the gain in library size is minimal.
3. Remove `Zcmt` from all configurations. GCC does not produce `Zcmt` code by default.
4. Add more general configurations for testing.

# Toolchain's size

When installed the toolchain occupies ~13GB. A compressed `tar.xz` archive (LZMA) occupies ~1.3GB with maximum compression rate.

# List of RMX-100 mini configurations

* All RMX-100 mini configurations use `-mtune=arc-v-rmx-100-series`.
* All RMX-100 mini configurations use `-mcmodel=medlow`.

| `march` | `mabi` | Comment |
|:--- |:--- |:--- |
| `rv32e` | `ilp32e` | General configuration |
| `rv32em` | `ilp32e` | General configuration |
| `rv32ea` | `ilp32e` | General configuration |
| `rv32ema` | `ilp32e` | General configuration |
| `rv32emac_zcb_zba_zbb_zbs_zfinx_zdinx` | `ilp32e` | Full featured RMX-100 mini |

# List of RMX-100 configurations

* All RMX-100 configurations use `-mtune=arc-v-rmx-100-series`.
* All RMX-100 configurations use `-mcmodel=medlow`.
* All RMX-100 profiles include `zcb_zba_zbb_zbs` set. All optimized configurations include them. However, using `C` extensions may lead to performance decrease for RMX-100, thus additional optimized configurations without `C` are shipped too.

| `march` | `mabi` | Comment |
|:--- |:--- |:--- |
| `rv32i` | `ilp32` | General configuration |
| `rv32ic` | `ilp32` | General configuration |
| `rv32im` | `ilp32` | General configuration |
| `rv32ia` | `ilp32` | General configuration |
| `rv32ima` | `ilp32` | General configuration |
| `rv32iac` | `ilp32` | General configuration |
| `rv32imac` | `ilp32` | General configuration |
| `rv32ic_zcb_zba_zbb_zbs` | `ilp32` | Optimized configuration |
| `rv32imc_zcb_zba_zbb_zbs` | `ilp32` | Optimized configuration |
| `rv32imac_zcb_zba_zbb_zbs` | `ilp32` | Optimized configuration |
| `rv32imac_zcb_zba_zbb_zbs_zfinx` | `ilp32` | Optimized configuration with SP FPU |
| `rv32imac_zcb_zba_zbb_zbs_zfinx_zdinx` | `ilp32` | Optimized configuration with DP FPU |
| `rv32i_zba_zbb_zbs` | `ilp32` | Optimized configuration without `C` |
| `rv32im_zba_zbb_zbs` | `ilp32` | Optimized configuration without `C` |
| `rv32ima_zba_zbb_zbs` | `ilp32` | Optimized configuration without `C` |
| `rv32ima_zba_zbb_zbs_zfinx` | `ilp32` | Optimized configuration without `C` with SP FPU|
| `rv32ima_zba_zbb_zbs_zfinx_zdinx` | `ilp32` | Optimized configuration without `C` with DP FPU |

# List of RMX-500 configurations

* All RMX-500 configurations use `-mtune=arc-v-rmx-500-series`.
* All RMX-500 configurations use `-mcmodel=medlow`.
* All RMX-500 profiles include `zcb_zba_zbb_zbs` set. All optimized configurations include them.

| `march` | `mabi` | Comment |
|:--- |:--- |:--- |
| `rv32i` | `ilp32` | General configuration |
| `rv32ic` | `ilp32` | General configuration |
| `rv32im` | `ilp32` | General configuration |
| `rv32ia` | `ilp32` | General configuration |
| `rv32ima` | `ilp32` | General configuration |
| `rv32iac` | `ilp32` | General configuration |
| `rv32imac` | `ilp32` | General configuration |
| `rv32ic_zcb_zba_zbb_zbs` | `ilp32` | Optimized configuration |
| `rv32imc_zcb_zba_zbb_zbs` | `ilp32` | Optimized configuration |
| `rv32imac_zcb_zba_zbb_zbs` | `ilp32` | Optimized configuration |
| `rv32imac_zcb_zba_zbb_zbs_zfinx` | `ilp32` | Optimized configuration with SP FPU |
| `rv32imac_zcb_zba_zbb_zbs_zfinx_zdinx` | `ilp32` | Optimized configuration with DP FPU |

# List of RHX-100 configurations

* All RHX-100 configurations use `-mtune=arc-v-rhx-100-series`.
* All RHX-100 configurations use `-mcmodel=medlow`.
* All RHX-100 profiles include `mac_zcb_zba_zbb_zbs` set. All optimized configurations include them.
* RHX-100 does not support `Zcd` and configurations with `D` extension contain `Zca` instead of `C`.

| `march` | `mabi` | Comment |
|:--- |:--- |:--- |
| `rv32i` | `ilp32` | General configuration |
| `rv32ic` | `ilp32` | General configuration |
| `rv32im` | `ilp32` | General configuration |
| `rv32ia` | `ilp32` | General configuration |
| `rv32ima` | `ilp32` | General configuration |
| `rv32iac` | `ilp32` | General configuration |
| `rv32imac` | `ilp32` | General configuration |
| `rv32imafc` | `ilp32f` | General configuration with FPU |
| `rv32imafd_zca` | `ilp32d` | General configuration with FPU |
| `rv32imac_zcb_zba_zbb_zbs` | `ilp32` | Optimized configuration |
| `rv32imafc_zcb_zba_zbb_zbs` | `ilp32f` | Optimized configuration with SP FPU |
| `rv32imafd_zca_zcb_zba_zbb_zbs` | `ilp32d` | Optimized configuration with DP FPU |

# List of RPX-100 configurations

* All RPX-100 configurations use `-mtune=arc-v-rhx-100-series`.
* All RPX-100 configurations use `-mcmodel=medany`.
* All RPX-100 profiles include `mac_zcb_zba_zbb_zbs` set. All optimized configurations include them.

| `march` | `mabi` | Comment |
|:--- |:--- |:--- |
| `rv64i` | `lp64` | General configuration |
| `rv64ic` | `lp64` | General configuration |
| `rv64im` | `lp64` | General configuration |
| `rv64imc` | `lp64` | General configuration |
| `rv64ia` | `lp64` | General configuration |
| `rv64ima` | `lp64` | General configuration |
| `rv64iac` | `lp64` | General configuration |
| `rv64imac` | `lp64` | General configuration |
| `rv64imafdc` | `lp64d` | General configuration |
| `rv64imac_zcb_zba_zbb_zbs` | `lp64` | Speed optimized configuration |
| `rv64imafdc_zcb_zba_zbb_zbs` | `lp64` | Speed optimized configuration with DP FPU |
