### PR TITLE
Revert "RISC-V: Add -mno-compress option"

### DIFF
--- a/gcc/common/config/riscv/riscv-common.cc
+++ b/gcc/common/config/riscv/riscv-common.cc
@@ -933,7 +933,6 @@ riscv_subset_list::to_string (bool version_p) const
   bool skip_zicsr = false;
   bool skip_b = false;
   bool i2p0 = false;
-  bool skip_zc = false;
 
   /* For RISC-V ISA version 2.2 or earlier version, zicsr and zifencei is
      included in the base ISA.  */
@@ -970,9 +969,6 @@ riscv_subset_list::to_string (bool version_p) const
   skip_b = true;
 #endif
 
-  if (riscv_mno_compress)
-    skip_zc = true;
-
   for (subset = m_head; subset != NULL; subset = subset->next)
     {
       if (((subset->implied_p && skip_zifencei) || i2p0) &&
@@ -990,9 +986,6 @@ riscv_subset_list::to_string (bool version_p) const
 	continue;
 
       if (skip_b && subset->name == "b")
-	continue;
-      if (skip_zc
-	  && (subset->name.find ("zc") == 0 || subset->name.find ("c") == 0))
 	continue;
 
       /* For !version_p, we only separate extension with underline for

--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -11470,9 +11470,6 @@ riscv_override_options_internal (struct gcc_options *opts)
       = (cf_protection_level) (opts->x_flag_cf_protection | CF_SET);
     }
 
-  if (opts->x_riscv_mno_compress)
-    opts->x_riscv_zc_subext = 0;
-
   /* Enable advanced fusion for the ARC-V cores that support it unless
      explicitly disabled.
      TODO Add arcv_rmx500 once it supports fusion.  */

--- a/gcc/config/riscv/riscv.opt
+++ b/gcc/config/riscv/riscv.opt
@@ -733,10 +733,6 @@ mlong-double-128
 Target RejectNegative Negative(mlong-double-64) InverseMask(LONG_DOUBLE_64)
 Use 128-bit long double.
 
-mno-compress
-Target RejectNegative Var(riscv_mno_compress) Init(0)
-Don't emit compressed instructions even if the extensions are enabled.
-
 marc-v-rmx-500-series-advanced-fusion
 Target Mask(ARCV_ADVANCED_FUSION)
 Explicitly disable or enable advanced fusion for the RMX-500 core.

--- a/gcc/testsuite/gcc.target/riscv/no-compress.c
+++ b/gcc/testsuite/gcc.target/riscv/no-compress.c
@@ -1,7 +1,0 @@
-/* { dg-do compile } */
-/* { dg-options " -march=rv32imac -mabi=ilp32 -mno-compress" } */
-
-int a, b, c;
-int foo(void) { return a + b + c; }
-
-/* { dg-final { scan-assembler "\.attribute arch, \"rv32i2p1_m2p0_a2p1_zmmul1p0_zaamo1p0_zalrsc1p0\"" } } */


### PR DESCRIPTION
This functionality is instead provided in the tcf script.