### PR TITLE
Partially revert "Add helpers to test whether an optab can be implemented"

### DIFF
--- a/gcc/tree-vect-generic.cc
+++ b/gcc/tree-vect-generic.cc
@@ -1598,29 +1598,49 @@ ssa_uniform_vector_p (tree op)
   return NULL_TREE;
 }
 
-/* Return the type that should be used to implement OP on type TYPE.
-   This is TYPE itself if the target can do the operation directly,
-   otherwise it is a scalar type or a smaller vector type.  */
+/* Return type in which CODE operation with optab OP can be
+   computed.  */
 
 static tree
-get_compute_type (optab op, tree type)
+get_compute_type (enum tree_code code, optab op, tree type)
 {
-  if (op)
+  /* For very wide vectors, try using a smaller vector mode.  */
+  tree compute_type = type;
+  if (op
+      && (!VECTOR_MODE_P (TYPE_MODE (type))
+	  || optab_handler (op, TYPE_MODE (type)) == CODE_FOR_nothing))
     {
-      if (VECTOR_MODE_P (TYPE_MODE (type))
-	  && can_implement_p (op, TYPE_MODE (type)))
-	return type;
-
-      /* For very wide vectors, try using a smaller vector mode.  */
-      tree vector_compute_type = type_for_widest_vector_mode (type, op);
+      tree vector_compute_type
+	= type_for_widest_vector_mode (type, op);
       if (vector_compute_type != NULL_TREE
 	  && maybe_ne (TYPE_VECTOR_SUBPARTS (vector_compute_type), 1U)
-	  && can_implement_p (op, TYPE_MODE (vector_compute_type)))
-	return vector_compute_type;
+	  && (optab_handler (op, TYPE_MODE (vector_compute_type))
+	      != CODE_FOR_nothing))
+	compute_type = vector_compute_type;
     }
 
-  /* There is no operation in hardware, so fall back to scalars.  */
-  return TREE_TYPE (type);
+  /* If we are breaking a BLKmode vector into smaller pieces,
+     type_for_widest_vector_mode has already looked into the optab,
+     so skip these checks.  */
+  if (compute_type == type)
+    {
+      machine_mode compute_mode = TYPE_MODE (compute_type);
+      if (VECTOR_MODE_P (compute_mode))
+	{
+	  if (op
+	      && (optab_handler (op, compute_mode) != CODE_FOR_nothing
+		  || optab_libfunc (op, compute_mode)))
+	    return compute_type;
+	  if (code == MULT_HIGHPART_EXPR
+	      && can_mult_highpart_p (compute_mode,
+				      TYPE_UNSIGNED (compute_type)))
+	    return compute_type;
+	}
+      /* There is no operation in hardware, so fall back to scalars.  */
+      compute_type = TREE_TYPE (type);
+    }
+
+  return compute_type;
 }
 
 static tree
@@ -1643,7 +1663,7 @@ expand_vector_scalar_condition (gimple_stmt_iterator *gsi)
   gassign *stmt = as_a <gassign *> (gsi_stmt (*gsi));
   tree lhs = gimple_assign_lhs (stmt);
   tree type = TREE_TYPE (lhs);
-  tree compute_type = get_compute_type (mov_optab, type);
+  tree compute_type = get_compute_type (COND_EXPR, mov_optab, type);
   machine_mode compute_mode = TYPE_MODE (compute_type);
   gcc_assert (compute_mode != BLKmode);
   tree rhs2 = gimple_assign_rhs2 (stmt);
@@ -1825,7 +1845,7 @@ expand_vector_conversion (gimple_stmt_iterator *gsi)
 	}
 
       if (optab1)
