### PR TITLE
Use correct return type for ARCVvdsp vmv intrinsic

### DIFF
--- a/gcc/config/riscv/arcv-vector.md
+++ b/gcc/config/riscv/arcv-vector.md
@@ -156,13 +156,13 @@
    (set (attr "avl_type_idx") (const_int 5))])
 
 (define_insn "@pred_arcv_vmv_s_v_scalar<V_VLSI:mode><P:mode>"
-  [(set (match_operand:<V_VLSI:MODE> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
-	(unspec:<V_VLSI:MODE>
+  [(set (match_operand:<V_LMUL1> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+	(unspec:<V_LMUL1>
 	  [(match_operand:V_VLSI 2 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
 	  (match_operand:P 3 "reg_or_int_operand" "r,r,r,r,r,r,i,i,i,i,i,i")
 	  (match_operand 4 "vector_length_operand" " rK, rK, rK, rK, rK, rK, rK, rK, rK, rK, rK, rK")
 	  (match_operand 5 "const_int_operand" " i,i,i,i,i,i,i,i,i,i,i,i")
-	  (match_operand:<V_VLSI:MODE> 1 "register_operand" "0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0")]
+	  (match_operand:<V_LMUL1> 1 "register_operand" "0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0")]
 	  UNSPEC_ARCV_VMV_S_V))]
   "TARGET_XARCVVDSP"
   { return which_alternative < 6 ? "arcv.vmv.s.v\t%0,%2,%3" : "arcv.vmvi.s.v\t%0,%2,%3"; }

--- a/gcc/config/riscv/riscv-vector-builtins-bases.cc
+++ b/gcc/config/riscv/riscv-vector-builtins-bases.cc
@@ -2230,7 +2230,7 @@ public:
   rtx vs1 = expand_normal (CALL_EXPR_ARG (e.exp, arg_offset++));
   rtx vs2 = expand_normal (CALL_EXPR_ARG (e.exp, arg_offset++));
 
-  e.add_input_operand (mode, vd);
+  e.add_input_operand (e.op_info->op == OP_TYPE_s_v ? e.arg_mode (0) : mode, vd);
   e.add_input_operand (mode, vs2);
   e.add_input_operand (Pmode, vs1);
   for (int argno = arg_offset; argno < call_expr_nargs (e.exp); argno++)

--- a/gcc/config/riscv/riscv-vector-builtins-shapes.cc
+++ b/gcc/config/riscv/riscv-vector-builtins-shapes.cc
@@ -890,6 +890,12 @@ struct arcv_vmv_def : public build_base
     if (!overloaded_p)
       {
 	b.append_name (type_suffixes[instance.type.index].vector);
+	if (instance.op_info->op == OP_TYPE_s_v)
+	  {
+	    vector_type_index ret_type_idx
+	      = instance.op_info->ret.get_function_type_index (instance.type.index);
+	    b.append_name (type_suffixes[ret_type_idx].vector);
+	  }
       }
 
     /* According to rvv-intrinsic-doc, it does not add "_m" suffix

--- a/gcc/config/riscv/riscv-vector-builtins.cc
+++ b/gcc/config/riscv/riscv-vector-builtins.cc
@@ -1158,7 +1158,7 @@ static CONSTEXPR const rvv_arg_type_info wwxh_args[]
      rvv_arg_type_info (RVV_BASE_quad_trunc_vector),
      rvv_arg_type_info_end};
 static CONSTEXPR const rvv_arg_type_info s_vx_args[]
- = { rvv_arg_type_info (RVV_BASE_vector),
+ = { rvv_arg_type_info (RVV_BASE_lmul1_vector),
      rvv_arg_type_info (RVV_BASE_size),
      rvv_arg_type_info (RVV_BASE_vector),
      rvv_arg_type_info_end};
@@ -3333,7 +3333,7 @@ static CONSTEXPR const rvv_op_info i_rqqvv_ops
 static CONSTEXPR const rvv_op_info iu_s_vx_ops
  = {iu_ops,			/* Types */
     OP_TYPE_s_v,			/* Suffix */
-    rvv_arg_type_info (RVV_BASE_vector),	/* Return type */
+    rvv_arg_type_info (RVV_BASE_lmul1_vector),	/* Return type */
     s_vx_args			/* Args */};
 
 static CONSTEXPR const rvv_op_info su_rqqvv_ops

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmv_s_v-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmv_s_v-compile-1.c
@@ -5,13 +5,19 @@
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint8m1_t test_vmv_s_v_i8 (vint8m1_t vd, int vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_s_v_i8m1 (vd, vs1, vs2, vl); }
-vint16m1_t test_vmv_s_v_i16 (vint16m1_t vd, int vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_s_v_i16m1 (vd, vs1, vs2, vl); }
-vint32m1_t test_vmv_s_v_i32 (vint32m1_t vd, int vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_s_v_i32m1 (vd, vs1, vs2, vl); }
-vint64m1_t test_vmv_s_v_i64 (vint64m1_t vd, int vs1, vint64m1_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_s_v_i64m1 (vd, vs1, vs2, vl); }
+vint8m1_t test_vmv_s_v_i8m1 (vint8m1_t vd, int vs1, vint8m1_t vs2, size_t vl) {
+  return __riscv_arcv_vmv_s_v_i8m1_i8m1 (vd, vs1, vs2, vl); }
+vint8m1_t test_vmv_s_v_i8m2 (vint8m1_t vd, int vs1, vint8m2_t vs2, size_t vl) {
+  return __riscv_arcv_vmv_s_v_i8m2_i8m1 (vd, vs1, vs2, vl); }
+vint8m1_t test_vmv_s_v_i8m4 (vint8m1_t vd, int vs1, vint8m4_t vs2, size_t vl) {
+  return __riscv_arcv_vmv_s_v_i8m4_i8m1 (vd, vs1, vs2, vl); }
+vint16m1_t test_vmv_s_v_i16m1 (vint16m1_t vd, int vs1, vint16m1_t vs2, size_t vl) {
+  return __riscv_arcv_vmv_s_v_i16m1_i16m1 (vd, vs1, vs2, vl); }
+vint32m1_t test_vmv_s_v_i32m1 (vint32m1_t vd, int vs1, vint32m1_t vs2, size_t vl) {
+  return __riscv_arcv_vmv_s_v_i32m1_i32m1 (vd, vs1, vs2, vl); }
+vint32m1_t test_vmv_s_v_i32m2 (vint32m1_t vd, int vs1, vint32m2_t vs2, size_t vl) {
+  return __riscv_arcv_vmv_s_v_i32m2_i32m1 (vd, vs1, vs2, vl); }
+vint64m1_t test_vmv_s_v_i64m1 (vint64m1_t vd, int vs1, vint64m1_t vs2, size_t vl) {
+  return __riscv_arcv_vmv_s_v_i64m1_i64m1 (vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vmv\\.s\\.v" 4 } } */
+/* { dg-final { scan-assembler-times "arcv\\.vmv\\.s\\.v" 7 } } */

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmvi_s_v-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmvi_s_v-compile-1.c
@@ -5,13 +5,19 @@
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint8m1_t test_vmvi_s_v_i8 (vint8m1_t vd, int vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_s_v_i8m1 (vd, 1, vs2, vl); }
-vint16m1_t test_vmvi_s_v_i16 (vint16m1_t vd, int vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_s_v_i16m1 (vd, 1, vs2, vl); }
-vint32m1_t test_vmvi_s_v_i32 (vint32m1_t vd, int vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_s_v_i32m1 (vd, 1, vs2, vl); }
-vint64m1_t test_vmvi_s_v_i64 (vint64m1_t vd, int vs1, vint64m1_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_s_v_i64m1 (vd, 1, vs2, vl); }
+vint8m1_t test_vmv_s_v_i8m1 (vint8m1_t vd, int vs1, vint8m1_t vs2, size_t vl) {
+  return __riscv_arcv_vmv_s_v_i8m1_i8m1 (vd, 1, vs2, vl); }
+vint8m1_t test_vmv_s_v_i8m2 (vint8m1_t vd, int vs1, vint8m2_t vs2, size_t vl) {
+  return __riscv_arcv_vmv_s_v_i8m2_i8m1 (vd, 1, vs2, vl); }
+vint8m1_t test_vmv_s_v_i8m4 (vint8m1_t vd, int vs1, vint8m4_t vs2, size_t vl) {
+  return __riscv_arcv_vmv_s_v_i8m4_i8m1 (vd, 1, vs2, vl); }
+vint16m1_t test_vmv_s_v_i16m1 (vint16m1_t vd, int vs1, vint16m1_t vs2, size_t vl) {
+  return __riscv_arcv_vmv_s_v_i16m1_i16m1 (vd, 1, vs2, vl); }
+vint32m1_t test_vmv_s_v_i32m1 (vint32m1_t vd, int vs1, vint32m1_t vs2, size_t vl) {
+  return __riscv_arcv_vmv_s_v_i32m1_i32m1 (vd, 1, vs2, vl); }
+vint32m1_t test_vmv_s_v_i32m2 (vint32m1_t vd, int vs1, vint32m2_t vs2, size_t vl) {
+  return __riscv_arcv_vmv_s_v_i32m2_i32m1 (vd, 1, vs2, vl); }
+vint64m1_t test_vmv_s_v_i64m1 (vint64m1_t vd, int vs1, vint64m1_t vs2, size_t vl) {
+  return __riscv_arcv_vmv_s_v_i64m1_i64m1 (vd, 1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vmvi\\.s\\.v" 4 } } */
+/* { dg-final { scan-assembler-times "arcv\\.vmvi\\.s\\.v" 7 } } */


### PR DESCRIPTION
    - The result is placed in a scalar-in-vector register. The type of vd is
      always LMUL=1.
    - The naming of the intrinsic now includes type of vs2 first, and the
      type of vd second.