### PR TITLE
Fix XARCVvsad intrinsic arguments and return types

### DIFF
--- a/gcc/config/riscv/arcv-vector-builtins-functions.def
+++ b/gcc/config/riscv/arcv-vector-builtins-functions.def
@@ -126,8 +126,8 @@ DEF_RVV_FUNCTION (arcv_vqcjrdot, arcv_rdot_alu, none_m_preds, i_rqqvv_ops)
 #undef REQUIRED_EXTENSIONS
 
 #define REQUIRED_EXTENSIONS XARCVVSAD_EXT
-DEF_RVV_FUNCTION (arcv_vwsad, alu, none_m_preds, i_wvv_ops)
-DEF_RVV_FUNCTION (arcv_vwsadu, alu, none_m_preds, u_wvv_ops)
+DEF_RVV_FUNCTION (arcv_vwsad, alu, none_m_preds, u_ss_wwvv_ops)
+DEF_RVV_FUNCTION (arcv_vwsadu, alu, none_m_preds, u_wwvv_ops)
 #undef REQUIRED_EXTENSIONS
 
 #define REQUIRED_EXTENSIONS XARCVMXMB_EXT

--- a/gcc/config/riscv/genrvv-type-indexer.cc
+++ b/gcc/config/riscv/genrvv-type-indexer.cc
@@ -376,7 +376,9 @@ main (int argc, const char **argv)
 		     same_ratio_eew_type (sew, lmul_log2, sew / 4, unsigned_p,
 					  false)
 		       .c_str ());
-	    fprintf (fp, "  /*DOUBLE_TRUNC_SIGNED*/ INVALID,\n");
+	    fprintf (fp, "  /*DOUBLE_TRUNC_SIGNED*/ %s,\n",
+		     same_ratio_eew_type (sew, lmul_log2, sew / 2, false, false)
+		       .c_str ());
 	    fprintf (fp, "  /*DOUBLE_TRUNC_UNSIGNED*/ %s,\n",
 		     same_ratio_eew_type (sew, lmul_log2, sew / 2, true, false)
 		       .c_str ());

--- a/gcc/config/riscv/riscv-vector-builtins-bases.cc
+++ b/gcc/config/riscv/riscv-vector-builtins-bases.cc
@@ -3289,7 +3289,8 @@ public:
     switch (e.op_info->op)
       {
       case OP_TYPE_vv:
-	return e.use_exact_insn (code_for_pred_widen_arcv_vwsad (e.vector_mode ()));
+	return e.use_widen_ternop_insn (
+	    code_for_pred_widen_arcv_vwsad (e.vector_mode ()));
       default:
 	gcc_unreachable ();
       }
@@ -3306,7 +3307,8 @@ public:
     switch (e.op_info->op)
       {
       case OP_TYPE_vv:
-	return e.use_exact_insn (code_for_pred_widen_arcv_vwsadu (e.vector_mode ()));
+	return e.use_widen_ternop_insn (
+	    code_for_pred_widen_arcv_vwsadu (e.vector_mode ()));
       default:
 	gcc_unreachable ();
       }

--- a/gcc/config/riscv/riscv-vector-builtins.cc
+++ b/gcc/config/riscv/riscv-vector-builtins.cc
@@ -1213,6 +1213,12 @@ static CONSTEXPR const rvv_arg_type_info v_sx_args[]
      rvv_arg_type_info (RVV_BASE_size),
      rvv_arg_type_info (RVV_BASE_vector),
      rvv_arg_type_info_end};
+static CONSTEXPR const rvv_arg_type_info ss_wwvv_args[]
+  = {rvv_arg_type_info (RVV_BASE_vector),
+     rvv_arg_type_info (RVV_BASE_double_trunc_signed_vector),
+     rvv_arg_type_info (RVV_BASE_double_trunc_signed_vector),
+     rvv_arg_type_info_end};
+
 
 /* A list of none preds that will be registered for intrinsic functions.  */
 static CONSTEXPR const predication_type_index none_preds[]
@@ -3359,6 +3365,12 @@ static CONSTEXPR const rvv_op_info su_rwwvv_ops
     OP_TYPE_vv,			/* Suffix */
     rvv_arg_type_info (RVV_BASE_widen_lmul1_vector),	/* Return type */
     surwwvv_args			/* Args */};
