### PR TITLE
arcv: Disable *<any_extract...>3 when fusion is available

### DIFF
--- a/gcc/config/riscv/iterators.md
+++ b/gcc/config/riscv/iterators.md
@@ -209,6 +209,8 @@
 				      (zero_extract "srliw")])
 (define_code_attr extract_shift [(sign_extract "ashiftrt")
 				 (zero_extract "lshiftrt")])
+(define_code_attr is_zero_extract [(sign_extract "false")
+				                   (zero_extract "true")])
 
 ;; This code iterator allows the two right shift instructions to be
 ;; generated from the same template.

--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -3052,6 +3052,7 @@
 ;; * Single-bit extraction (SFB)
 ;; * Extraction instruction th.ext(u) (XTheadBb)
 ;; * lshrsi3_extend_2 (see above)
+;; * Zero extraction fusion (ARC-V)
 (define_insn_and_split "*<any_extract:optab><GPR:mode>3"
   [(set (match_operand:GPR 0 "register_operand" "=r")
 	 (any_extract:GPR
@@ -3063,6 +3064,8 @@
       || TARGET_XVENTANACONDOPS || TARGET_SFB_ALU)
      && (INTVAL (operands[2]) == 1))
    && !TARGET_XTHEADBB
+   && !(arcv_micro_arch_supports_fusion_p ()
+        && <any_extract:is_zero_extract>)
    && !(TARGET_64BIT
         && (INTVAL (operands[3]) > 0)
         && (INTVAL (operands[2]) + INTVAL (operands[3]) == 32))"

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-xbfu.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-xbfu.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target rv32 } */
 /* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-Oz" "-Os" } } */
-/* { dg-options "-mtune=arc-v-rhx-100-series -march=rv32im_zbs -mabi=ilp32" } */
+/* { dg-options "-mtune=arc-v-rhx-100-series -march=rv32im_zbs -mabi=ilp32 -dp" } */
 
 #define bit_extract(x,start,amt) (((x)>>(start)) & (~(0xffffffff << (amt))))
 
@@ -11,4 +11,4 @@ f (int x)
   return bit_extract(x,10,14) + bit_extract(x,1,1);
 }
 
-/* { dg-final { scan-assembler {\sslli\s([ast][0-9]+),a0,8\n\ssrli\s([ast][0-9]+),\1,18\n\sbexti\sa0,a0,1\n\sadd\sa0,\2,a0\n} } } */
+/* { dg-final { scan-assembler {\sslli\s([ast][0-9]+),a0,8.*zero_extract_fused\n\ssrli\s([ast][0-9]+),\1,18\n\sbexti\sa0,a0,1.*\n\sadd\sa0,\2,a0.*\n} } } */


### PR DESCRIPTION
Updated the test. It succeeded despite the fused case not being selected because the right instructions were produced still.