### PR TITLE
Revert enabling -gvariable-location-views by default

### DIFF
--- a/gcc/dwarf2out.cc
+++ b/gcc/dwarf2out.cc
@@ -10372,10 +10372,8 @@ dwarf2out_maybe_output_loclist_view_pair (dw_loc_list_ref curr)
     }
   else
     {
-      dw2_asm_output_data_uleb128 (ZERO_VIEW_P (curr->vbegin)
-				   ? 0 : curr->vbegin, "Location view begin");
-      dw2_asm_output_data_uleb128 (ZERO_VIEW_P (curr->vend)
-				   ? 0 : curr->vend, "Location view end");
+      dw2_asm_output_data_uleb128 (curr->vbegin, "Location view begin");
+      dw2_asm_output_data_uleb128 (curr->vend, "Location view end");
     }
 #endif /* DW_LLE_view_pair */
 
@@ -10438,12 +10436,10 @@ output_loc_list (dw_loc_list_ref list_head)
 	    }
 	  else
 	    {
-	      dw2_asm_output_data_uleb128 (ZERO_VIEW_P (curr->vbegin)
-					   ? 0 : curr->vbegin,
+	      dw2_asm_output_data_uleb128 (curr->vbegin,
 					   "View list begin (%s)",
 					   list_head->vl_symbol);
-	      dw2_asm_output_data_uleb128 (ZERO_VIEW_P (curr->vend)
-					   ? 0 : curr->vend,
+	      dw2_asm_output_data_uleb128 (curr->vend,
 					   "View list end (%s)",
 					   list_head->vl_symbol);
 	    }

--- a/gcc/testsuite/gcc.dg/debug/dwarf2/inline2.c
+++ b/gcc/testsuite/gcc.dg/debug/dwarf2/inline2.c
@@ -30,9 +30,6 @@
    layout.  */
 /* { dg-final { scan-assembler-times "\\(DIE \\(\[^\n\]*\\) DW_TAG_lexical_block" 0 } } */
 
-/* Each inline instance should have DW_AT_entry_pc and DW_AT_GNU_entry_view.  */
-/* { dg-final { scan-assembler-times " DW_AT_entry_pc" 6 } } */
-/* { dg-final { scan-assembler-times " DW_AT_GNU_entry_view" 6 } } */
 
 /* There are 3 DW_AT_inline attributes: one per abstract inline instance.
    The value of the attribute must be 0x3, meaning the function was

--- a/gcc/testsuite/gcc.dg/debug/dwarf2/inline2.c
+++ b/gcc/testsuite/gcc.dg/debug/dwarf2/inline2.c
@@ -16,7 +16,7 @@
 
 /* Explicitly use dwarf-2 because dwarf-5 might use DW_FORM_implicit_const
    which is hard to scan for. */
-/* { dg-options "-O -g3 -gdwarf-2 -gno-strict-dwarf -dA -fgnu89-inline" } */
+/* { dg-options "-O -g3 -gdwarf-2 -dA -fgnu89-inline" } */
 /* { dg-do compile } */
 
 /* There are 6 inlined subroutines:

--- a/gcc/testsuite/gcc.dg/debug/dwarf2/inline6.c
+++ b/gcc/testsuite/gcc.dg/debug/dwarf2/inline6.c
@@ -16,7 +16,7 @@
 
 /* Explicitly use dwarf-5 which uses DW_FORM_implicit_const.  */
 /* { dg-do compile } */
-/* { dg-options "-O -g3 -gdwarf-5 -gno-strict-dwarf -dA -fgnu89-inline -gno-as-loc-support" } */
+/* { dg-options "-O -g3 -gdwarf-5 -dA -fgnu89-inline -gno-as-loc-support" } */
 
 /* There are 6 inlined subroutines:
    - One for each subroutine inlined into main, that's 3.

--- a/gcc/testsuite/gcc.dg/debug/dwarf2/inline6.c
+++ b/gcc/testsuite/gcc.dg/debug/dwarf2/inline6.c
@@ -16,7 +16,7 @@
 
 /* Explicitly use dwarf-5 which uses DW_FORM_implicit_const.  */
 /* { dg-do compile } */
-/* { dg-options "-O -g3 -gdwarf-5 -dA -fgnu89-inline -gno-as-loc-support" } */
+/* { dg-options "-O -g3 -gdwarf-5 -dA -fgnu89-inline" } */
 
 /* There are 6 inlined subroutines:
    - One for each subroutine inlined into main, that's 3.
@@ -29,11 +29,6 @@
    layout.  */
 /* { dg-final { scan-assembler-times "\\(DIE \\(\[^\n\]*\\) DW_TAG_lexical_block" 0 } } */
 
-/* Each inline instance should have DW_AT_entry_pc and DW_AT_GNU_entry_view. */
-/* { dg-final { scan-assembler-times " DW_AT_entry_pc" 6 } } */
-/* { dg-final { scan-assembler-times " DW_AT_GNU_entry_view" 6 } } */
-/* { dg-final { scan-assembler-times "uleb128\[^\n\]*LVU\[^\n\]* (View list|Location view) (begin|end)" 0 } } */
-/* { dg-final { scan-assembler-times "uleb128\[^\n\]*0xffffffff\[^\n\]* (View list|Location view) (begin|end)" 0 } } */
 
 /* There are 3 DW_AT_inline attributes: one per abstract inline instance.
    The value of the attribute must be 0x3, meaning the function was

--- a/gcc/toplev.cc
+++ b/gcc/toplev.cc
@@ -1506,14 +1506,6 @@ process_options ()
     dwarf2out_as_loc_support = dwarf2out_default_as_loc_support ();
   if (!OPTION_SET_P (dwarf2out_as_locview_support))
     dwarf2out_as_locview_support = dwarf2out_default_as_locview_support ();
-  if (dwarf2out_as_locview_support && !dwarf2out_as_loc_support)
-    {
-      if (OPTION_SET_P (dwarf2out_as_locview_support))
-	warning_at (UNKNOWN_LOCATION, 0,
-		    "%<-gas-locview-support%> is forced disabled "
-		    "without %<-gas-loc-support%>");
-      dwarf2out_as_locview_support = false;
-    }
 
   if (!OPTION_SET_P (debug_variable_location_views))
     {
@@ -1521,7 +1513,9 @@ process_options ()
 	= (flag_var_tracking
 	   && debug_info_level >= DINFO_LEVEL_NORMAL
 	   && dwarf_debuginfo_p ()
-	   && !dwarf_strict);
+	   && !dwarf_strict
+	   && dwarf2out_as_loc_support
+	   && dwarf2out_as_locview_support);
     }
   else if (debug_variable_location_views == -1 && dwarf_version != 5)
     {


### PR DESCRIPTION
This PR reverts a couple of patches in GCC 15 which turn on `-gvariable-location-views` by default (as it said in the original commit message). Somehow this behavior leads to significant increase of binaries' size. Mostly it's debug symbols and relocations for them. E.g., our toolchain with GCC 15 without this fix is 15GB, and with this fix it is 11GB.

In the future releases we should investigate how to overcome this issue without reverting of these patches.