### PR TITLE
arc64: select correct encoding for 'mpyuw b, b, s12'

### DIFF
--- a/gcc/config/arc64/arc64.h
+++ b/gcc/config/arc64/arc64.h
@@ -477,6 +477,7 @@ extern const enum reg_class arc64_regno_to_regclass[];
 #define UNSIGNED_INT8(X) (UNSIGNED(X,8))
 #define UNSIGNED_INT9(X) (UNSIGNED(X,9))
 #define UNSIGNED_INT10(X) (UNSIGNED(X,10))
+#define UNSIGNED_INT11(X) (UNSIGNED(X,11))
 #define UNSIGNED_INT12(X) (UNSIGNED(X,12))
 #define UNSIGNED_INT16(X) (UNSIGNED(X,16))
 // TODO: Fix for 32 bit compiler host architecture.

--- a/gcc/config/arc64/arith.md
+++ b/gcc/config/arc64/arith.md
@@ -757,7 +757,7 @@
 	(mult:SI
 	 (zero_extend:SI
 	  (match_operand:HI 1 "register_operand"           "%0,    r,    0,    0,    r,r"))
-	 (match_operand:HI 2 "unsign_immediate_operand" "U06S0,U06S0,U12S0,U16S0,U16S0,U16S0")))]
+	 (match_operand:HI 2 "unsign_immediate_operand" "U06S0,U06S0,U11S0,U16S0,U16S0,U16S0")))]
   ""
   "@
    mpyuw%?\\t%0,%1,%2
@@ -769,6 +769,20 @@
   [(set_attr "length" "4,4,4,8,8,8")
    (set_attr "type" "mpy")
    (set_attr "predicable" "yes,no,no,yes,no,no")])
+
+(define_insn "mpyuws12"
+  [(set (match_operand:SI 0 "register_operand"            "=r")
+	(mult:SI
+	 (zero_extend:SI
+	  (match_operand:HI 1 "register_operand"           "%0"))
+	 (zero_extend:SI
+          (sign_extend:HI
+           (match_operand:HI 2 "s12_immediate_operand" "S12S0")))))]
+  ""
+  "mpyuw%?\\t%0,%1,%2"
+  [(set_attr "length" "4")
+   (set_attr "type" "mpy")
+   (set_attr "predicable" "no")])
 
 ;faulty;(define_insn "<ANY_EXTEND:su_optab>mulhisi3ize"
 ;faulty;  [(set (match_operand:DI 0 "register_operand"              "=r,    r,    r,r,r")

--- a/gcc/config/arc64/constraints.md
+++ b/gcc/config/arc64/constraints.md
@@ -355,6 +355,12 @@
     (match_code "const_int")
     (match_test "UNSIGNED_INT10 (ival)")))
 
+(define_constraint "U11S0" "@internal
+  A 11-bit unsigned integer constant"
+  (and
+    (match_code "const_int")
+    (match_test "UNSIGNED_INT11 (ival)")))
+
 (define_constraint "U08S0" "@internal
   A 8-bit unsigned integer constant"
   (and

--- a/gcc/config/arc64/predicates.md
+++ b/gcc/config/arc64/predicates.md
@@ -280,6 +280,10 @@
   (and (match_code "const_int")
        (match_test "UNSIGNED_INT16 (INTVAL (op))")))
 
+(define_predicate "s12_immediate_operand"
+  (and (match_code "const_int")
+       (match_test "SIGNED_INT12 (INTVAL (op))")))
+
 (define_predicate "usigned32b_operand"
   (and (match_code "const_int")
        (match_test "INTVAL (op) > 0")

--- a/gcc/testsuite/gcc.target/arc64/mpyuw.c
+++ b/gcc/testsuite/gcc.target/arc64/mpyuw.c
@@ -1,0 +1,16 @@
+/* { dg-do compile } */
+/* { dg-options "-O2 -dp" } */
+
+// Should produce 4-byte mpyuw using the "mpyuw b, b, s12" variant.
+unsigned eleven_bits(unsigned short x)
+{
+  /* { dg-final { scan-assembler "mpyuw\\s+r0,r0,1237\\s+.+\[c=..\\s+l=4\]\\s+umulhisi3i/2" } } */
+  return (unsigned) x * 1237;
+}
+
+// Should be 8 bytes because it doesn't fit in a 12-byte signed integer encoding.
+unsigned sixteen_bits(unsigned short x)
+{
+  /* { dg-final { scan-assembler "mpyuw\\s+r0,r0,2237\\s+.+\[c=..\\s+l=8\]\\s+umulhisi3i/3" } } */
+  return (unsigned) x * 2237;
+}


### PR DESCRIPTION
Fix for https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/issues/663