### PR TITLE
arcv: do not emit 64-bit MAC pairs for 32-bit data

### DIFF
--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -3731,7 +3731,21 @@
 	rtx tmp0 = gen_reg_rtx (SImode), tmp1 = gen_reg_rtx (SImode);
 	emit_insn (gen_extendhisi2 (tmp0, operands[1]));
 	emit_insn (gen_extendhisi2 (tmp1, operands[2]));
-	emit_insn (gen_madd_split_fused (operands[0], tmp0, tmp1, operands[3]));
+
+	if (TARGET_64BIT)
+	  {
+	    rtx op0 = gen_reg_rtx (DImode);
+	    emit_insn (gen_madd_split_fused_extended (op0, tmp0, tmp1, operands[3]));
+	    op0 = gen_lowpart (SImode, op0);
+	    SUBREG_PROMOTED_VAR_P (op0) = 1;
+	    SUBREG_PROMOTED_SET (op0, SRP_SIGNED);
+	    emit_move_insn (operands[0], op0);
+	  }
+	else
+	  {
+	    emit_insn (gen_madd_split_fused (operands[0], tmp0, tmp1, operands[3]));
+	  }
+
 	DONE;
       }
   }
@@ -3749,7 +3763,21 @@
     rtx tmp0 = gen_reg_rtx (SImode), tmp1 = gen_reg_rtx (SImode);
     emit_insn (gen_zero_extendhisi2 (tmp0, operands[1]));
     emit_insn (gen_zero_extendhisi2 (tmp1, operands[2]));
-    emit_insn (gen_madd_split_fused (operands[0], tmp0, tmp1, operands[3]));
+
+    if (TARGET_64BIT)
+      {
+	rtx op0 = gen_reg_rtx (DImode);
+	emit_insn (gen_madd_split_fused_extended (op0, tmp0, tmp1, operands[3]));
+	op0 = gen_lowpart (SImode, op0);
+	SUBREG_PROMOTED_VAR_P (op0) = 1;
+	SUBREG_PROMOTED_SET (op0, SRP_SIGNED);
+	emit_move_insn (operands[0], op0);
+      }
+    else
+      {
+	emit_insn (gen_madd_split_fused (operands[0], tmp0, tmp1, operands[3]));
+      }
+
     DONE;
   }
 )
@@ -3780,6 +3808,29 @@
      else
        {
 	 return "mul\t%0,%1,%2\n\tadd\t%0,%0,%3";
+       }
+  }
+  [(set_attr "type" "imul_fused")]
+)
+
+(define_insn "madd_split_fused_extended"
+  [(set (match_operand:DI 0 "register_operand" "=&r,r")
+     (sign_extend:DI
+      (plus:SI
+	(mult:SI (match_operand:SI 1 "register_operand" "r,r")
+		 (match_operand:SI 2 "register_operand" "r,r"))
+	(match_operand:SI 3 "register_operand" "r,?0"))))
+    (clobber (match_scratch:SI 4 "=&r,&r"))]
+  "arcv_micro_arch_supports_fusion_p ()
+   && (TARGET_ZMMUL || TARGET_MUL)"
+  {
+     if (REGNO (operands[0]) == REGNO (operands[3]))
+       {
+	 return "mulw\t%4,%1,%2\n\taddw\t%4,%3,%4\n\tmv\t%0,%4";
+       }
+     else
+       {
+	 return "mulw\t%0,%1,%2\n\taddw\t%0,%0,%3";
        }
   }
   [(set_attr "type" "imul_fused")]


### PR DESCRIPTION
Currently on ARC-V, the maddhisi3 pattern always expands to the madd_split_fused instruction regardless of the target word size, which leads to the full-width mul and add instructions being emitted for 32-bit data even on riscv64:

mul	a6,a4,s6
add	a6,a6,s7
sext.w	s7,a6

To fix this, add another define_insn (madd_split_fused_extended) pattern wrapping the result of a MAC operation into a sign-extension from 32 to 64 bits, and use it in the (u)maddhisi3 expander in case of a 64-bit target.  The assembly code after this change is more efficient, viz.:

mulw	a6,a4,s6
addw	a6,a6,s7

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