-	compute_type = get_compute_type (optab1, arg_type);
+	compute_type = get_compute_type (code1, optab1, arg_type);
       enum insn_code icode1;
       if (VECTOR_TYPE_P (compute_type)
 	  && ((icode1 = optab_handler (optab1, TYPE_MODE (compute_type)))
@@ -1906,7 +1926,7 @@ expand_vector_conversion (gimple_stmt_iterator *gsi)
 	}
 
       if (optab1 && optab2)
-	compute_type = get_compute_type (optab1, arg_type);
+	compute_type = get_compute_type (code1, optab1, arg_type);
 
       enum insn_code icode1, icode2;
       if (VECTOR_TYPE_P (compute_type)
@@ -2159,12 +2179,12 @@ expand_vector_operations_1 (gimple_stmt_iterator *gsi)
 	{
           op = optab_for_tree_code (code, type, optab_scalar);
 
-	  compute_type = get_compute_type (op, type);
+	  compute_type = get_compute_type (code, op, type);
 	  if (compute_type == type)
 	    return;
 	  /* The rtl expander will expand vector/scalar as vector/vector
 	     if necessary.  Pick one with wider vector type.  */
-	  tree compute_vtype = get_compute_type (opv, type);
+	  tree compute_vtype = get_compute_type (code, opv, type);
 	  if (subparts_gt (compute_vtype, compute_type))
 	    {
 	      compute_type = compute_vtype;
@@ -2175,7 +2195,7 @@ expand_vector_operations_1 (gimple_stmt_iterator *gsi)
       if (code == LROTATE_EXPR || code == RROTATE_EXPR)
 	{
 	  if (compute_type == NULL_TREE)
-	    compute_type = get_compute_type (op, type);
+	    compute_type = get_compute_type (code, op, type);
 	  if (compute_type == type)
 	    return;
 	  /* Before splitting vector rotates into scalar rotates,
@@ -2188,11 +2208,11 @@ expand_vector_operations_1 (gimple_stmt_iterator *gsi)
 	    {
 	      optab oplv = vashl_optab, opl = ashl_optab;
 	      optab oprv = vlshr_optab, opr = lshr_optab, opo = ior_optab;
-	      tree compute_lvtype = get_compute_type (oplv, type);
-	      tree compute_rvtype = get_compute_type (oprv, type);
-	      tree compute_otype = get_compute_type (opo, type);
-	      tree compute_ltype = get_compute_type (opl, type);
-	      tree compute_rtype = get_compute_type (opr, type);
+	      tree compute_lvtype = get_compute_type (LSHIFT_EXPR, oplv, type);
+	      tree compute_rvtype = get_compute_type (RSHIFT_EXPR, oprv, type);
+	      tree compute_otype = get_compute_type (BIT_IOR_EXPR, opo, type);
+	      tree compute_ltype = get_compute_type (LSHIFT_EXPR, opl, type);
+	      tree compute_rtype = get_compute_type (RSHIFT_EXPR, opr, type);
 	      /* The rtl expander will expand vector/scalar as vector/vector
 		 if necessary.  Pick one with wider vector type.  */
 	      if (subparts_gt (compute_lvtype, compute_ltype))
@@ -2235,7 +2255,7 @@ expand_vector_operations_1 (gimple_stmt_iterator *gsi)
     op = optab_for_tree_code (MINUS_EXPR, type, optab_default);
 
   if (compute_type == NULL_TREE)
-    compute_type = get_compute_type (op, type);
+    compute_type = get_compute_type (code, op, type);
   if (compute_type == type)
     return;
 

--- a/gcc/tree-vect-stmts.cc
+++ b/gcc/tree-vect-stmts.cc
@@ -7079,15 +7079,21 @@ vectorizable_operation (vec_info *vinfo,
   /* Supportable by target?  */
 
   vec_mode = TYPE_MODE (vectype);
-  optab = optab_for_tree_code (code, vectype, optab_default);
-  if (!optab)
+  if (code == MULT_HIGHPART_EXPR)
+    target_support_p = can_mult_highpart_p (vec_mode, TYPE_UNSIGNED (vectype));
+  else
     {
-      if (dump_enabled_p ())
-	dump_printf_loc (MSG_MISSED_OPTIMIZATION, vect_location,
-			 "no optab.\n");
-      return false;
+      optab = optab_for_tree_code (code, vectype, optab_default);
+      if (!optab)
+	{
+          if (dump_enabled_p ())
+            dump_printf_loc (MSG_MISSED_OPTIMIZATION, vect_location,
+                             "no optab.\n");
+	  return false;
+	}
+      target_support_p = (optab_handler (optab, vec_mode) != CODE_FOR_nothing
+			  || optab_libfunc (optab, vec_mode));
     }
-  target_support_p = can_implement_p (optab, vec_mode);
 
   bool using_emulated_vectors_p = vect_emulated_vector_p (vectype);
   if (!target_support_p || using_emulated_vectors_p)


### PR DESCRIPTION
Reverts the changes from 485ab50c204ddba922c92d8d467ac734428a4e8a in tree-vect-generic.cc and tree-vect-stmts.cc. This fixes the following failing tests for the arc & arc64 target:
 - gcc.dg/torture/pr52407.c
 - gcc.c-torture/execute/pr23135.c
 - gcc.c-torture/execute/pr53645.c
 - gcc.c-torture/execute/scal-to-vec1.c
 - gcc.c-torture/execute/scal-to-vec2.c
 - gcc.c-torture/execute/simd-1.c
 - gcc.dg/pr88598-4.c

The new helpers the reverted commit introduced are left in place because they're used in new places after they were comitted.