### PR TITLE
Apply patches to fix Zc* implication issues

### DIFF
--- a/gcc/common/config/riscv/riscv-common.cc
+++ b/gcc/common/config/riscv/riscv-common.cc
@@ -183,6 +183,37 @@ static const riscv_implied_info_t riscv_implied_info[] =
    {
      return subset_list->xlen () == 32 && subset_list->lookup ("f");
    }},
+  {"zca", "c",
+   [] (const riscv_subset_list *subset_list) -> bool
+   {
+     /* For RV32 Zca implies C for one of these combinations of
+	extensions: Zca, F_Zca_Zcf and FD_Zca_Zcf_Zcd.  */
+     if (subset_list->xlen () == 32)
+       {
+	 if (subset_list->lookup ("d"))
+	   return subset_list->lookup ("zcf") && subset_list->lookup ("zcd");
+
+	 if (subset_list->lookup ("f"))
+	   return subset_list->lookup ("zcf");
+
+	 return true;
+       }
+
+     /* For RV64 Zca implies C for one of these combinations of
+	extensions: Zca and FD_Zca_Zcd (Zcf is not available
+	for RV64).  */
+     if (subset_list->xlen () == 64)
+       {
+	 if (subset_list->lookup ("d"))
+	   return subset_list->lookup ("zcd");
+
+	 return true;
+       }
+
+     /* Do nothing for future RV128 specification. Behaviour
+	for this case is not yet well defined.  */
+     return false;
+   }},
 
   {"smaia", "ssaia"},
   {"smstateen", "ssstateen"},

--- a/gcc/common/config/riscv/riscv-common.cc
+++ b/gcc/common/config/riscv/riscv-common.cc
@@ -178,7 +178,7 @@ static const riscv_implied_info_t riscv_implied_info[] =
   {"zcmp", "zca"},
   {"zcmt", "zca"},
   {"zcmt", "zicsr"},
-  {"zcf", "f",
+  {"zce", "zcf",
    [] (const riscv_subset_list *subset_list) -> bool
    {
      return subset_list->xlen () == 32 && subset_list->lookup ("f");

--- a/gcc/testsuite/gcc.target/riscv/arch-25.c
+++ b/gcc/testsuite/gcc.target/riscv/arch-25.c
@@ -2,4 +2,4 @@
 /* { dg-options "-march=rv64i_zcf -mabi=lp64" } */
 int foo() {}
 /* { dg-error "'-march=rv64i_zcf': zcf extension supports in rv32 only" "" { target *-*-* } 0 } */
-/* { dg-error "'-march=rv64i_zca_zcf': zcf extension supports in rv32 only" "" { target *-*-* } 0 } */
+/* { dg-error "'-march=rv64ic_zca_zcf': zcf extension supports in rv32 only" "" { target *-*-* } 0 } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-c-1.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-c-1.c
@@ -1,0 +1,6 @@
+/* { dg-do compile } */
+/* { dg-options "-mriscv-attribute -march=rv32i_zca -mabi=ilp32" } */
+
+void foo(){}
+
+/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p1_c2p0_zca1p0\"" } } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-c-2.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-c-2.c
@@ -1,0 +1,6 @@
+/* { dg-do compile } */
+/* { dg-options "-mriscv-attribute -march=rv32if_zca -mabi=ilp32" } */
+
+void foo(){}
+
+/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p1_f2p2_zicsr2p0_zca1p0\"" } } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-c-3.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-c-3.c
@@ -1,0 +1,6 @@
+/* { dg-do compile } */
+/* { dg-options "-mriscv-attribute -march=rv32if_zca_zcf -mabi=ilp32" } */
+
+void foo(){}
+
+/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p1_f2p2_c2p0_zicsr2p0_zca1p0_zcf1p0\"" } } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-c-4.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-c-4.c
@@ -1,0 +1,6 @@
+/* { dg-do compile } */
+/* { dg-options "-mriscv-attribute -march=rv32ifd_zca_zcf -mabi=ilp32" } */
+
+void foo(){}
+
+/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p1_f2p2_d2p2_zicsr2p0_zca1p0_zcf1p0\"" } } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-c-5.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-c-5.c
@@ -1,0 +1,6 @@
+/* { dg-do compile } */
+/* { dg-options "-mriscv-attribute -march=rv32ifd_zca_zcf_zcd -mabi=ilp32" } */
+
+void foo(){}
+
+/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p1_f2p2_d2p2_c2p0_zicsr2p0_zca1p0_zcd1p0_zcf1p0\"" } } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-c-6.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-c-6.c
@@ -1,0 +1,6 @@
+/* { dg-do compile } */
+/* { dg-options "-mriscv-attribute -march=rv64i_zca -mabi=lp64" } */
+
+void foo(){}
+
+/* { dg-final { scan-assembler ".attribute arch, \"rv64i2p1_c2p0_zca1p0\"" } } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-c-7.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-c-7.c
@@ -1,0 +1,6 @@
+/* { dg-do compile } */
+/* { dg-options "-mriscv-attribute -march=rv64ifd_zca -mabi=lp64" } */
+
+void foo(){}
+
+/* { dg-final { scan-assembler ".attribute arch, \"rv64i2p1_f2p2_d2p2_zicsr2p0_zca1p0\"" } } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-c-8.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-c-8.c
@@ -1,0 +1,6 @@
+/* { dg-do compile } */
+/* { dg-options "-mriscv-attribute -march=rv64ifd_zca_zcd -mabi=lp64" } */
+
+void foo(){}
+
+/* { dg-final { scan-assembler ".attribute arch, \"rv64i2p1_f2p2_d2p2_c2p0_zicsr2p0_zca1p0_zcd1p0\"" } } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-zce-1.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-zce-1.c
@@ -1,0 +1,6 @@
+/* { dg-do compile } */
+/* { dg-options "-mriscv-attribute -march=rv32i_zce -mabi=ilp32" } */
+
+void foo(){}
+
+/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p1_zicsr2p0_zca1p0_zcb1p0_zce1p0_zcmp1p0_zcmt1p0\"" } } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-zce-1.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-zce-1.c
@@ -3,4 +3,4 @@
 
 void foo(){}
 