+
+static CONSTEXPR const rvv_op_info u_ss_wwvv_ops
+  = {wextu_ops,				  /* Types */
+     OP_TYPE_vv,			  /* Suffix */
+     rvv_arg_type_info (RVV_BASE_vector), /* Return type */
+     ss_wwvv_args /* Args */};
 
 
 /* A list of all RVV base function types.  */

--- a/gcc/testsuite/gcc.target/riscv/arcv-vsad-vwsad_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vsad-vwsad_vv-compile-1.c
@@ -5,13 +5,13 @@
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint16m2_t test_vwsad_vv_i8 (vint8m1_t vs2, vint8m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwsad_vv_i16m2 (vs2, vs1, vl); }
-vint16m2_t test_vwsad_vv_i8_m (vbool8_t mask, vint8m1_t vs2, vint8m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwsad_vv_i16m2_m (mask, vs2, vs1, vl); }
-vint32m2_t test_vwsad_vv_i16 (vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwsad_vv_i32m2 (vs2, vs1, vl); }
-vint32m2_t test_vwsad_vv_i16_m (vbool16_t mask, vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwsad_vv_i32m2_m (mask, vs2, vs1, vl); }
+vuint16m2_t test_vwsad_vv_i8 (vuint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
+  return __riscv_arcv_vwsad_vv_u16m2 (vd, vs1, vs2, vl); }
+vuint16m2_t test_vwsad_vv_i8_m (vbool8_t mask, vuint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
+  return __riscv_arcv_vwsad_vv_u16m2_m (mask, vd, vs1, vs2, vl); }
+vuint32m2_t test_vwsad_vv_i16 (vuint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
+  return __riscv_arcv_vwsad_vv_u32m2 (vd, vs1, vs2, vl); }
+vuint32m2_t test_vwsad_vv_i16_m (vbool16_t mask, vuint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
+  return __riscv_arcv_vwsad_vv_u32m2_m (mask, vd, vs1, vs2, vl); }
 
 /* { dg-final { scan-assembler-times "arcv\\.vwsad\\.vv" 4 } } */

--- a/gcc/testsuite/gcc.target/riscv/arcv-vsad-vwsadu_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vsad-vwsadu_vv-compile-1.c
@@ -5,13 +5,13 @@
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vuint16m2_t test_vwsadu_vv_u8 (vuint8m1_t vs2, vuint8m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwsadu_vv_u16m2 (vs2, vs1, vl); }
-vuint16m2_t test_vwsadu_vv_u8_m (vbool8_t mask, vuint8m1_t vs2, vuint8m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwsadu_vv_u16m2_m (mask, vs2, vs1, vl); }
-vuint32m2_t test_vwsadu_vv_u16 (vuint16m1_t vs2, vuint16m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwsadu_vv_u32m2 (vs2, vs1, vl); }
-vuint32m2_t test_vwsadu_vv_u16_m (vbool16_t mask, vuint16m1_t vs2, vuint16m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwsadu_vv_u32m2_m (mask, vs2, vs1, vl); }
+vuint16m2_t test_vwsadu_vv_u8 (vuint16m2_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
+  return __riscv_arcv_vwsadu_vv_u16m2 (vd, vs1, vs2, vl); }
+vuint16m2_t test_vwsadu_vv_u8_m (vbool8_t mask, vuint16m2_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
+  return __riscv_arcv_vwsadu_vv_u16m2_m (mask, vd, vs1, vs2, vl); }
+vuint32m2_t test_vwsadu_vv_u16 (vuint32m2_t vd, vuint16m1_t vs1, vuint16m1_t vs2, size_t vl) {
+  return __riscv_arcv_vwsadu_vv_u32m2 (vd, vs1, vs2, vl); }
+vuint32m2_t test_vwsadu_vv_u16_m (vbool16_t mask, vuint32m2_t vd, vuint16m1_t vs1, vuint16m1_t vs2, size_t vl) {
+  return __riscv_arcv_vwsadu_vv_u32m2_m (mask, vd, vs1, vs2, vl); }
 
 /* { dg-final { scan-assembler-times "arcv\\.vwsadu\\.vv" 4 } } */


### PR DESCRIPTION
Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
