### PR TITLE
arcv: Use -mabi=ilp32 in arcv-fusion-madd.c

### DIFF
--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-madd.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-madd.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target rv32 } */
 /* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" } } */
-/* { dg-options "-mtune=arc-v-rhx-100-series -march=rv32im" } */
+/* { dg-options "-mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32" } */
 
 int
 f (int x, int y, int z, int v, int w)


### PR DESCRIPTION
Pass it explicitly to avoid build errors with a default -mabi value.