-/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p1_zicsr2p0_zca1p0_zcb1p0_zce1p0_zcmp1p0_zcmt1p0\"" } } */
+/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p1_c2p0_zicsr2p0_zca1p0_zcb1p0_zce1p0_zcmp1p0_zcmt1p0\"" } } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-zce-2.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-zce-2.c
@@ -1,0 +1,6 @@
+/* { dg-do compile } */
+/* { dg-options "-mriscv-attribute -march=rv32if_zce -mabi=ilp32" } */
+
+void foo(){}
+
+/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p1_f2p2_zicsr2p0_zca1p0_zcb1p0_zce1p0_zcf1p0_zcmp1p0_zcmt1p0\"" } } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-zce-2.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-zce-2.c
@@ -3,4 +3,4 @@
 
 void foo(){}
 
-/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p1_f2p2_zicsr2p0_zca1p0_zcb1p0_zce1p0_zcf1p0_zcmp1p0_zcmt1p0\"" } } */
+/* { dg-final { scan-assembler ".attribute arch, \"rv32i2p1_f2p2_c2p0_zicsr2p0_zca1p0_zcb1p0_zce1p0_zcf1p0_zcmp1p0_zcmt1p0\"" } } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-zce-3.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-zce-3.c
@@ -1,0 +1,6 @@
+/* { dg-do compile } */
+/* { dg-options "-mriscv-attribute -march=rv64i_zce -mabi=lp64" } */
+
+void foo(){}
+
+/* { dg-final { scan-assembler ".attribute arch, \"rv64i2p1_zicsr2p0_zca1p0_zcb1p0_zce1p0_zcmp1p0_zcmt1p0\"" } } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-zce-3.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-zce-3.c
@@ -3,4 +3,4 @@
 
 void foo(){}
 
-/* { dg-final { scan-assembler ".attribute arch, \"rv64i2p1_zicsr2p0_zca1p0_zcb1p0_zce1p0_zcmp1p0_zcmt1p0\"" } } */
+/* { dg-final { scan-assembler ".attribute arch, \"rv64i2p1_c2p0_zicsr2p0_zca1p0_zcb1p0_zce1p0_zcmp1p0_zcmt1p0\"" } } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-zce-4.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-zce-4.c
@@ -1,0 +1,6 @@
+/* { dg-do compile } */
+/* { dg-options "-mriscv-attribute -march=rv64if_zce -mabi=lp64" } */
+
+void foo(){}
+
+/* { dg-final { scan-assembler ".attribute arch, \"rv64i2p1_f2p2_zicsr2p0_zca1p0_zcb1p0_zce1p0_zcmp1p0_zcmt1p0\"" } } */

--- a/gcc/testsuite/gcc.target/riscv/attribute-zce-4.c
+++ b/gcc/testsuite/gcc.target/riscv/attribute-zce-4.c
@@ -3,4 +3,4 @@
 
 void foo(){}
 
-/* { dg-final { scan-assembler ".attribute arch, \"rv64i2p1_f2p2_zicsr2p0_zca1p0_zcb1p0_zce1p0_zcmp1p0_zcmt1p0\"" } } */
+/* { dg-final { scan-assembler ".attribute arch, \"rv64i2p1_f2p2_c2p0_zicsr2p0_zca1p0_zcb1p0_zce1p0_zcmp1p0_zcmt1p0\"" } } */


### PR DESCRIPTION
Apply 2 patches for GCC to fix [this issu](https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/issues/653):

1. `[PR target/118906] [PATCH v2] RISC-V: Fix a typo in zce to zcf implication`
   This one was pushed to upstream. Fixes [PR118906](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=118906).
2. `RISC-V: Imply C from Zca whenever possible [PR119122]`
   This one fixes [PR119122](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=119122) and it's not pushed yet. It was deferred to GCC 16 (https://gcc.gnu.org/pipermail/gcc-patches/2025-March/677744.html) but this patch would be very useful in `arc-2025.06`.