### PR TITLE
ARC: Use correct input operand for *extvsi_n_0 define_insn_and_split

### DIFF
--- a/gcc/config/arc/arc.md
+++ b/gcc/config/arc/arc.md
@@ -6293,7 +6293,7 @@ archs4x, archs4xd"
 		(optimize_insn_for_size_p () ? 28 : 30))"
   "#"
   "&& 1"
-[(set (match_dup 0) (and:SI (match_dup 0) (match_dup 3)))
+[(set (match_dup 0) (and:SI (match_dup 1) (match_dup 3)))
  (set (match_dup 0) (xor:SI (match_dup 0) (match_dup 4)))
  (set (match_dup 0) (minus:SI (match_dup 0) (match_dup 4)))]
 {

--- a/gcc/testsuite/gcc.target/arc/extvsi-3.c
+++ b/gcc/testsuite/gcc.target/arc/extvsi-3.c
@@ -1,0 +1,14 @@
+/* { dg-do compile } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=em" } } */
+/* { dg-options "-O2 -mcpu=em" } */
+struct S { int a : 5; };
+
+/* An extra parameter is added to ensure a different register is used for input and output. */
+int foo (int unused, struct S p)
+{
+  return p.a;
+}
+
+/* { dg-final { scan-assembler "and\\s+r0,r1,31" } } */
+/* { dg-final { scan-assembler "xor\\s+r0,r0,16" } } */
+/* { dg-final { scan-assembler "sub\\s+r0,r0,16" } } */


### PR DESCRIPTION
This define_insn_and_split was defined here: https://github.com/foss-for-synopsys-dwc-arc-processors/gcc/commit/ff8d0ce17fb585a29a83349acbc67b2dd3556629