### PR TITLE
arc64: Update symbol-2.c to use strict function prototypes.

### DIFF
--- a/gcc/testsuite/gcc.target/arc64/symbol-2.c
+++ b/gcc/testsuite/gcc.target/arc64/symbol-2.c
@@ -7,7 +7,9 @@ struct s {
   int a;
 } _nl_C_locobj;
 
-extern int f();
+extern int f1();
+extern int f2(int,int,int,void*);
+extern int f3(int,int,int,struct s);
 
 int b;
 int c()
@@ -18,8 +20,8 @@ int c()
       if (c < '9')
 	{
 	  char e = ({ (&_nl_C_locobj)->a; });
-	  if (e == 'i' && f())
-	    f(0, 0, 0, &_nl_C_locobj);
-	  e == 'n' && f(0, 0, 0, _nl_C_locobj);
+	  if (e == 'i' && f1())
+	    f2(0, 0, 0, &_nl_C_locobj);
+	  e == 'n' && f3(0, 0, 0, _nl_C_locobj);
 	}
 }


### PR DESCRIPTION
Changed the test case to declare separate functions with explicit prototypes:

- `f1()` replaces the old K&R-style `f()` for calls with no arguments.
- `f2(int,int,int,void*)` is used when passing a pointer to `_nl_C_locobj`.
- `f3(int,int,int,struct s)` is used when passing `_nl_C_locobj` by value.

This ensures the test compiles cleanly on GCC 15, preserving the `_nl_C_locobj` access patterns for the assembly scan.

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
