### PR TITLE
fixup! arcv: Make -mtune=arc-v-rmx-100-series a default for ARC-V

### DIFF
--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -4912,7 +4912,8 @@ case "${target}" in
 		fi
 
 		# Handle --with-tune.
-		if test "x${with_tune}" = xdefault; then
+		case ${with_tune} in
+		"")
 			case ${target} in
 			*-snps-*)
 				# Use a default mtune for Synopsys ARC-V.
@@ -4921,7 +4922,10 @@ case "${target}" in
 			*)
 				;;
 			esac
-		fi
+			;;
+		*)
+			;;
+		esac
 		;;
 
 	mips*-*-*)


### PR DESCRIPTION
Handle `--with-tune=""` instead of `--with-tune=default` as default for compatibility with `--with-arch` and `--with-abi`. Using "default" must not be used for `-mtune` and `--with-tune`.

