### PR TITLE
RISC-V: Add -mno-compress option

### DIFF
--- a/gcc/common/config/riscv/riscv-common.cc
+++ b/gcc/common/config/riscv/riscv-common.cc
@@ -888,6 +888,7 @@ riscv_subset_list::to_string (bool version_p) const
   bool skip_zifencei = false;
   bool skip_zicsr = false;
   bool i2p0 = false;
+  bool skip_zc = false;
 
   /* For RISC-V ISA version 2.2 or earlier version, zicsr and zifencei is
      included in the base ISA.  */
@@ -914,6 +915,9 @@ riscv_subset_list::to_string (bool version_p) const
   skip_zifencei = true;
 #endif
 
+  if (riscv_mno_compress)
+    skip_zc = true;
+
   for (subset = m_head; subset != NULL; subset = subset->next)
     {
       if (((subset->implied_p && skip_zifencei) || i2p0) &&
@@ -922,6 +926,10 @@ riscv_subset_list::to_string (bool version_p) const
 
       if (((subset->implied_p && skip_zicsr) || i2p0) &&
 	  subset->name == "zicsr")
+	continue;
+
+      if (skip_zc
+	  && (subset->name.find ("zc") == 0 || subset->name.find ("c") == 0))
 	continue;
 
       /* For !version_p, we only separate extension with underline for

--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -9988,6 +9988,9 @@ riscv_override_options_internal (struct gcc_options *opts)
 
   /* Convert -march and -mrvv-vector-bits to a chunks count.  */
   riscv_vector_chunks = riscv_convert_vector_chunks (opts);
+
+  if (opts->x_riscv_mno_compress)
+    opts->x_riscv_zc_subext = 0;
 }
 
 /* Implement TARGET_OPTION_OVERRIDE.  */

--- a/gcc/config/riscv/riscv.opt
+++ b/gcc/config/riscv/riscv.opt
@@ -675,3 +675,7 @@ Use 64-bit long double.
 mlong-double-128
 Target RejectNegative Negative(mlong-double-64) InverseMask(LONG_DOUBLE_64)
 Use 128-bit long double.
+
+mno-compress
+Target RejectNegative Var(riscv_mno_compress) Init(0)
+Don't emit compressed instructions even if the extensions are enabled.

--- a/gcc/testsuite/gcc.target/riscv/no-compress.c
+++ b/gcc/testsuite/gcc.target/riscv/no-compress.c
@@ -1,0 +1,7 @@
+/* { dg-do compile } */
+/* { dg-options " -march=rv32imac -mabi=ilp32 -mno-compress" } */
+
+int a, b, c;
+int foo(void) { return a + b + c; }
+
+/* { dg-final { scan-assembler "\.attribute arch, \"rv32i2p1_m2p0_a2p1_zaamo1p0_zalrsc1p0\"" } } */


### PR DESCRIPTION
This option prevents GCC from emitting compressed instructions even if the extensions are specified.