### PR TITLE
fixup! arcv: implement the XARCVudsp extension

### DIFF
--- a/gcc/config/riscv/arcv-udsp.md
+++ b/gcc/config/riscv/arcv-udsp.md
@@ -143,7 +143,7 @@
 [(set_attr "type" "arith")])
 
 (define_insn "riscv_arcv_udsp_xvwmul_vv_i16mf2"
-  [(set (match_operand:SI 0 "register_operand" "=r")
+  [(set (match_operand:SI 0 "register_operand" "=&r")
 	(unspec:SI [(match_operand:HI 1 "register_operand" "%r")
 	      (match_operand:HI 2 "register_operand" "r")]
   UNSPEC_ARCV_UDSP_VWMUL_VV_I16MF2))]


### PR DESCRIPTION
Designate the output operand of the LMUL=1/2 variant of arcv.xvwmul.vv as early-clobber to avoid overlap with one of the inputs.

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
