### PR TITLE
Correct RTL patterns for XARCV instructions

### DIFF
--- a/gcc/config/riscv/arcv-vector.md
+++ b/gcc/config/riscv/arcv-vector.md
@@ -767,7 +767,7 @@
   "TARGET_XARCVVDSP"
   "arcv.vwsra.v%o4\t%0,%3,%4%p1"
   [(set_attr "type" "vsshift")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_arcv_vwsra_scalar<mode>"
   [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -791,7 +791,7 @@
   "TARGET_XARCVVDSP"
   "arcv.vwsra.v%o4\t%0,%3,%4%p1"
   [(set_attr "type" "vsshift")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_arcv_vaddsub<mode>"
   [(set (match_operand:V_VLSI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -876,9 +876,9 @@
 	  UNSPEC_ARCV_VQRDOT)
 	(match_dup 2)))]
   "TARGET_XARCVVDSP"
-  "arcv.vqrdot.v%o3\t%0,%2,%3%p1"
+  "arcv.vqrdot.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<V_QEXT_LMUL1>")])
+   (set_attr "mode" "<MODE>")])
 
 (define_insn "@pred_quad_widen_arcv_vqrdot_2s<mode>"
   [(set (match_operand:<V_QEXT_LMUL1> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -898,9 +898,9 @@
 	  UNSPEC_ARCV_VQRDOT_2S)
 	(match_dup 2)))]
   "TARGET_XARCVVDSP"
-  "arcv.vqrdot.2s.v%o3\t%0,%2,%3%p1"
+  "arcv.vqrdot.2s.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<V_QEXT_LMUL1>")])
+   (set_attr "mode" "<MODE>")])
 
 (define_insn "@pred_widen_arcv_vwsrdot_2s<mode>"
   [(set (match_operand:<V_EXT_LMUL1> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -920,9 +920,9 @@
 	  UNSPEC_ARCV_VWSRDOT_2S)
 	(match_dup 2)))]
   "TARGET_XARCVVDSP"
-  "arcv.vwsrdot.2s.v%o3\t%0,%2,%3%p1"
+  "arcv.vwsrdot.2s.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<V_EXT_LMUL1>")])
+   (set_attr "mode" "<MODE>")])
 
 (define_insn "@pred_quad_widen_arcv_vqrdotu<mode>"
   [(set (match_operand:<V_QEXT_LMUL1> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -942,9 +942,9 @@
 	  UNSPEC_ARCV_VQRDOTU)
 	(match_dup 2)))]
   "TARGET_XARCVVDSP"
-  "arcv.vqrdotu.v%o3\t%0,%2,%3%p1"
+  "arcv.vqrdotu.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<V_QEXT_LMUL1>")])
+   (set_attr "mode" "<MODE>")])
 
 (define_insn "@pred_quad_widen_arcv_vqrdotsu<mode>"
   [(set (match_operand:<V_QEXT_LMUL1> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -964,9 +964,9 @@
 	  UNSPEC_ARCV_VQRDOTSU)
 	(match_dup 2)))]
   "TARGET_XARCVVDSP"
-  "arcv.vqrdotsu.v%o3\t%0,%2,%3%p1"
+  "arcv.vqrdotsu.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<V_QEXT_LMUL1>")])
+   (set_attr "mode" "<MODE>")])
 
 (define_insn "@pred_widen_arcv_vwrdot<mode>"
   [(set (match_operand:<V_EXT_LMUL1> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -986,9 +986,9 @@
 	  UNSPEC_ARCV_VWRDOT)
 	(match_dup 2)))]
   "TARGET_XARCVVDSP"
-  "arcv.vwrdot.v%o3\t%0,%2,%3%p1"
+  "arcv.vwrdot.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<V_EXT_LMUL1>")])
+   (set_attr "mode" "<MODE>")])
 
 (define_insn "@pred_widen_half_arcv_vwrdot<mode>"
   [(set (match_operand:<V_EXT_LMUL1> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1009,9 +1009,9 @@
 	  UNSPEC_ARCV_VWRDOT)
 	(match_dup 2)))]
   "TARGET_XARCVVDSP"
-  "arcv.vwrdot.h%o3\t%0,%2,%3%p1"
+  "arcv.vwrdot.h%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<V_EXT_LMUL1>")])
+   (set_attr "mode" "<MODE>")])
 
 (define_insn "@pred_widen_arcv_vwsrdot<mode>"
   [(set (match_operand:<V_EXT_LMUL1> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1031,9 +1031,9 @@
 	  UNSPEC_ARCV_VWSRDOT)
 	(match_dup 2)))]
   "TARGET_XARCVVDSP"
-  "arcv.vwsrdot.v%o3\t%0,%2,%3%p1"
+  "arcv.vwsrdot.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<V_EXT_LMUL1>")])
+   (set_attr "mode" "<MODE>")])
 
 (define_insn "@pred_widen_arcv_vwrdotu<mode>"
   [(set (match_operand:<V_EXT_LMUL1> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1053,9 +1053,9 @@
 	  UNSPEC_ARCV_VWRDOTU)
 	(match_dup 2)))]
   "TARGET_XARCVVDSP"
-  "arcv.vwrdotu.v%o3\t%0,%2,%3%p1"
+  "arcv.vwrdotu.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<V_EXT_LMUL1>")])
+   (set_attr "mode" "<MODE>")])
 
 (define_insn "@pred_widen_half_arcv_vwrdotu<mode>"
   [(set (match_operand:<V_EXT_LMUL1> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1076,9 +1076,9 @@
 	  UNSPEC_ARCV_VWRDOTU)
 	(match_dup 2)))]
   "TARGET_XARCVVDSP"
-  "arcv.vwrdotu.h%o3\t%0,%2,%3%p1"
+  "arcv.vwrdotu.h%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<V_EXT_LMUL1>")])
+   (set_attr "mode" "<MODE>")])
 
 (define_insn "@pred_widen_arcv_vwrdotsu<mode>"
   [(set (match_operand:<V_EXT_LMUL1> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1098,9 +1098,9 @@
 	  UNSPEC_ARCV_VWRDOTSU)
 	(match_dup 2)))]
   "TARGET_XARCVVDSP"
-  "arcv.vwrdotsu.v%o3\t%0,%2,%3%p1"
+  "arcv.vwrdotsu.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<V_EXT_LMUL1>")])
+   (set_attr "mode" "<MODE>")])
 
 (define_insn "@pred_widen_arcv_vwsmac<mode>"
   [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1122,9 +1122,9 @@
 	  UNSPEC_ARCV_VWSMAC)
 	(match_dup 2)))]
   "TARGET_XARCVVDSP"
-  "arcv.vwsmac.v%o3\t%0,%2,%3%p1"
+  "arcv.vwsmac.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_arcv_vwsmac_scalar<mode>"
   [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1145,9 +1145,9 @@
 	  UNSPEC_ARCV_VWSMAC)
 	(match_dup 2)))]
   "TARGET_XARCVVDSP"
-  "arcv.vwsmac.v%o3\t%0,%2,%3%p1"
+  "arcv.vwsmac.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_arcv_vwsnmsac<mode>"
   [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1169,9 +1169,9 @@
 	  UNSPEC_ARCV_VWSNMSAC)
 	(match_dup 2)))]
   "TARGET_XARCVVDSP"
-  "arcv.vwsnmsac.v%o3\t%0,%2,%3%p1"
+  "arcv.vwsnmsac.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_arcv_vwsnmsac_scalar<mode>"
   [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1192,9 +1192,9 @@
 	  UNSPEC_ARCV_VWSNMSAC)
 	(match_dup 2)))]
   "TARGET_XARCVVDSP"
-  "arcv.vwsnmsac.v%o3\t%0,%2,%3%p1"
+  "arcv.vwsnmsac.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_half_arcv_vwmul<mode>"
   [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1217,7 +1217,7 @@
   "TARGET_XARCVVDSP"
   "arcv.vwmul.h%o4\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_half_arcv_vwmul_scalar<mode>"
   [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1239,7 +1239,7 @@
   "TARGET_XARCVVDSP"
   "arcv.vwmul.h%o4\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_half_arcv_vwmac<mode>"
   [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1261,9 +1261,9 @@
 	  UNSPEC_ARCV_VWMAC)
 	(match_dup 2)))]
   "TARGET_XARCVVDSP"
-  "arcv.vwmac.h%o3\t%0,%2,%3%p1"
+  "arcv.vwmac.h%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_half_arcv_vwmac_scalar<mode>"
   [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1284,9 +1284,9 @@
 	  UNSPEC_ARCV_VWMAC)
 	(match_dup 2)))]
   "TARGET_XARCVVDSP"
-  "arcv.vwmac.h%o3\t%0,%2,%3%p1"
+  "arcv.vwmac.h%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_half_arcv_vwmulu<mode>"
   [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1309,7 +1309,7 @@
   "TARGET_XARCVVDSP"
   "arcv.vwmulu.h%o4\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_half_arcv_vwmulu_scalar<mode>"
   [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1331,7 +1331,7 @@
   "TARGET_XARCVVDSP"
   "arcv.vwmulu.h%o4\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_half_arcv_vwmacu<mode>"
   [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1353,9 +1353,9 @@
 	  UNSPEC_ARCV_VWMACU)
 	(match_dup 2)))]
   "TARGET_XARCVVDSP"
-  "arcv.vwmacu.h%o3\t%0,%2,%3%p1"
+  "arcv.vwmacu.h%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_half_arcv_vwmacu_scalar<mode>"
   [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1376,9 +1376,9 @@
 	  UNSPEC_ARCV_VWMACU)
 	(match_dup 2)))]
   "TARGET_XARCVVDSP"
-  "arcv.vwmacu.h%o3\t%0,%2,%3%p1"
+  "arcv.vwmacu.h%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_half_arcv_vsmulf<mode>"
   [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1449,7 +1449,7 @@
   "TARGET_XARCVVDSP"
   "arcv.vwmulf.h%o4\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_half_arcv_vwmulf_scalar<mode>"
   [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1471,7 +1471,7 @@
   "TARGET_XARCVVDSP"
   "arcv.vwmulf.h%o4\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_half_arcv_vwsmacf<mode>"
   [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1493,9 +1493,9 @@
 	  UNSPEC_ARCV_VWSMACF)
 	(match_dup 2)))]
   "TARGET_XARCVVDSP"
-  "arcv.vwsmacf.h%o3\t%0,%2,%3%p1"
+  "arcv.vwsmacf.h%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_half_arcv_vwsmacf_scalar<mode>"
   [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1516,9 +1516,9 @@
 	  UNSPEC_ARCV_VWSMACF)
 	(match_dup 2)))]
   "TARGET_XARCVVDSP"
-  "arcv.vwsmacf.h%o3\t%0,%2,%3%p1"
+  "arcv.vwsmacf.h%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_half_arcv_vwsnmsacf<mode>"
   [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1540,9 +1540,9 @@
 	  UNSPEC_ARCV_VWSNMSACF)
 	(match_dup 2)))]
   "TARGET_XARCVVDSP"
-  "arcv.vwsnmsacf.h%o3\t%0,%2,%3%p1"
+  "arcv.vwsnmsacf.h%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_half_arcv_vwsnmsacf_scalar<mode>"
   [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1563,9 +1563,9 @@
 	  UNSPEC_ARCV_VWSNMSACF)
 	(match_dup 2)))]
   "TARGET_XARCVVDSP"
-  "arcv.vwsnmsacf.h%o3\t%0,%2,%3%p1"
+  "arcv.vwsnmsacf.h%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_half_arcv_vwsrdotf<mode>"
   [(set (match_operand:<V_EXT_LMUL1> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1586,9 +1586,9 @@
 	  UNSPEC_ARCV_VWSRDOTF)
 	(match_dup 2)))]
   "TARGET_XARCVVDSP"
-  "arcv.vwsrdotf.h%o3\t%0,%2,%3%p1"
+  "arcv.vwsrdotf.h%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<V_EXT_LMUL1>")])
+   (set_attr "mode" "<MODE>")])
 
 (define_insn "@pred_arcv_vconj<mode>"
   [(set (match_operand:V_VLSI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1771,7 +1771,7 @@
   "TARGET_XARCVVCPLX"
   "arcv.vwcredsum.v%o4\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<V_EXT_LMUL1>")])
+   (set_attr "mode" "<MODE>")])
 
 (define_insn "@pred_arcv_vscmul<mode>"
   [(set (match_operand:V_VLSI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1886,7 +1886,7 @@
   "TARGET_XARCVVCPLX"
   "arcv.vwscmul.v%o4\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_arcv_vwscmul_scalar<mode>"
   [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1908,7 +1908,7 @@
   "TARGET_XARCVVCPLX"
   "arcv.vwscmul.v%o4\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_arcv_vwscjmul<mode>"
   [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1931,7 +1931,7 @@
   "TARGET_XARCVVCPLX"
   "arcv.vwscjmul.v%o4\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_arcv_vwscjmul_scalar<mode>"
   [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1953,7 +1953,7 @@
   "TARGET_XARCVVCPLX"
   "arcv.vwscjmul.v%o4\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_arcv_vwscmac<mode>"
   [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1975,9 +1975,9 @@
 	  UNSPEC_ARCV_VWSCMAC)
 	(match_dup 2)))]
   "TARGET_XARCVVCPLX"
-  "arcv.vwscmac.v%o3\t%0,%2,%3%p1"
+  "arcv.vwscmac.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_arcv_vwscmac_scalar<mode>"
   [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -1998,9 +1998,9 @@
 	  UNSPEC_ARCV_VWSCMAC)
 	(match_dup 2)))]
   "TARGET_XARCVVCPLX"
-  "arcv.vwscmac.v%o3\t%0,%2,%3%p1"
+  "arcv.vwscmac.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_arcv_vwscnmsac<mode>"
   [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -2022,9 +2022,9 @@
 	  UNSPEC_ARCV_VWSCNMSAC)
 	(match_dup 2)))]
   "TARGET_XARCVVCPLX"
-  "arcv.vwscnmsac.v%o3\t%0,%2,%3%p1"
+  "arcv.vwscnmsac.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_arcv_vwscnmsac_scalar<mode>"
   [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -2045,9 +2045,9 @@
 	  UNSPEC_ARCV_VWSCNMSAC)
 	(match_dup 2)))]
   "TARGET_XARCVVCPLX"
-  "arcv.vwscnmsac.v%o3\t%0,%2,%3%p1"
+  "arcv.vwscnmsac.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_arcv_vwscjmac<mode>"
   [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -2069,9 +2069,9 @@
 	  UNSPEC_ARCV_VWSCJMAC)
 	(match_dup 2)))]
   "TARGET_XARCVVCPLX"
-  "arcv.vwscjmac.v%o3\t%0,%2,%3%p1"
+  "arcv.vwscjmac.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_arcv_vwscjmac_scalar<mode>"
   [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -2092,9 +2092,9 @@
 	  UNSPEC_ARCV_VWSCJMAC)
 	(match_dup 2)))]
   "TARGET_XARCVVCPLX"
-  "arcv.vwscjmac.v%o3\t%0,%2,%3%p1"
+  "arcv.vwscjmac.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_arcv_vwscjnmsac<mode>"
   [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -2116,9 +2116,9 @@
 	  UNSPEC_ARCV_VWSCJNMSAC)
 	(match_dup 2)))]
   "TARGET_XARCVVCPLX"
-  "arcv.vwscjnmsac.v%o3\t%0,%2,%3%p1"
+  "arcv.vwscjnmsac.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_arcv_vwscjnmsac_scalar<mode>"
   [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -2139,9 +2139,9 @@
 	  UNSPEC_ARCV_VWSCJNMSAC)
 	(match_dup 2)))]
   "TARGET_XARCVVCPLX"
-  "arcv.vwscjnmsac.v%o3\t%0,%2,%3%p1"
+  "arcv.vwscjnmsac.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_arcv_vwscrdot<mode>"
   [(set (match_operand:<V_EXT_LMUL1> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -2161,9 +2161,9 @@
 	  UNSPEC_ARCV_VWSCRDOT)
 	(match_dup 2)))]
   "TARGET_XARCVVCPLX"
-  "arcv.vwscrdot.v%o3\t%0,%2,%3%p1"
+  "arcv.vwscrdot.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<V_EXT_LMUL1>")])
+   (set_attr "mode" "<MODE>")])
 
 (define_insn "@pred_widen_arcv_vwscjrdot<mode>"
   [(set (match_operand:<V_EXT_LMUL1> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -2183,9 +2183,9 @@
 	  UNSPEC_ARCV_VWSCJRDOT)
 	(match_dup 2)))]
   "TARGET_XARCVVCPLX"
-  "arcv.vwscjrdot.v%o3\t%0,%2,%3%p1"
+  "arcv.vwscjrdot.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<V_EXT_LMUL1>")])
+   (set_attr "mode" "<MODE>")])
 
 (define_insn "@pred_quad_widen_arcv_vqcrdot<mode>"
   [(set (match_operand:<V_QEXT_LMUL1> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -2205,9 +2205,9 @@
 	  UNSPEC_ARCV_VQCRDOT)
 	(match_dup 2)))]
   "TARGET_XARCVVCPLX"
-  "arcv.vqcrdot.v%o3\t%0,%2,%3%p1"
+  "arcv.vqcrdot.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<V_QEXT_LMUL1>")])
+   (set_attr "mode" "<MODE>")])
 
 (define_insn "@pred_quad_widen_arcv_vqcjrdot<mode>"
   [(set (match_operand:<V_QEXT_LMUL1> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -2227,9 +2227,9 @@
 	  UNSPEC_ARCV_VQCJRDOT)
 	(match_dup 2)))]
   "TARGET_XARCVVCPLX"
-  "arcv.vqcjrdot.v%o3\t%0,%2,%3%p1"
+  "arcv.vqcjrdot.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<V_QEXT_LMUL1>")])
+   (set_attr "mode" "<MODE>")])
 
 (define_insn "@pred_widen_arcv_vwsad<mode>"
   [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -2252,7 +2252,7 @@
   "TARGET_XARCVVSAD"
   "arcv.vwsad.v%o4\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_arcv_vwsadu<mode>"
   [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -2275,7 +2275,7 @@
   "TARGET_XARCVVSAD"
   "arcv.vwsadu.v%o4\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_quad_widen_arcv_vqmxm4<mode>"
   [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -2297,9 +2297,9 @@
 	  UNSPEC_ARCV_VQMXM4)
 	(match_dup 2)))]
   "TARGET_XARCVMXMB"
-  "arcv.vqmxm4.v%o3\t%0,%2,%3%p1"
+  "arcv.vqmxm4.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_QUAD_TRUNC>")])
 
 (define_insn "@pred_quad_widen_arcv_vqmxm4u<mode>"
   [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -2321,9 +2321,9 @@
 	  UNSPEC_ARCV_VQMXM4U)
 	(match_dup 2)))]
   "TARGET_XARCVMXMB"
-  "arcv.vqmxm4u.v%o3\t%0,%2,%3%p1"
+  "arcv.vqmxm4u.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_QUAD_TRUNC>")])
 
 (define_insn "@pred_quad_widen_arcv_vqmxm4su<mode>"
   [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -2345,9 +2345,9 @@
 	  UNSPEC_ARCV_VQMXM4SU)
 	(match_dup 2)))]
   "TARGET_XARCVMXMB"
-  "arcv.vqmxm4su.v%o3\t%0,%2,%3%p1"
+  "arcv.vqmxm4su.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_QUAD_TRUNC>")])
 
 (define_insn "@pred_quad_widen_arcv_vqmxm8<mode>"
   [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -2369,9 +2369,9 @@
 	  UNSPEC_ARCV_VQMXM8)
 	(match_dup 2)))]
   "TARGET_XARCVMXMC"
-  "arcv.vqmxm8.v%o3\t%0,%2,%3%p1"
+  "arcv.vqmxm8.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_QUAD_TRUNC>")])
 
 (define_insn "@pred_quad_widen_arcv_vqmxm8u<mode>"
   [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -2393,9 +2393,9 @@
 	  UNSPEC_ARCV_VQMXM8U)
 	(match_dup 2)))]
   "TARGET_XARCVMXMC"
-  "arcv.vqmxm8u.v%o3\t%0,%2,%3%p1"
+  "arcv.vqmxm8u.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_QUAD_TRUNC>")])
 
 (define_insn "@pred_quad_widen_arcv_vqmxm8su<mode>"
   [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -2417,9 +2417,9 @@
 	  UNSPEC_ARCV_VQMXM8SU)
 	(match_dup 2)))]
   "TARGET_XARCVMXMC"
-  "arcv.vqmxm8su.v%o3\t%0,%2,%3%p1"
+  "arcv.vqmxm8su.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_QUAD_TRUNC>")])
 
 (define_insn "@pred_quad_widen_arcv_vqmxm16<mode>"
   [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -2441,9 +2441,9 @@
 	  UNSPEC_ARCV_VQMXM16)
 	(match_dup 2)))]
   "TARGET_XARCVMXMD"
-  "arcv.vqmxm16.v%o3\t%0,%2,%3%p1"
+  "arcv.vqmxm16.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_QUAD_TRUNC>")])
 
 (define_insn "@pred_quad_widen_arcv_vqmxm16u<mode>"
   [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -2465,9 +2465,9 @@
 	  UNSPEC_ARCV_VQMXM16U)
 	(match_dup 2)))]
   "TARGET_XARCVMXMD"
-  "arcv.vqmxm16u.v%o3\t%0,%2,%3%p1"
+  "arcv.vqmxm16u.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_QUAD_TRUNC>")])
 
 (define_insn "@pred_quad_widen_arcv_vqmxm16su<mode>"
   [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
@@ -2489,6 +2489,6 @@
 	  UNSPEC_ARCV_VQMXM16SU)
 	(match_dup 2)))]
   "TARGET_XARCVMXMD"
-  "arcv.vqmxm16su.v%o3\t%0,%2,%3%p1"
+  "arcv.vqmxm16su.v%o3\t%0,%3,%4%p1"
   [(set_attr "type" "viwmuladd")
-   (set_attr "mode" "<MODE>")])
+   (set_attr "mode" "<V_QUAD_TRUNC>")])

--- a/gcc/config/riscv/arcv-vector.md
+++ b/gcc/config/riscv/arcv-vector.md
@@ -308,7 +308,7 @@
 	     (reg:SI VXRM_REGNUM)] UNSPEC_VPREDICATE)
 	(unspec:V_VLSI
 	[(match_operand:V_VLSI 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
-	(match_operand:<VEL> 4 "reg_or_int_operand" "r,r,r,r,r,r,i,i,i,i,i,i")]
+	(match_operand 4 "pmode_reg_or_uimm5_operand" "r,r,r,r,r,r,K,K,K,K,K,K")]
 	  UNSPEC_ARCV_VSRA)
 	(match_operand:V_VLSI 2 "vector_merge_operand"     "vu,0,vu,0,vu,0,vu,0,vu,0,vu,0")))]
   "TARGET_XARCVVDSP"
@@ -350,7 +350,7 @@
 	     (reg:SI VTYPE_REGNUM)] UNSPEC_VPREDICATE)
 	(unspec:V_VLSI
 	[(match_operand:V_VLSI 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
-	(match_operand:<VEL> 4 "reg_or_int_operand" "r,r,r,r,r,r,i,i,i,i,i,i")]
+	(match_operand 4 "pmode_reg_or_uimm5_operand" "r,r,r,r,r,r,K,K,K,K,K,K")]
 	  UNSPEC_ARCV_VSRAT)
 	(match_operand:V_VLSI 2 "vector_merge_operand"     "vu,0,vu,0,vu,0,vu,0,vu,0,vu,0")))]
   "TARGET_XARCVVDSP"
@@ -396,7 +396,7 @@
 		 (reg:SI VXRM_REGNUM)] UNSPEC_VPREDICATE)
 	(unspec:V_VLSI
 	[(match_operand:V_VLSI 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
-	(match_operand:<VEL> 4 "reg_or_int_operand" "r,r,r,r,r,r,i,i,i,i,i,i")]
+	(match_operand 4 "pmode_reg_or_uimm5_operand" "r,r,r,r,r,r,K,K,K,K,K,K")]
 	  UNSPEC_ARCV_VSRA_S)
 	(match_operand:V_VLSI 2 "vector_merge_operand"     "vu,0,vu,0,vu,0,vu,0,vu,0,vu,0")))]
   "TARGET_XARCVVDSP"
@@ -442,7 +442,7 @@
 		 (reg:SI VXRM_REGNUM)] UNSPEC_VPREDICATE)
 	(unspec:V_VLSI
 	[(match_operand:V_VLSI 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
-	(match_operand:<VEL> 4 "reg_or_int_operand" "r,r,r,r,r,r,i,i,i,i,i,i")]
+	(match_operand 4 "pmode_reg_or_uimm5_operand" "r,r,r,r,r,r,K,K,K,K,K,K")]
 	  UNSPEC_ARCV_VSRA_2S)
 	(match_operand:V_VLSI 2 "vector_merge_operand"     "vu,0,vu,0,vu,0,vu,0,vu,0,vu,0")))]
   "TARGET_XARCVVDSP"
@@ -516,7 +516,7 @@
 	(truncate:<V_DOUBLE_TRUNC>
 	  (unspec:VWEXTI
 	  [(match_operand:VWEXTI 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
-	  (match_operand:SI 4 "reg_or_int_operand" "r,r,r,r,r,r,i,i,i,i,i,i")]
+	  (match_operand 4 "pmode_reg_or_uimm5_operand" "r,r,r,r,r,r,K,K,K,K,K,K")]
 	  UNSPEC_ARCV_VNSRA))
 	(match_operand:<V_DOUBLE_TRUNC> 2 "vector_merge_operand"     "vu,0,vu,0,vu,0,vu,0,vu,0,vu,0")))]
   "TARGET_XARCVVDSP"
@@ -540,7 +540,7 @@
 	(truncate:<V_QUAD_TRUNC>
 	  (unspec:VQEXTI
 	  [(match_operand:VQEXTI 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
-	  (match_operand:SI 4 "reg_or_int_operand" "r,r,r,r,r,r,i,i,i,i,i,i")]
+	  (match_operand 4 "pmode_reg_or_uimm5_operand" "r,r,r,r,r,r,K,K,K,K,K,K")]
 	  UNSPEC_ARCV_VNSRA))
 	(match_operand:<V_QUAD_TRUNC> 2 "vector_merge_operand"     "vu,0,vu,0,vu,0,vu,0,vu,0,vu,0")))]
   "TARGET_XARCVVDSP"
@@ -614,7 +614,7 @@
 	(truncate:<V_DOUBLE_TRUNC>
 	  (unspec:VWEXTI
 	  [(match_operand:VWEXTI 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
-	  (match_operand:SI 4 "reg_or_int_operand" "r,r,r,r,r,r,i,i,i,i,i,i")]
+	  (match_operand 4 "pmode_reg_or_uimm5_operand" "r,r,r,r,r,r,K,K,K,K,K,K")]
 	  UNSPEC_ARCV_VNSRA_S))
 	(match_operand:<V_DOUBLE_TRUNC> 2 "vector_merge_operand"     "vu,0,vu,0,vu,0,vu,0,vu,0,vu,0")))]
   "TARGET_XARCVVDSP"
@@ -638,7 +638,7 @@
 	(truncate:<V_QUAD_TRUNC>
 	  (unspec:VQEXTI
 	  [(match_operand:VQEXTI 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
-	  (match_operand:SI 4 "reg_or_int_operand" "r,r,r,r,r,r,i,i,i,i,i,i")]
+	  (match_operand 4 "pmode_reg_or_uimm5_operand" "r,r,r,r,r,r,K,K,K,K,K,K")]
 	  UNSPEC_ARCV_VNSRA_S))
 	(match_operand:<V_QUAD_TRUNC> 2 "vector_merge_operand"     "vu,0,vu,0,vu,0,vu,0,vu,0,vu,0")))]
   "TARGET_XARCVVDSP"
@@ -712,7 +712,7 @@
 	(truncate:<V_DOUBLE_TRUNC>
 	  (unspec:VWEXTI
 	  [(match_operand:VWEXTI 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
-	  (match_operand:SI 4 "reg_or_int_operand" "r,r,r,r,r,r,i,i,i,i,i,i")]
+	  (match_operand 4 "pmode_reg_or_uimm5_operand" "r,r,r,r,r,r,K,K,K,K,K,K")]
 	  UNSPEC_ARCV_VNSRA_2S))
 	(match_operand:<V_DOUBLE_TRUNC> 2 "vector_merge_operand"     "vu,0,vu,0,vu,0,vu,0,vu,0,vu,0")))]
   "TARGET_XARCVVDSP"
@@ -736,7 +736,7 @@
 	(truncate:<V_QUAD_TRUNC>
 	  (unspec:VQEXTI
 	  [(match_operand:VQEXTI 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
-	  (match_operand:SI 4 "reg_or_int_operand" "r,r,r,r,r,r,i,i,i,i,i,i")]
+	  (match_operand 4 "pmode_reg_or_uimm5_operand" "r,r,r,r,r,r,K,K,K,K,K,K")]
 	  UNSPEC_ARCV_VNSRA_2S))
 	(match_operand:<V_QUAD_TRUNC> 2 "vector_merge_operand"     "vu,0,vu,0,vu,0,vu,0,vu,0,vu,0")))]
   "TARGET_XARCVVDSP"
@@ -785,7 +785,7 @@
 	(unspec:VWEXTI
 	[(sign_extend:VWEXTI
 	  (match_operand:<V_DOUBLE_TRUNC> 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr"))
-	(match_operand:SI 4 "reg_or_int_operand" "r,r,r,r,r,r,i,i,i,i,i,i")]
+	  (match_operand 4 "pmode_reg_or_uimm5_operand" "r,r,r,r,r,r,K,K,K,K,K,K")]
 	  UNSPEC_ARCV_VWSRA)
 	(match_operand:VWEXTI 2 "vector_merge_operand"     "vu,0,vu,0,vu,0,vu,0,vu,0,vu,0")))]
   "TARGET_XARCVVDSP"

--- a/gcc/config/riscv/arcv-vector.md
+++ b/gcc/config/riscv/arcv-vector.md
@@ -451,7 +451,7 @@
    (set_attr "mode" "<MODE>")])
 
 (define_insn "@pred_narrow_arcv_vnsra<mode>"
-  [(set (match_operand:<V_DOUBLE_TRUNC> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+  [(set (match_operand:<V_DOUBLE_TRUNC> 0 "register_operand" "=&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr")
 	(if_then_else:<V_DOUBLE_TRUNC>
 	  (unspec:<VM>
 	    [(match_operand:<VM> 1 "vector_mask_operand" "vm, vm,Wc1, Wc1, vm, vm,Wc1,Wc1, vm, vm,Wc1,Wc1")
@@ -465,7 +465,7 @@
 		 (reg:SI VXRM_REGNUM)] UNSPEC_VPREDICATE)
 	(truncate:<V_DOUBLE_TRUNC>
 	  (unspec:VWEXTI
-	  [(match_operand:VWEXTI 3 "register_operand" "vr,vr,vr,vr,0,0,vr,vr,0,0,vr,vr")
+	  [(match_operand:VWEXTI 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
 	  (sign_extend:VWEXTI
 	    (match_operand:<V_DOUBLE_TRUNC> 4 "vector_shift_operand" "0,0,0,0,vr,vr,vr,vr,vk,vk,vk,vk"))]
 	  UNSPEC_ARCV_VNSRA))
@@ -476,7 +476,7 @@
    (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_quad_narrow_arcv_vnsra<mode>"
-  [(set (match_operand:<V_QUAD_TRUNC> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+  [(set (match_operand:<V_QUAD_TRUNC> 0 "register_operand" "=&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr")
 	(if_then_else:<V_QUAD_TRUNC>
 	  (unspec:<VM>
 	    [(match_operand:<VM> 1 "vector_mask_operand" "vm, vm,Wc1, Wc1, vm, vm,Wc1,Wc1, vm, vm,Wc1,Wc1")
@@ -490,7 +490,7 @@
 		 (reg:SI VXRM_REGNUM)] UNSPEC_VPREDICATE)
 	(truncate:<V_QUAD_TRUNC>
 	  (unspec:VQEXTI
-	  [(match_operand:VQEXTI 3 "register_operand" "vr,vr,vr,vr,0,0,vr,vr,0,0,vr,vr")
+	  [(match_operand:VQEXTI 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
 	  (sign_extend:VQEXTI
 	    (match_operand:<V_QUAD_TRUNC> 4 "vector_shift_operand" "0,0,0,0,vr,vr,vr,vr,vk,vk,vk,vk"))]
 	  UNSPEC_ARCV_VNSRA))
@@ -501,7 +501,7 @@
    (set_attr "mode" "<V_QUAD_TRUNC>")])
 
 (define_insn "@pred_narrow_arcv_vnsra_scalar<mode>"
-  [(set (match_operand:<V_DOUBLE_TRUNC> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+  [(set (match_operand:<V_DOUBLE_TRUNC> 0 "register_operand" "=&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr")
 	(if_then_else:<V_DOUBLE_TRUNC>
 	  (unspec:<VM>
 	    [(match_operand:<VM> 1 "vector_mask_operand" "vm, vm,Wc1, Wc1, vm, vm,Wc1,Wc1, vm, vm,Wc1,Wc1")
@@ -515,7 +515,7 @@
 		 (reg:SI VXRM_REGNUM)] UNSPEC_VPREDICATE)
 	(truncate:<V_DOUBLE_TRUNC>
 	  (unspec:VWEXTI
-	  [(match_operand:VWEXTI 3 "register_operand" "vr,vr,vr,vr,0,0,vr,vr,0,0,vr,vr")
+	  [(match_operand:VWEXTI 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
 	  (match_operand:SI 4 "reg_or_int_operand" "r,r,r,r,r,r,i,i,i,i,i,i")]
 	  UNSPEC_ARCV_VNSRA))
 	(match_operand:<V_DOUBLE_TRUNC> 2 "vector_merge_operand"     "vu,0,vu,0,vu,0,vu,0,vu,0,vu,0")))]
@@ -525,7 +525,7 @@
    (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_quad_narrow_arcv_vnsra_scalar<mode>"
-  [(set (match_operand:<V_QUAD_TRUNC> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+  [(set (match_operand:<V_QUAD_TRUNC> 0 "register_operand" "=&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr")
 	(if_then_else:<V_QUAD_TRUNC>
 	  (unspec:<VM>
 	    [(match_operand:<VM> 1 "vector_mask_operand" "vm, vm,Wc1, Wc1, vm, vm,Wc1,Wc1, vm, vm,Wc1,Wc1")
@@ -539,7 +539,7 @@
 		 (reg:SI VXRM_REGNUM)] UNSPEC_VPREDICATE)
 	(truncate:<V_QUAD_TRUNC>
 	  (unspec:VQEXTI
-	  [(match_operand:VQEXTI 3 "register_operand" "vr,vr,vr,vr,0,0,vr,vr,0,0,vr,vr")
+	  [(match_operand:VQEXTI 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
 	  (match_operand:SI 4 "reg_or_int_operand" "r,r,r,r,r,r,i,i,i,i,i,i")]
 	  UNSPEC_ARCV_VNSRA))
 	(match_operand:<V_QUAD_TRUNC> 2 "vector_merge_operand"     "vu,0,vu,0,vu,0,vu,0,vu,0,vu,0")))]
@@ -549,7 +549,7 @@
    (set_attr "mode" "<V_QUAD_TRUNC>")])
 
 (define_insn "@pred_narrow_arcv_vnsra_s<mode>"
-  [(set (match_operand:<V_DOUBLE_TRUNC> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+  [(set (match_operand:<V_DOUBLE_TRUNC> 0 "register_operand" "=&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr")
 	(if_then_else:<V_DOUBLE_TRUNC>
 	  (unspec:<VM>
 	    [(match_operand:<VM> 1 "vector_mask_operand" "vm, vm,Wc1, Wc1, vm, vm,Wc1,Wc1, vm, vm,Wc1,Wc1")
@@ -563,7 +563,7 @@
 		 (reg:SI VXRM_REGNUM)] UNSPEC_VPREDICATE)
 	(truncate:<V_DOUBLE_TRUNC>
 	  (unspec:VWEXTI
-	  [(match_operand:VWEXTI 3 "register_operand" "vr,vr,vr,vr,0,0,vr,vr,0,0,vr,vr")
+	  [(match_operand:VWEXTI 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
 	  (sign_extend:VWEXTI
 	    (match_operand:<V_DOUBLE_TRUNC> 4 "vector_shift_operand" "0,0,0,0,vr,vr,vr,vr,vk,vk,vk,vk"))]
 	  UNSPEC_ARCV_VNSRA_S))
@@ -574,7 +574,7 @@
    (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_quad_narrow_arcv_vnsra_s<mode>"
-  [(set (match_operand:<V_QUAD_TRUNC> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+  [(set (match_operand:<V_QUAD_TRUNC> 0 "register_operand" "=&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr")
 	(if_then_else:<V_QUAD_TRUNC>
 	  (unspec:<VM>
 	    [(match_operand:<VM> 1 "vector_mask_operand" "vm, vm,Wc1, Wc1, vm, vm,Wc1,Wc1, vm, vm,Wc1,Wc1")
@@ -588,7 +588,7 @@
 		 (reg:SI VXRM_REGNUM)] UNSPEC_VPREDICATE)
 	(truncate:<V_QUAD_TRUNC>
 	  (unspec:VQEXTI
-	  [(match_operand:VQEXTI 3 "register_operand" "vr,vr,vr,vr,0,0,vr,vr,0,0,vr,vr")
+	  [(match_operand:VQEXTI 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
 	  (sign_extend:VQEXTI
 	    (match_operand:<V_QUAD_TRUNC> 4 "vector_shift_operand" "0,0,0,0,vr,vr,vr,vr,vk,vk,vk,vk"))]
 	  UNSPEC_ARCV_VNSRA_S))
@@ -599,7 +599,7 @@
    (set_attr "mode" "<V_QUAD_TRUNC>")])
 
 (define_insn "@pred_narrow_arcv_vnsra_s_scalar<mode>"
-  [(set (match_operand:<V_DOUBLE_TRUNC> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+  [(set (match_operand:<V_DOUBLE_TRUNC> 0 "register_operand" "=&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr")
 	(if_then_else:<V_DOUBLE_TRUNC>
 	  (unspec:<VM>
 	    [(match_operand:<VM> 1 "vector_mask_operand" "vm, vm,Wc1, Wc1, vm, vm,Wc1,Wc1, vm, vm,Wc1,Wc1")
@@ -613,7 +613,7 @@
 		 (reg:SI VXRM_REGNUM)] UNSPEC_VPREDICATE)
 	(truncate:<V_DOUBLE_TRUNC>
 	  (unspec:VWEXTI
-	  [(match_operand:VWEXTI 3 "register_operand" "vr,vr,vr,vr,0,0,vr,vr,0,0,vr,vr")
+	  [(match_operand:VWEXTI 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
 	  (match_operand:SI 4 "reg_or_int_operand" "r,r,r,r,r,r,i,i,i,i,i,i")]
 	  UNSPEC_ARCV_VNSRA_S))
 	(match_operand:<V_DOUBLE_TRUNC> 2 "vector_merge_operand"     "vu,0,vu,0,vu,0,vu,0,vu,0,vu,0")))]
@@ -623,7 +623,7 @@
    (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_quad_narrow_arcv_vnsra_s_scalar<mode>"
-  [(set (match_operand:<V_QUAD_TRUNC> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+  [(set (match_operand:<V_QUAD_TRUNC> 0 "register_operand" "=&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr")
 	(if_then_else:<V_QUAD_TRUNC>
 	  (unspec:<VM>
 	    [(match_operand:<VM> 1 "vector_mask_operand" "vm, vm,Wc1, Wc1, vm, vm,Wc1,Wc1, vm, vm,Wc1,Wc1")
@@ -637,7 +637,7 @@
 		 (reg:SI VXRM_REGNUM)] UNSPEC_VPREDICATE)
 	(truncate:<V_QUAD_TRUNC>
 	  (unspec:VQEXTI
-	  [(match_operand:VQEXTI 3 "register_operand" "vr,vr,vr,vr,0,0,vr,vr,0,0,vr,vr")
+	  [(match_operand:VQEXTI 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
 	  (match_operand:SI 4 "reg_or_int_operand" "r,r,r,r,r,r,i,i,i,i,i,i")]
 	  UNSPEC_ARCV_VNSRA_S))
 	(match_operand:<V_QUAD_TRUNC> 2 "vector_merge_operand"     "vu,0,vu,0,vu,0,vu,0,vu,0,vu,0")))]
@@ -647,7 +647,7 @@
    (set_attr "mode" "<V_QUAD_TRUNC>")])
 
 (define_insn "@pred_narrow_arcv_vnsra_2s<mode>"
-  [(set (match_operand:<V_DOUBLE_TRUNC> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+  [(set (match_operand:<V_DOUBLE_TRUNC> 0 "register_operand" "=&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr")
 	(if_then_else:<V_DOUBLE_TRUNC>
 	  (unspec:<VM>
 	    [(match_operand:<VM> 1 "vector_mask_operand" "vm, vm,Wc1, Wc1, vm, vm,Wc1,Wc1, vm, vm,Wc1,Wc1")
@@ -661,7 +661,7 @@
 		 (reg:SI VXRM_REGNUM)] UNSPEC_VPREDICATE)
 	(truncate:<V_DOUBLE_TRUNC>
 	  (unspec:VWEXTI
-	  [(match_operand:VWEXTI 3 "register_operand" "vr,vr,vr,vr,0,0,vr,vr,0,0,vr,vr")
+	  [(match_operand:VWEXTI 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
 	  (sign_extend:VWEXTI
 	    (match_operand:<V_DOUBLE_TRUNC> 4 "vector_shift_operand" "0,0,0,0,vr,vr,vr,vr,vk,vk,vk,vk"))]
 	  UNSPEC_ARCV_VNSRA_2S))
@@ -672,7 +672,7 @@
    (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_quad_narrow_arcv_vnsra_2s<mode>"
-  [(set (match_operand:<V_QUAD_TRUNC> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+  [(set (match_operand:<V_QUAD_TRUNC> 0 "register_operand" "=&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr")
 	(if_then_else:<V_QUAD_TRUNC>
 	  (unspec:<VM>
 	    [(match_operand:<VM> 1 "vector_mask_operand" "vm, vm,Wc1, Wc1, vm, vm,Wc1,Wc1, vm, vm,Wc1,Wc1")
@@ -686,7 +686,7 @@
 		 (reg:SI VXRM_REGNUM)] UNSPEC_VPREDICATE)
 	(truncate:<V_QUAD_TRUNC>
 	  (unspec:VQEXTI
-	  [(match_operand:VQEXTI 3 "register_operand" "vr,vr,vr,vr,0,0,vr,vr,0,0,vr,vr")
+	  [(match_operand:VQEXTI 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
 	  (sign_extend:VQEXTI
 	    (match_operand:<V_QUAD_TRUNC> 4 "vector_shift_operand" "0,0,0,0,vr,vr,vr,vr,vk,vk,vk,vk"))]
 	  UNSPEC_ARCV_VNSRA_2S))
@@ -697,7 +697,7 @@
    (set_attr "mode" "<V_QUAD_TRUNC>")])
 
 (define_insn "@pred_narrow_arcv_vnsra_2s_scalar<mode>"
-  [(set (match_operand:<V_DOUBLE_TRUNC> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+  [(set (match_operand:<V_DOUBLE_TRUNC> 0 "register_operand" "=&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr")
 	(if_then_else:<V_DOUBLE_TRUNC>
 	  (unspec:<VM>
 	    [(match_operand:<VM> 1 "vector_mask_operand" "vm, vm,Wc1, Wc1, vm, vm,Wc1,Wc1, vm, vm,Wc1,Wc1")
@@ -711,7 +711,7 @@
 		 (reg:SI VXRM_REGNUM)] UNSPEC_VPREDICATE)
 	(truncate:<V_DOUBLE_TRUNC>
 	  (unspec:VWEXTI
-	  [(match_operand:VWEXTI 3 "register_operand" "vr,vr,vr,vr,0,0,vr,vr,0,0,vr,vr")
+	  [(match_operand:VWEXTI 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
 	  (match_operand:SI 4 "reg_or_int_operand" "r,r,r,r,r,r,i,i,i,i,i,i")]
 	  UNSPEC_ARCV_VNSRA_2S))
 	(match_operand:<V_DOUBLE_TRUNC> 2 "vector_merge_operand"     "vu,0,vu,0,vu,0,vu,0,vu,0,vu,0")))]
@@ -721,7 +721,7 @@
    (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_quad_narrow_arcv_vnsra_2s_scalar<mode>"
-  [(set (match_operand:<V_QUAD_TRUNC> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+  [(set (match_operand:<V_QUAD_TRUNC> 0 "register_operand" "=&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr")
 	(if_then_else:<V_QUAD_TRUNC>
 	  (unspec:<VM>
 	    [(match_operand:<VM> 1 "vector_mask_operand" "vm, vm,Wc1, Wc1, vm, vm,Wc1,Wc1, vm, vm,Wc1,Wc1")
@@ -735,7 +735,7 @@
 		 (reg:SI VXRM_REGNUM)] UNSPEC_VPREDICATE)
 	(truncate:<V_QUAD_TRUNC>
 	  (unspec:VQEXTI
-	  [(match_operand:VQEXTI 3 "register_operand" "vr,vr,vr,vr,0,0,vr,vr,0,0,vr,vr")
+	  [(match_operand:VQEXTI 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
 	  (match_operand:SI 4 "reg_or_int_operand" "r,r,r,r,r,r,i,i,i,i,i,i")]
 	  UNSPEC_ARCV_VNSRA_2S))
 	(match_operand:<V_QUAD_TRUNC> 2 "vector_merge_operand"     "vu,0,vu,0,vu,0,vu,0,vu,0,vu,0")))]
@@ -745,7 +745,7 @@
    (set_attr "mode" "<V_QUAD_TRUNC>")])
 
 (define_insn "@pred_widen_arcv_vwsra<mode>"
-  [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+  [(set (match_operand:VWEXTI 0 "register_operand" "=&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr")
 	(if_then_else:VWEXTI
 	  (unspec:<VM>
 	    [(match_operand:<VM> 1 "vector_mask_operand" "vm, vm,Wc1, Wc1, vm, vm,Wc1,Wc1, vm, vm,Wc1,Wc1")
@@ -770,7 +770,7 @@
    (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_arcv_vwsra_scalar<mode>"
-  [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+  [(set (match_operand:VWEXTI 0 "register_operand" "=&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr")
 	(if_then_else:VWEXTI
 	  (unspec:<VM>
 	    [(match_operand:<VM> 1 "vector_mask_operand" "vm, vm,Wc1, Wc1, vm, vm,Wc1,Wc1, vm, vm,Wc1,Wc1")
@@ -1197,7 +1197,7 @@
    (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_half_arcv_vwmul<mode>"
-  [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+  [(set (match_operand:VQEXTI 0 "register_operand" "=&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr")
 	(if_then_else:VQEXTI
 	  (unspec:<VM>
 	    [(match_operand:<VM> 1 "vector_mask_operand" "vm, vm,Wc1, Wc1, vm, vm,Wc1,Wc1, vm, vm,Wc1,Wc1")
@@ -1209,7 +1209,7 @@
 	     (reg:SI VTYPE_REGNUM)] UNSPEC_VPREDICATE)
 	  (unspec:VQEXTI
 	    [(sign_extend:VQEXTI
-	      (match_operand:<V_QUAD_TRUNC> 3 "register_operand" "vr,vr,vr,vr,0,0,vr,vr,0,0,vr,vr"))
+	      (match_operand:<V_QUAD_TRUNC> 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr"))
 	     (sign_extend:VQEXTI
 	      (match_operand:<V_DOUBLE_TRUNC> 4 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr"))]
 	  UNSPEC_ARCV_VWMUL)
@@ -1220,7 +1220,7 @@
    (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_half_arcv_vwmul_scalar<mode>"
-  [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+  [(set (match_operand:VQEXTI 0 "register_operand" "=&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr")
 	(if_then_else:VQEXTI
 	  (unspec:<VM>
 	    [(match_operand:<VM> 1 "vector_mask_operand" "vm, vm,Wc1, Wc1, vm, vm,Wc1,Wc1, vm, vm,Wc1,Wc1")
@@ -1232,7 +1232,7 @@
 	     (reg:SI VTYPE_REGNUM)] UNSPEC_VPREDICATE)
 	  (unspec:VQEXTI
 	    [(sign_extend:VQEXTI
-	      (match_operand:<V_QUAD_TRUNC> 3 "register_operand" "vr,vr,vr,vr,0,0,vr,vr,0,0,vr,vr"))
+	      (match_operand:<V_QUAD_TRUNC> 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr"))
 	     (match_operand:<VSUBEL> 4 "register_operand" "r,r,r,r,r,r,r,r,r,r,r,r")]
 	  UNSPEC_ARCV_VWMUL)
 	(match_operand:VQEXTI 2 "vector_merge_operand"     "vu,0,vu,0,vu,0,vu,0,vu,0,vu,0")))]
@@ -1289,7 +1289,7 @@
    (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_half_arcv_vwmulu<mode>"
-  [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+  [(set (match_operand:VQEXTI 0 "register_operand" "=&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr")
 	(if_then_else:VQEXTI
 	  (unspec:<VM>
 	    [(match_operand:<VM> 1 "vector_mask_operand" "vm, vm,Wc1, Wc1, vm, vm,Wc1,Wc1, vm, vm,Wc1,Wc1")
@@ -1301,7 +1301,7 @@
 	     (reg:SI VTYPE_REGNUM)] UNSPEC_VPREDICATE)
 	  (unspec:VQEXTI
 	    [(sign_extend:VQEXTI
-	      (match_operand:<V_QUAD_TRUNC> 3 "register_operand" "vr,vr,vr,vr,0,0,vr,vr,0,0,vr,vr"))
+	      (match_operand:<V_QUAD_TRUNC> 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr"))
 	     (sign_extend:VQEXTI
 	      (match_operand:<V_DOUBLE_TRUNC> 4 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr"))]
 	  UNSPEC_ARCV_VWMULU)
@@ -1312,7 +1312,7 @@
    (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_half_arcv_vwmulu_scalar<mode>"
-  [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+  [(set (match_operand:VQEXTI 0 "register_operand" "=&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr")
 	(if_then_else:VQEXTI
 	  (unspec:<VM>
 	    [(match_operand:<VM> 1 "vector_mask_operand" "vm, vm,Wc1, Wc1, vm, vm,Wc1,Wc1, vm, vm,Wc1,Wc1")
@@ -1324,7 +1324,7 @@
 	     (reg:SI VTYPE_REGNUM)] UNSPEC_VPREDICATE)
 	  (unspec:VQEXTI
 	    [(sign_extend:VQEXTI
-	      (match_operand:<V_QUAD_TRUNC> 3 "register_operand" "vr,vr,vr,vr,0,0,vr,vr,0,0,vr,vr"))
+	      (match_operand:<V_QUAD_TRUNC> 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr"))
 	     (match_operand:<VSUBEL> 4 "register_operand" "r,r,r,r,r,r,r,r,r,r,r,r")]
 	  UNSPEC_ARCV_VWMULU)
 	(match_operand:VQEXTI 2 "vector_merge_operand"     "vu,0,vu,0,vu,0,vu,0,vu,0,vu,0")))]
@@ -1381,7 +1381,7 @@
    (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_half_arcv_vsmulf<mode>"
-  [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+  [(set (match_operand:VWEXTI 0 "register_operand" "=&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr")
 	(if_then_else:VWEXTI
 	  (unspec:<VM>
 	    [(match_operand:<VM> 1 "vector_mask_operand" "vm, vm,Wc1, Wc1, vm, vm,Wc1,Wc1, vm, vm,Wc1,Wc1")
@@ -1395,7 +1395,7 @@
 		 (reg:SI VXRM_REGNUM)] UNSPEC_VPREDICATE)
 	  (unspec:VWEXTI
 	    [(sign_extend:VWEXTI
-	      (match_operand:<V_DOUBLE_TRUNC> 3 "register_operand" "vr,vr,vr,vr,0,0,vr,vr,0,0,vr,vr"))
+	      (match_operand:<V_DOUBLE_TRUNC> 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr"))
 	     (match_operand:VWEXTI 4 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")]
 	  UNSPEC_ARCV_VSMULF)
 	(match_operand:VWEXTI 2 "vector_merge_operand"     "vu,0,vu,0,vu,0,vu,0,vu,0,vu,0")))]
@@ -1405,7 +1405,7 @@
    (set_attr "mode" "<MODE>")])
 
 (define_insn "@pred_half_arcv_vsmulf_scalar<mode>"
-  [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+  [(set (match_operand:VWEXTI 0 "register_operand" "=&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr")
 	(if_then_else:VWEXTI
 	  (unspec:<VM>
 	    [(match_operand:<VM> 1 "vector_mask_operand" "vm, vm,Wc1, Wc1, vm, vm,Wc1,Wc1, vm, vm,Wc1,Wc1")
@@ -1419,7 +1419,7 @@
 		 (reg:SI VXRM_REGNUM)] UNSPEC_VPREDICATE)
 	  (unspec:VWEXTI
 	    [(sign_extend:VWEXTI
-	      (match_operand:<V_DOUBLE_TRUNC> 3 "register_operand" "vr,vr,vr,vr,0,0,vr,vr,0,0,vr,vr"))
+	      (match_operand:<V_DOUBLE_TRUNC> 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr"))
 	     (match_operand:<VEL> 4 "register_operand" "r,r,r,r,r,r,r,r,r,r,r,r")]
 	  UNSPEC_ARCV_VSMULF)
 	(match_operand:VWEXTI 2 "vector_merge_operand"     "vu,0,vu,0,vu,0,vu,0,vu,0,vu,0")))]
@@ -1429,7 +1429,7 @@
    (set_attr "mode" "<MODE>")])
 
 (define_insn "@pred_widen_half_arcv_vwmulf<mode>"
-  [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+  [(set (match_operand:VQEXTI 0 "register_operand" "=&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr")
 	(if_then_else:VQEXTI
 	  (unspec:<VM>
 	    [(match_operand:<VM> 1 "vector_mask_operand" "vm, vm,Wc1, Wc1, vm, vm,Wc1,Wc1, vm, vm,Wc1,Wc1")
@@ -1441,7 +1441,7 @@
 	     (reg:SI VTYPE_REGNUM)] UNSPEC_VPREDICATE)
 	  (unspec:VQEXTI
 	    [(sign_extend:VQEXTI
-	      (match_operand:<V_QUAD_TRUNC> 3 "register_operand" "vr,vr,vr,vr,0,0,vr,vr,0,0,vr,vr"))
+	      (match_operand:<V_QUAD_TRUNC> 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr"))
 	     (sign_extend:VQEXTI
 	      (match_operand:<V_DOUBLE_TRUNC> 4 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr"))]
 	  UNSPEC_ARCV_VWMULF)
@@ -1452,7 +1452,7 @@
    (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_half_arcv_vwmulf_scalar<mode>"
-  [(set (match_operand:VQEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+  [(set (match_operand:VQEXTI 0 "register_operand" "=&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr")
 	(if_then_else:VQEXTI
 	  (unspec:<VM>
 	    [(match_operand:<VM> 1 "vector_mask_operand" "vm, vm,Wc1, Wc1, vm, vm,Wc1,Wc1, vm, vm,Wc1,Wc1")
@@ -1464,7 +1464,7 @@
 	     (reg:SI VTYPE_REGNUM)] UNSPEC_VPREDICATE)
 	  (unspec:VQEXTI
 	    [(sign_extend:VQEXTI
-	      (match_operand:<V_QUAD_TRUNC> 3 "register_operand" "vr,vr,vr,vr,0,0,vr,vr,0,0,vr,vr"))
+	      (match_operand:<V_QUAD_TRUNC> 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr"))
 	     (match_operand:<VSUBEL> 4 "register_operand" "r,r,r,r,r,r,r,r,r,r,r,r")]
 	  UNSPEC_ARCV_VWMULF)
 	(match_operand:VQEXTI 2 "vector_merge_operand"     "vu,0,vu,0,vu,0,vu,0,vu,0,vu,0")))]
@@ -1866,7 +1866,7 @@
    (set_attr "mode" "<MODE>")])
 
 (define_insn "@pred_widen_arcv_vwscmul<mode>"
-  [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+  [(set (match_operand:VWEXTI 0 "register_operand" "=&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr")
 	(if_then_else:VWEXTI
 	  (unspec:<VM>
 	    [(match_operand:<VM> 1 "vector_mask_operand" "vm, vm,Wc1, Wc1, vm, vm,Wc1,Wc1, vm, vm,Wc1,Wc1")
@@ -1889,7 +1889,7 @@
    (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_arcv_vwscmul_scalar<mode>"
-  [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+  [(set (match_operand:VWEXTI 0 "register_operand" "=&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr")
 	(if_then_else:VWEXTI
 	  (unspec:<VM>
 	    [(match_operand:<VM> 1 "vector_mask_operand" "vm, vm,Wc1, Wc1, vm, vm,Wc1,Wc1, vm, vm,Wc1,Wc1")
@@ -1911,7 +1911,7 @@
    (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_arcv_vwscjmul<mode>"
-  [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+  [(set (match_operand:VWEXTI 0 "register_operand" "=&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr")
 	(if_then_else:VWEXTI
 	  (unspec:<VM>
 	    [(match_operand:<VM> 1 "vector_mask_operand" "vm, vm,Wc1, Wc1, vm, vm,Wc1,Wc1, vm, vm,Wc1,Wc1")
@@ -1934,7 +1934,7 @@
    (set_attr "mode" "<V_DOUBLE_TRUNC>")])
 
 (define_insn "@pred_widen_arcv_vwscjmul_scalar<mode>"
-  [(set (match_operand:VWEXTI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+  [(set (match_operand:VWEXTI 0 "register_operand" "=&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr,&vd,&vd,&vr,&vr")
 	(if_then_else:VWEXTI
 	  (unspec:<VM>
 	    [(match_operand:<VM> 1 "vector_mask_operand" "vm, vm,Wc1, Wc1, vm, vm,Wc1,Wc1, vm, vm,Wc1,Wc1")

--- a/gcc/testsuite/gcc.target/riscv/arcv-mxmb-vqmxm4_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-mxmb-vqmxm4_vv-compile-1.c
@@ -1,13 +1,31 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_mxmb } */
-/* { dg-options "-march=rv32im_xarcvmxmb -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvmxmb -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m4_t test_vqmxm4_vv_i8 (vint32m4_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqmxm4_vv_i32m4 (vd, vs1, vs2, vl); }
-vint32m4_t test_vqmxm4_vv_i8_m (vbool8_t mask, vint32m4_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqmxm4_vv_i32m4_m (mask, vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vqmxm4\\.vv" 2 } } */
+/*
+** test_vqmxm4_vv_i8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vqmxm4\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m4_t test_vqmxm4_vv_i8 (vint32m4_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqmxm4_vv_i32m4 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vqmxm4_vv_i8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vqmxm4\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m4_t test_vqmxm4_vv_i8_m (vbool8_t mask, vint32m4_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqmxm4_vv_i32m4_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-mxmb-vqmxm4su_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-mxmb-vqmxm4su_vv-compile-1.c
@@ -1,13 +1,31 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_mxmb } */
-/* { dg-options "-march=rv32im_xarcvmxmb -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvmxmb -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m4_t test_vqmxm4su_vv_i8 (vint32m4_t vd, vint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqmxm4su_vv_i32m4 (vd, vs1, vs2, vl); }
-vint32m4_t test_vqmxm4su_vv_i8_m (vbool8_t mask, vint32m4_t vd, vint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqmxm4su_vv_i32m4_m (mask, vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vqmxm4su\\.vv" 2 } } */
+/*
+** test_vqmxm4su_vv_i8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vqmxm4su\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m4_t test_vqmxm4su_vv_i8 (vint32m4_t vd, vint8m1_t vs1, vuint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqmxm4su_vv_i32m4 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vqmxm4su_vv_i8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vqmxm4su\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m4_t test_vqmxm4su_vv_i8_m (vbool8_t mask, vint32m4_t vd, vint8m1_t vs1, vuint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqmxm4su_vv_i32m4_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-mxmb-vqmxm4u_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-mxmb-vqmxm4u_vv-compile-1.c
@@ -1,13 +1,31 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_mxmb } */
-/* { dg-options "-march=rv32im_xarcvmxmb -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvmxmb -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vuint32m4_t test_vqmxm4u_vv_u8 (vuint32m4_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqmxm4u_vv_u32m4 (vd, vs1, vs2, vl); }
-vuint32m4_t test_vqmxm4u_vv_u8_m (vbool8_t mask, vuint32m4_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqmxm4u_vv_u32m4_m (mask, vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vqmxm4u\\.vv" 2 } } */
+/*
+** test_vqmxm4u_vv_u8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vqmxm4u\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vuint32m4_t test_vqmxm4u_vv_u8 (vuint32m4_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqmxm4u_vv_u32m4 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vqmxm4u_vv_u8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vqmxm4u\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vuint32m4_t test_vqmxm4u_vv_u8_m (vbool8_t mask, vuint32m4_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqmxm4u_vv_u32m4_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-mxmc-vqmxm8_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-mxmc-vqmxm8_vv-compile-1.c
@@ -1,13 +1,31 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_mxmc } */
-/* { dg-options "-march=rv32im_xarcvmxmc -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvmxmc -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m4_t test_vqmxm8_vv_i8 (vint32m4_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqmxm8_vv_i32m4 (vd, vs1, vs2, vl); }
-vint32m4_t test_vqmxm8_vv_i8_m (vbool8_t mask, vint32m4_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqmxm8_vv_i32m4_m (mask, vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vqmxm8\\.vv" 2 } } */
+/*
+** test_vqmxm8_vv_i8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vqmxm8\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m4_t test_vqmxm8_vv_i8 (vint32m4_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqmxm8_vv_i32m4 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vqmxm8_vv_i8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vqmxm8\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m4_t test_vqmxm8_vv_i8_m (vbool8_t mask, vint32m4_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqmxm8_vv_i32m4_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-mxmc-vqmxm8su_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-mxmc-vqmxm8su_vv-compile-1.c
@@ -1,13 +1,31 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_mxmc } */
-/* { dg-options "-march=rv32im_xarcvmxmc -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvmxmc -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m4_t test_vqmxm8su_vv_i8 (vint32m4_t vd, vint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqmxm8su_vv_i32m4 (vd, vs1, vs2, vl); }
-vint32m4_t test_vqmxm8su_vv_i8_m (vbool8_t mask, vint32m4_t vd, vint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqmxm8su_vv_i32m4_m (mask, vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vqmxm8su\\.vv" 2 } } */
+/*
+** test_vqmxm8su_vv_i8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vqmxm8su\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m4_t test_vqmxm8su_vv_i8 (vint32m4_t vd, vint8m1_t vs1, vuint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqmxm8su_vv_i32m4 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vqmxm8su_vv_i8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vqmxm8su\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m4_t test_vqmxm8su_vv_i8_m (vbool8_t mask, vint32m4_t vd, vint8m1_t vs1, vuint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqmxm8su_vv_i32m4_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-mxmc-vqmxm8u_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-mxmc-vqmxm8u_vv-compile-1.c
@@ -1,13 +1,31 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_mxmc } */
-/* { dg-options "-march=rv32im_xarcvmxmc -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvmxmc -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vuint32m4_t test_vqmxm8u_vv_u8 (vuint32m4_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqmxm8u_vv_u32m4 (vd, vs1, vs2, vl); }
-vuint32m4_t test_vqmxm8u_vv_u8_m (vbool8_t mask, vuint32m4_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqmxm8u_vv_u32m4_m (mask, vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vqmxm8u\\.vv" 2 } } */
+/*
+** test_vqmxm8u_vv_u8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vqmxm8u\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vuint32m4_t test_vqmxm8u_vv_u8 (vuint32m4_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqmxm8u_vv_u32m4 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vqmxm8u_vv_u8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vqmxm8u\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vuint32m4_t test_vqmxm8u_vv_u8_m (vbool8_t mask, vuint32m4_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqmxm8u_vv_u32m4_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-mxmd-vqmxm16_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-mxmd-vqmxm16_vv-compile-1.c
@@ -1,13 +1,31 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_mxmd } */
-/* { dg-options "-march=rv32im_xarcvmxmd -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvmxmd -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m4_t test_vqmxm16_vv_i8 (vint32m4_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqmxm16_vv_i32m4 (vd, vs1, vs2, vl); }
-vint32m4_t test_vqmxm16_vv_i8_m (vbool8_t mask, vint32m4_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqmxm16_vv_i32m4_m (mask, vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vqmxm16\\.vv" 2 } } */
+/*
+** test_vqmxm16_vv_i8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vqmxm16\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m4_t test_vqmxm16_vv_i8 (vint32m4_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqmxm16_vv_i32m4 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vqmxm16_vv_i8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vqmxm16\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m4_t test_vqmxm16_vv_i8_m (vbool8_t mask, vint32m4_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqmxm16_vv_i32m4_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-mxmd-vqmxm16su_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-mxmd-vqmxm16su_vv-compile-1.c
@@ -1,13 +1,31 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_mxmd } */
-/* { dg-options "-march=rv32im_xarcvmxmd -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvmxmd -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m4_t test_vqmxm16su_vv_i8 (vint32m4_t vd, vint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqmxm16su_vv_i32m4 (vd, vs1, vs2, vl); }
-vint32m4_t test_vqmxm16su_vv_i8_m (vbool8_t mask, vint32m4_t vd, vint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqmxm16su_vv_i32m4_m (mask, vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vqmxm16su\\.vv" 2 } } */
+/*
+** test_vqmxm16su_vv_i8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vqmxm16su\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m4_t test_vqmxm16su_vv_i8 (vint32m4_t vd, vint8m1_t vs1, vuint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqmxm16su_vv_i32m4 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vqmxm16su_vv_i8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vqmxm16su\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m4_t test_vqmxm16su_vv_i8_m (vbool8_t mask, vint32m4_t vd, vint8m1_t vs1, vuint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqmxm16su_vv_i32m4_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-mxmd-vqmxm16u_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-mxmd-vqmxm16u_vv-compile-1.c
@@ -1,13 +1,31 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_mxmd } */
-/* { dg-options "-march=rv32im_xarcvmxmd -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvmxmd -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vuint32m4_t test_vqmxm16u_vv_u8 (vuint32m4_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqmxm16u_vv_u32m4 (vd, vs1, vs2, vl); }
-vuint32m4_t test_vqmxm16u_vv_u8_m (vbool8_t mask, vuint32m4_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqmxm16u_vv_u32m4_m (mask, vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vqmxm16u\\.vv" 2 } } */
+/*
+** test_vqmxm16u_vv_u8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vqmxm16u\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vuint32m4_t test_vqmxm16u_vv_u8 (vuint32m4_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqmxm16u_vv_u32m4 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vqmxm16u_vv_u8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vqmxm16u\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vuint32m4_t test_vqmxm16u_vv_u8_m (vbool8_t mask, vuint32m4_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqmxm16u_vv_u32m4_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vcmuli_v-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vcmuli_v-compile-1.c
@@ -1,17 +1,53 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint16m1_t test_vcmuli_v_i16 (vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vcmuli_v_i16m1 (vs2, vl); }
-vint16m1_t test_vcmuli_v_i16_m (vbool16_t mask, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vcmuli_v_i16m1_m (mask, vs2, vl); }
-vint32m1_t test_vcmuli_v_i32 (vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vcmuli_v_i32m1 (vs2, vl); }
-vint32m1_t test_vcmuli_v_i32_m (vbool32_t mask, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vcmuli_v_i32m1_m (mask, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vcmuli\\.v" 4 } } */
+/*
+** test_vcmuli_v_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vcmuli\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint16m1_t test_vcmuli_v_i16 (vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vcmuli_v_i16m1 (vs2, vl);
+}
+
+/*
+** test_vcmuli_v_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vcmuli\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint16m1_t test_vcmuli_v_i16_m (vbool16_t mask, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vcmuli_v_i16m1_m (mask, vs2, vl);
+}
+
+/*
+** test_vcmuli_v_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vcmuli\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m1_t test_vcmuli_v_i32 (vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vcmuli_v_i32m1 (vs2, vl);
+}
+
+/*
+** test_vcmuli_v_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vcmuli\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_vcmuli_v_i32_m (vbool32_t mask, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vcmuli_v_i32m1_m (mask, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vcmulni_v-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vcmulni_v-compile-1.c
@@ -1,17 +1,53 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint16m1_t test_vcmulni_v_i16 (vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vcmulni_v_i16m1 (vs2, vl); }
-vint16m1_t test_vcmulni_v_i16_m (vbool16_t mask, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vcmulni_v_i16m1_m (mask, vs2, vl); }
-vint32m1_t test_vcmulni_v_i32 (vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vcmulni_v_i32m1 (vs2, vl); }
-vint32m1_t test_vcmulni_v_i32_m (vbool32_t mask, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vcmulni_v_i32m1_m (mask, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vcmulni\\.v" 4 } } */
+/*
+** test_vcmulni_v_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vcmulni\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint16m1_t test_vcmulni_v_i16 (vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vcmulni_v_i16m1 (vs2, vl);
+}
+
+/*
+** test_vcmulni_v_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vcmulni\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint16m1_t test_vcmulni_v_i16_m (vbool16_t mask, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vcmulni_v_i16m1_m (mask, vs2, vl);
+}
+
+/*
+** test_vcmulni_v_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vcmulni\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m1_t test_vcmulni_v_i32 (vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vcmulni_v_i32m1 (vs2, vl);
+}
+
+/*
+** test_vcmulni_v_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vcmulni\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_vcmulni_v_i32_m (vbool32_t mask, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vcmulni_v_i32m1_m (mask, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vconj_v-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vconj_v-compile-1.c
@@ -1,17 +1,53 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint16m1_t test_vconj_v_i16 (vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vconj_v_i16m1 (vs2, vl); }
-vint16m1_t test_vconj_v_i16_m (vbool16_t mask, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vconj_v_i16m1_m (mask, vs2, vl); }
-vint32m1_t test_vconj_v_i32 (vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vconj_v_i32m1 (vs2, vl); }
-vint32m1_t test_vconj_v_i32_m (vbool32_t mask, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vconj_v_i32m1_m (mask, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vconj\\.v" 4 } } */
+/*
+** test_vconj_v_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vconj\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint16m1_t test_vconj_v_i16 (vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vconj_v_i16m1 (vs2, vl);
+}
+
+/*
+** test_vconj_v_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vconj\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint16m1_t test_vconj_v_i16_m (vbool16_t mask, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vconj_v_i16m1_m (mask, vs2, vl);
+}
+
+/*
+** test_vconj_v_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vconj\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m1_t test_vconj_v_i32 (vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vconj_v_i32m1 (vs2, vl);
+}
+
+/*
+** test_vconj_v_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vconj\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_vconj_v_i32_m (vbool32_t mask, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vconj_v_i32m1_m (mask, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-veven_v-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-veven_v-compile-1.c
@@ -1,17 +1,53 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint16m1_t test_veven_v_i16 (vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_veven_v_i16m1 (vs2, vl); }
-vint16m1_t test_veven_v_i16_m (vbool16_t mask, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_veven_v_i16m1_m (mask, vs2, vl); }
-vint32m1_t test_veven_v_i32 (vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_veven_v_i32m1 (vs2, vl); }
-vint32m1_t test_veven_v_i32_m (vbool32_t mask, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_veven_v_i32m1_m (mask, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.veven\\.v" 4 } } */
+/*
+** test_veven_v_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.veven\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint16m1_t test_veven_v_i16 (vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_veven_v_i16m1 (vs2, vl);
+}
+
+/*
+** test_veven_v_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.veven\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint16m1_t test_veven_v_i16_m (vbool16_t mask, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_veven_v_i16m1_m (mask, vs2, vl);
+}
+
+/*
+** test_veven_v_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.veven\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m1_t test_veven_v_i32 (vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_veven_v_i32m1 (vs2, vl);
+}
+
+/*
+** test_veven_v_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.veven\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_veven_v_i32_m (vbool32_t mask, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_veven_v_i32m1_m (mask, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vinterleave_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vinterleave_vv-compile-1.c
@@ -1,17 +1,53 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint16m1_t test_vinterleave_vv_i16 (vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
-  return __riscv_arcv_vinterleave_vv_i16m1 (vs2, vs1, vl); }
-vint16m1_t test_vinterleave_vv_i16_m (vbool16_t mask, vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
-  return __riscv_arcv_vinterleave_vv_i16m1_m (mask, vs2, vs1, vl); }
-vint32m1_t test_vinterleave_vv_i32 (vint32m1_t vs2, vint32m1_t vs1, size_t vl) {
-  return __riscv_arcv_vinterleave_vv_i32m1 (vs2, vs1, vl); }
-vint32m1_t test_vinterleave_vv_i32_m (vbool32_t mask, vint32m1_t vs2, vint32m1_t vs1, size_t vl) {
-  return __riscv_arcv_vinterleave_vv_i32m1_m (mask, vs2, vs1, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vinterleave\\.vv" 4 } } */
+/*
+** test_vinterleave_vv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vinterleave\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint16m1_t test_vinterleave_vv_i16 (vint16m1_t vs2, vint16m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vinterleave_vv_i16m1 (vs2, vs1, vl);
+}
+
+/*
+** test_vinterleave_vv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vinterleave\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint16m1_t test_vinterleave_vv_i16_m (vbool16_t mask, vint16m1_t vs2, vint16m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vinterleave_vv_i16m1_m (mask, vs2, vs1, vl);
+}
+
+/*
+** test_vinterleave_vv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vinterleave\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m1_t test_vinterleave_vv_i32 (vint32m1_t vs2, vint32m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vinterleave_vv_i32m1 (vs2, vs1, vl);
+}
+
+/*
+** test_vinterleave_vv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vinterleave\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_vinterleave_vv_i32_m (vbool32_t mask, vint32m1_t vs2, vint32m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vinterleave_vv_i32m1_m (mask, vs2, vs1, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vodd_v-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vodd_v-compile-1.c
@@ -1,17 +1,53 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint16m1_t test_vodd_v_i16 (vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vodd_v_i16m1 (vs2, vl); }
-vint16m1_t test_vodd_v_i16_m (vbool16_t mask, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vodd_v_i16m1_m (mask, vs2, vl); }
-vint32m1_t test_vodd_v_i32 (vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vodd_v_i32m1 (vs2, vl); }
-vint32m1_t test_vodd_v_i32_m (vbool32_t mask, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vodd_v_i32m1_m (mask, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vodd\\.v" 4 } } */
+/*
+** test_vodd_v_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vodd\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint16m1_t test_vodd_v_i16 (vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vodd_v_i16m1 (vs2, vl);
+}
+
+/*
+** test_vodd_v_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vodd\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint16m1_t test_vodd_v_i16_m (vbool16_t mask, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vodd_v_i16m1_m (mask, vs2, vl);
+}
+
+/*
+** test_vodd_v_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vodd\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m1_t test_vodd_v_i32 (vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vodd_v_i32m1 (vs2, vl);
+}
+
+/*
+** test_vodd_v_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vodd\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_vodd_v_i32_m (vbool32_t mask, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vodd_v_i32m1_m (mask, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vqcjrdot_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vqcjrdot_vv-compile-1.c
@@ -1,13 +1,31 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint64m1_t test_vqcjrdot_vv_i16 (vint64m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqcjrdot_vv_i16m1_i64m1 (vd, vs1, vs2, vl); }
-vint64m1_t test_vqcjrdot_vv_i16_m (vbool16_t mask, vint64m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqcjrdot_vv_i16m1_i64m1_m (mask, vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vqcjrdot\\.vv" 2 } } */
+/*
+** test_vqcjrdot_vv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vqcjrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint64m1_t test_vqcjrdot_vv_i16 (vint64m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqcjrdot_vv_i16m1_i64m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vqcjrdot_vv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vqcjrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint64m1_t test_vqcjrdot_vv_i16_m (vbool16_t mask, vint64m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqcjrdot_vv_i16m1_i64m1_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vqcrdot_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vqcrdot_vv-compile-1.c
@@ -1,13 +1,31 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint64m1_t test_vqcrdot_vv_i16 (vint64m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqcrdot_vv_i16m1_i64m1 (vd, vs1, vs2, vl); }
-vint64m1_t test_vqcrdot_vv_i16_m (vbool16_t mask, vint64m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqcrdot_vv_i16m1_i64m1_m (mask, vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vqcrdot\\.vv" 2 } } */
+/*
+** test_vqcrdot_vv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vqcrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint64m1_t test_vqcrdot_vv_i16 (vint64m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqcrdot_vv_i16m1_i64m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vqcrdot_vv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vqcrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint64m1_t test_vqcrdot_vv_i16_m (vbool16_t mask, vint64m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqcrdot_vv_i16m1_i64m1_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vscredsum_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vscredsum_vv-compile-1.c
@@ -1,21 +1,75 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint16m1_t test_vscredsum_vv_i16 (vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
-  return __riscv_arcv_vscredsum_vv_i16m1_i16m1 (vs2, vs1, vl); }
-vint16m1_t test_vscredsum_vv_i16_m (vbool16_t mask, vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
-  return __riscv_arcv_vscredsum_vv_i16m1_i16m1_m (mask, vs2, vs1, vl); }
-vint32m1_t test_vscredsum_vv_i32 (vint32m1_t vs2, vint32m1_t vs1, size_t vl) {
-  return __riscv_arcv_vscredsum_vv_i32m1_i32m1 (vs2, vs1, vl); }
-vint32m1_t test_vscredsum_vv_i32_m (vbool32_t mask, vint32m1_t vs2, vint32m1_t vs1, size_t vl) {
-  return __riscv_arcv_vscredsum_vv_i32m1_i32m1_m (mask, vs2, vs1, vl); }
-vint64m1_t test_vscredsum_vv_i64 (vint64m1_t vs2, vint64m1_t vs1, size_t vl) {
-  return __riscv_arcv_vscredsum_vv_i64m1_i64m1 (vs2, vs1, vl); }
-vint64m1_t test_vscredsum_vv_i64_m (vbool64_t mask, vint64m1_t vs2, vint64m1_t vs1, size_t vl) {
-  return __riscv_arcv_vscredsum_vv_i64m1_i64m1_m (mask, vs2, vs1, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vscredsum\\.vv" 6 } } */
+/*
+** test_vscredsum_vv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vscredsum\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint16m1_t test_vscredsum_vv_i16 (vint16m1_t vs2, vint16m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vscredsum_vv_i16m1_i16m1 (vs2, vs1, vl);
+}
+
+/*
+** test_vscredsum_vv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vscredsum\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint16m1_t test_vscredsum_vv_i16_m (vbool16_t mask, vint16m1_t vs2, vint16m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vscredsum_vv_i16m1_i16m1_m (mask, vs2, vs1, vl);
+}
+
+/*
+** test_vscredsum_vv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vscredsum\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m1_t test_vscredsum_vv_i32 (vint32m1_t vs2, vint32m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vscredsum_vv_i32m1_i32m1 (vs2, vs1, vl);
+}
+
+/*
+** test_vscredsum_vv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vscredsum\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_vscredsum_vv_i32_m (vbool32_t mask, vint32m1_t vs2, vint32m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vscredsum_vv_i32m1_i32m1_m (mask, vs2, vs1, vl);
+}
+
+/*
+** test_vscredsum_vv_i64:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m1,\s*t[au],\s*m[au]
+**  arcv\.vscredsum\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint64m1_t test_vscredsum_vv_i64 (vint64m1_t vs2, vint64m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vscredsum_vv_i64m1_i64m1 (vs2, vs1, vl);
+}
+
+/*
+** test_vscredsum_vv_i64_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m1,\s*t[au],\s*m[au]
+**  arcv\.vscredsum\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint64m1_t test_vscredsum_vv_i64_m (vbool64_t mask, vint64m1_t vs2, vint64m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vscredsum_vv_i64m1_i64m1_m (mask, vs2, vs1, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwcredsum_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwcredsum_vv-compile-1.c
@@ -1,17 +1,53 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m1_t test_vwcredsum_vv_i16 (vint16m1_t vs2, vint32m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwcredsum_vv_i16m1_i32m1 (vs2, vs1, vl); }
-vint32m1_t test_vwcredsum_vv_i16_m (vbool16_t mask, vint16m1_t vs2, vint32m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwcredsum_vv_i16m1_i32m1_m (mask, vs2, vs1, vl); }
-vint64m1_t test_vwcredsum_vv_i32 (vint32m1_t vs2, vint64m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwcredsum_vv_i32m1_i64m1 (vs2, vs1, vl); }
-vint64m1_t test_vwcredsum_vv_i32_m (vbool32_t mask, vint32m1_t vs2, vint64m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwcredsum_vv_i32m1_i64m1_m (mask, vs2, vs1, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vwcredsum\\.vv" 4 } } */
+/*
+** test_vwcredsum_vv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vwcredsum\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m1_t test_vwcredsum_vv_i16 (vint16m1_t vs2, vint32m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vwcredsum_vv_i16m1_i32m1 (vs2, vs1, vl);
+}
+
+/*
+** test_vwcredsum_vv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vwcredsum\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_vwcredsum_vv_i16_m (vbool16_t mask, vint16m1_t vs2, vint32m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vwcredsum_vv_i16m1_i32m1_m (mask, vs2, vs1, vl);
+}
+
+/*
+** test_vwcredsum_vv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vwcredsum\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint64m1_t test_vwcredsum_vv_i32 (vint32m1_t vs2, vint64m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vwcredsum_vv_i32m1_i64m1 (vs2, vs1, vl);
+}
+
+/*
+** test_vwcredsum_vv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vwcredsum\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint64m1_t test_vwcredsum_vv_i32_m (vbool32_t mask, vint32m1_t vs2, vint64m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vwcredsum_vv_i32m1_i64m1_m (mask, vs2, vs1, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjmac_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjmac_vv-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m2_t test_vwscjmac_vv_i16 (vint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscjmac_vv_i32m2 (vd, vs1, vs2, vl); }
-vint32m2_t test_vwscjmac_vv_i16_m (vbool16_t mask, vint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscjmac_vv_i32m2_m (mask, vd, vs1, vs2, vl); }
-vint64m2_t test_vwscjmac_vv_i32 (vint64m2_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscjmac_vv_i64m2 (vd, vs1, vs2, vl); }
-vint64m2_t test_vwscjmac_vv_i32_m (vbool32_t mask, vint64m2_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscjmac_vv_i64m2_m (mask, vd, vs1, vs2, vl); }
+/*
+** test_vwscjmac_vv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwscjmac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint32m2_t
+test_vwscjmac_vv_i16 (vint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscjmac_vv_i32m2 (vd, vs1, vs2, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwscjmac\\.vv" 4 } } */
+/*
+** test_vwscjmac_vv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwscjmac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint32m2_t
+test_vwscjmac_vv_i16_m (vbool16_t mask, vint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscjmac_vv_i32m2_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwscjmac_vv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwscjmac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint64m2_t
+test_vwscjmac_vv_i32 (vint64m2_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscjmac_vv_i64m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwscjmac_vv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwscjmac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint64m2_t
+test_vwscjmac_vv_i32_m (vbool32_t mask, vint64m2_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscjmac_vv_i64m2_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjmac_vx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjmac_vx-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m2_t test_vwscjmac_vx_i16 (vint32m2_t vd, int vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscjmac_vx_i32m2 (vd, vs1, vs2, vl); }
-vint32m2_t test_vwscjmac_vx_i16_m (vbool16_t mask, vint32m2_t vd, int vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscjmac_vx_i32m2_m (mask, vd, vs1, vs2, vl); }
-vint64m2_t test_vwscjmac_vx_i32 (vint64m2_t vd, int vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscjmac_vx_i64m2 (vd, vs1, vs2, vl); }
-vint64m2_t test_vwscjmac_vx_i32_m (vbool32_t mask, vint64m2_t vd, int vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscjmac_vx_i64m2_m (mask, vd, vs1, vs2, vl); }
+/*
+** test_vwscjmac_vx_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwscjmac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint32m2_t
+test_vwscjmac_vx_i16 (vint32m2_t vd, int vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscjmac_vx_i32m2 (vd, vs1, vs2, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwscjmac\\.vx" 4 } } */
+/*
+** test_vwscjmac_vx_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwscjmac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint32m2_t
+test_vwscjmac_vx_i16_m (vbool16_t mask, vint32m2_t vd, int vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscjmac_vx_i32m2_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwscjmac_vx_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwscjmac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint64m2_t
+test_vwscjmac_vx_i32 (vint64m2_t vd, int vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscjmac_vx_i64m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwscjmac_vx_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwscjmac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint64m2_t
+test_vwscjmac_vx_i32_m (vbool32_t mask, vint64m2_t vd, int vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscjmac_vx_i64m2_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjmul_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjmul_vv-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m2_t test_vwscjmul_vv_i16 (vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwscjmul_vv_i32m2 (vs2, vs1, vl); }
-vint32m2_t test_vwscjmul_vv_i16_m (vbool16_t mask, vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwscjmul_vv_i32m2_m (mask, vs2, vs1, vl); }
-vint64m2_t test_vwscjmul_vv_i32 (vint32m1_t vs2, vint32m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwscjmul_vv_i64m2 (vs2, vs1, vl); }
-vint64m2_t test_vwscjmul_vv_i32_m (vbool32_t mask, vint32m1_t vs2, vint32m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwscjmul_vv_i64m2_m (mask, vs2, vs1, vl); }
+/*
+** test_vwscjmul_vv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwscjmul.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint32m2_t
+test_vwscjmul_vv_i16 (vint16m1_t vs2, vint16m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vwscjmul_vv_i32m2 (vs2, vs1, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwscjmul\\.vv" 4 } } */
+/*
+** test_vwscjmul_vv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwscjmul.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint32m2_t
+test_vwscjmul_vv_i16_m (vbool16_t mask, vint16m1_t vs2, vint16m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vwscjmul_vv_i32m2_m (mask, vs2, vs1, vl);
+}
+
+/*
+** test_vwscjmul_vv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwscjmul.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint64m2_t
+test_vwscjmul_vv_i32 (vint32m1_t vs2, vint32m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vwscjmul_vv_i64m2 (vs2, vs1, vl);
+}
+
+/*
+** test_vwscjmul_vv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwscjmul.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint64m2_t
+test_vwscjmul_vv_i32_m (vbool32_t mask, vint32m1_t vs2, vint32m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vwscjmul_vv_i64m2_m (mask, vs2, vs1, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjmul_vx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjmul_vx-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m2_t test_vwscjmul_vx_i16 (vint16m1_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vwscjmul_vx_i32m2 (vs2, vs1, vl); }
-vint32m2_t test_vwscjmul_vx_i16_m (vbool16_t mask, vint16m1_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vwscjmul_vx_i32m2_m (mask, vs2, vs1, vl); }
-vint64m2_t test_vwscjmul_vx_i32 (vint32m1_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vwscjmul_vx_i64m2 (vs2, vs1, vl); }
-vint64m2_t test_vwscjmul_vx_i32_m (vbool32_t mask, vint32m1_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vwscjmul_vx_i64m2_m (mask, vs2, vs1, vl); }
+/*
+** test_vwscjmul_vx_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwscjmul.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint32m2_t
+test_vwscjmul_vx_i16 (vint16m1_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vwscjmul_vx_i32m2 (vs2, vs1, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwscjmul\\.vx" 4 } } */
+/*
+** test_vwscjmul_vx_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwscjmul.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**  ret
+*/
+vint32m2_t
+test_vwscjmul_vx_i16_m (vbool16_t mask, vint16m1_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vwscjmul_vx_i32m2_m (mask, vs2, vs1, vl);
+}
+
+/*
+** test_vwscjmul_vx_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwscjmul.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint64m2_t
+test_vwscjmul_vx_i32 (vint32m1_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vwscjmul_vx_i64m2 (vs2, vs1, vl);
+}
+
+/*
+** test_vwscjmul_vx_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwscjmul.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**  ret
+*/
+vint64m2_t
+test_vwscjmul_vx_i32_m (vbool32_t mask, vint32m1_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vwscjmul_vx_i64m2_m (mask, vs2, vs1, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjnmsac_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjnmsac_vv-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m2_t test_vwscjnmsac_vv_i16 (vint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscjnmsac_vv_i32m2 (vd, vs1, vs2, vl); }
-vint32m2_t test_vwscjnmsac_vv_i16_m (vbool16_t mask, vint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscjnmsac_vv_i32m2_m (mask, vd, vs1, vs2, vl); }
-vint64m2_t test_vwscjnmsac_vv_i32 (vint64m2_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscjnmsac_vv_i64m2 (vd, vs1, vs2, vl); }
-vint64m2_t test_vwscjnmsac_vv_i32_m (vbool32_t mask, vint64m2_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscjnmsac_vv_i64m2_m (mask, vd, vs1, vs2, vl); }
+/*
+** test_vwscjnmsac_vv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwscjnmsac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint32m2_t
+test_vwscjnmsac_vv_i16 (vint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscjnmsac_vv_i32m2 (vd, vs1, vs2, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwscjnmsac\\.vv" 4 } } */
+/*
+** test_vwscjnmsac_vv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwscjnmsac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint32m2_t
+test_vwscjnmsac_vv_i16_m (vbool16_t mask, vint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscjnmsac_vv_i32m2_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwscjnmsac_vv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwscjnmsac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint64m2_t
+test_vwscjnmsac_vv_i32 (vint64m2_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscjnmsac_vv_i64m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwscjnmsac_vv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwscjnmsac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint64m2_t
+test_vwscjnmsac_vv_i32_m (vbool32_t mask, vint64m2_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscjnmsac_vv_i64m2_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjnmsac_vx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjnmsac_vx-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m2_t test_vwscjnmsac_vx_i16 (vint32m2_t vd, int vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscjnmsac_vx_i32m2 (vd, vs1, vs2, vl); }
-vint32m2_t test_vwscjnmsac_vx_i16_m (vbool16_t mask, vint32m2_t vd, int vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscjnmsac_vx_i32m2_m (mask, vd, vs1, vs2, vl); }
-vint64m2_t test_vwscjnmsac_vx_i32 (vint64m2_t vd, int vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscjnmsac_vx_i64m2 (vd, vs1, vs2, vl); }
-vint64m2_t test_vwscjnmsac_vx_i32_m (vbool32_t mask, vint64m2_t vd, int vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscjnmsac_vx_i64m2_m (mask, vd, vs1, vs2, vl); }
+/*
+** test_vwscjnmsac_vx_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwscjnmsac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint32m2_t
+test_vwscjnmsac_vx_i16 (vint32m2_t vd, int vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscjnmsac_vx_i32m2 (vd, vs1, vs2, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwscjnmsac\\.vx" 4 } } */
+/*
+** test_vwscjnmsac_vx_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwscjnmsac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint32m2_t
+test_vwscjnmsac_vx_i16_m (vbool16_t mask, vint32m2_t vd, int vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscjnmsac_vx_i32m2_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwscjnmsac_vx_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwscjnmsac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint64m2_t
+test_vwscjnmsac_vx_i32 (vint64m2_t vd, int vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscjnmsac_vx_i64m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwscjnmsac_vx_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwscjnmsac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint64m2_t
+test_vwscjnmsac_vx_i32_m (vbool32_t mask, vint64m2_t vd, int vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscjnmsac_vx_i64m2_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjrdot_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjrdot_vv-compile-1.c
@@ -1,17 +1,53 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m1_t test_vwscjrdot_vv_i16 (vint32m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscjrdot_vv_i16m1_i32m1 (vd, vs1, vs2, vl); }
-vint32m1_t test_vwscjrdot_vv_i16_m (vbool16_t mask, vint32m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscjrdot_vv_i16m1_i32m1_m (mask, vd, vs1, vs2, vl); }
-vint64m1_t test_vwscjrdot_vv_i32 (vint64m1_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscjrdot_vv_i32m1_i64m1 (vd, vs1, vs2, vl); }
-vint64m1_t test_vwscjrdot_vv_i32_m (vbool32_t mask, vint64m1_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscjrdot_vv_i32m1_i64m1_m (mask, vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vwscjrdot\\.vv" 4 } } */
+/*
+** test_vwscjrdot_vv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vwscjrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m1_t test_vwscjrdot_vv_i16 (vint32m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscjrdot_vv_i16m1_i32m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwscjrdot_vv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vwscjrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_vwscjrdot_vv_i16_m (vbool16_t mask, vint32m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscjrdot_vv_i16m1_i32m1_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwscjrdot_vv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vwscjrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint64m1_t test_vwscjrdot_vv_i32 (vint64m1_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscjrdot_vv_i32m1_i64m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwscjrdot_vv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vwscjrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint64m1_t test_vwscjrdot_vv_i32_m (vbool32_t mask, vint64m1_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscjrdot_vv_i32m1_i64m1_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscmac_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscmac_vv-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m2_t test_vwscmac_vv_i16 (vint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscmac_vv_i32m2 (vd, vs1, vs2, vl); }
-vint32m2_t test_vwscmac_vv_i16_m (vbool16_t mask, vint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscmac_vv_i32m2_m (mask, vd, vs1, vs2, vl); }
-vint64m2_t test_vwscmac_vv_i32 (vint64m2_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscmac_vv_i64m2 (vd, vs1, vs2, vl); }
-vint64m2_t test_vwscmac_vv_i32_m (vbool32_t mask, vint64m2_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscmac_vv_i64m2_m (mask, vd, vs1, vs2, vl); }
+/*
+** test_vwscmac_vv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwscmac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint32m2_t
+test_vwscmac_vv_i16 (vint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscmac_vv_i32m2 (vd, vs1, vs2, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwscmac\\.vv" 4 } } */
+/*
+** test_vwscmac_vv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwscmac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint32m2_t
+test_vwscmac_vv_i16_m (vbool16_t mask, vint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscmac_vv_i32m2_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwscmac_vv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwscmac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint64m2_t
+test_vwscmac_vv_i32 (vint64m2_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscmac_vv_i64m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwscmac_vv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwscmac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint64m2_t
+test_vwscmac_vv_i32_m (vbool32_t mask, vint64m2_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscmac_vv_i64m2_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscmac_vx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscmac_vx-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m2_t test_vwscmac_vx_i16 (vint32m2_t vd, int vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscmac_vx_i32m2 (vd, vs1, vs2, vl); }
-vint32m2_t test_vwscmac_vx_i16_m (vbool16_t mask, vint32m2_t vd, int vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscmac_vx_i32m2_m (mask, vd, vs1, vs2, vl); }
-vint64m2_t test_vwscmac_vx_i32 (vint64m2_t vd, int vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscmac_vx_i64m2 (vd, vs1, vs2, vl); }
-vint64m2_t test_vwscmac_vx_i32_m (vbool32_t mask, vint64m2_t vd, int vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscmac_vx_i64m2_m (mask, vd, vs1, vs2, vl); }
+/*
+** test_vwscmac_vx_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwscmac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint32m2_t
+test_vwscmac_vx_i16 (vint32m2_t vd, int vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscmac_vx_i32m2 (vd, vs1, vs2, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwscmac\\.vx" 4 } } */
+/*
+** test_vwscmac_vx_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwscmac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint32m2_t
+test_vwscmac_vx_i16_m (vbool16_t mask, vint32m2_t vd, int vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscmac_vx_i32m2_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwscmac_vx_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwscmac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint64m2_t
+test_vwscmac_vx_i32 (vint64m2_t vd, int vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscmac_vx_i64m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwscmac_vx_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwscmac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint64m2_t
+test_vwscmac_vx_i32_m (vbool32_t mask, vint64m2_t vd, int vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscmac_vx_i64m2_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscmul_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscmul_vv-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m2_t test_vwscmul_vv_i16 (vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwscmul_vv_i32m2 (vs2, vs1, vl); }
-vint32m2_t test_vwscmul_vv_i16_m (vbool16_t mask, vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwscmul_vv_i32m2_m (mask, vs2, vs1, vl); }
-vint64m2_t test_vwscmul_vv_i32 (vint32m1_t vs2, vint32m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwscmul_vv_i64m2 (vs2, vs1, vl); }
-vint64m2_t test_vwscmul_vv_i32_m (vbool32_t mask, vint32m1_t vs2, vint32m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwscmul_vv_i64m2_m (mask, vs2, vs1, vl); }
+/*
+** test_vwscmul_vv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwscmul.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint32m2_t
+test_vwscmul_vv_i16 (vint16m1_t vs2, vint16m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vwscmul_vv_i32m2 (vs2, vs1, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwscmul\\.vv" 4 } } */
+/*
+** test_vwscmul_vv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwscmul.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint32m2_t
+test_vwscmul_vv_i16_m (vbool16_t mask, vint16m1_t vs2, vint16m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vwscmul_vv_i32m2_m (mask, vs2, vs1, vl);
+}
+
+/*
+** test_vwscmul_vv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwscmul.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint64m2_t
+test_vwscmul_vv_i32 (vint32m1_t vs2, vint32m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vwscmul_vv_i64m2 (vs2, vs1, vl);
+}
+
+/*
+** test_vwscmul_vv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwscmul.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint64m2_t
+test_vwscmul_vv_i32_m (vbool32_t mask, vint32m1_t vs2, vint32m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vwscmul_vv_i64m2_m (mask, vs2, vs1, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscmul_vx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscmul_vx-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m2_t test_vwscmul_vx_i16 (vint16m1_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vwscmul_vx_i32m2 (vs2, vs1, vl); }
-vint32m2_t test_vwscmul_vx_i16_m (vbool16_t mask, vint16m1_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vwscmul_vx_i32m2_m (mask, vs2, vs1, vl); }
-vint64m2_t test_vwscmul_vx_i32 (vint32m1_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vwscmul_vx_i64m2 (vs2, vs1, vl); }
-vint64m2_t test_vwscmul_vx_i32_m (vbool32_t mask, vint32m1_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vwscmul_vx_i64m2_m (mask, vs2, vs1, vl); }
+/*
+** test_vwscmul_vx_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwscmul.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint32m2_t
+test_vwscmul_vx_i16 (vint16m1_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vwscmul_vx_i32m2 (vs2, vs1, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwscmul\\.vx" 4 } } */
+/*
+** test_vwscmul_vx_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwscmul.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**  ret
+*/
+vint32m2_t
+test_vwscmul_vx_i16_m (vbool16_t mask, vint16m1_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vwscmul_vx_i32m2_m (mask, vs2, vs1, vl);
+}
+
+/*
+** test_vwscmul_vx_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwscmul.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint64m2_t
+test_vwscmul_vx_i32 (vint32m1_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vwscmul_vx_i64m2 (vs2, vs1, vl);
+}
+
+/*
+** test_vwscmul_vx_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwscmul.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**  ret
+*/
+vint64m2_t
+test_vwscmul_vx_i32_m (vbool32_t mask, vint32m1_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vwscmul_vx_i64m2_m (mask, vs2, vs1, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscnmsac_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscnmsac_vv-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m2_t test_vwscnmsac_vv_i16 (vint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscnmsac_vv_i32m2 (vd, vs1, vs2, vl); }
-vint32m2_t test_vwscnmsac_vv_i16_m (vbool16_t mask, vint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscnmsac_vv_i32m2_m (mask, vd, vs1, vs2, vl); }
-vint64m2_t test_vwscnmsac_vv_i32 (vint64m2_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscnmsac_vv_i64m2 (vd, vs1, vs2, vl); }
-vint64m2_t test_vwscnmsac_vv_i32_m (vbool32_t mask, vint64m2_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscnmsac_vv_i64m2_m (mask, vd, vs1, vs2, vl); }
+/*
+** test_vwscnmsac_vv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwscnmsac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint32m2_t
+test_vwscnmsac_vv_i16 (vint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscnmsac_vv_i32m2 (vd, vs1, vs2, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwscnmsac\\.vv" 4 } } */
+/*
+** test_vwscnmsac_vv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwscnmsac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint32m2_t
+test_vwscnmsac_vv_i16_m (vbool16_t mask, vint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscnmsac_vv_i32m2_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwscnmsac_vv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwscnmsac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint64m2_t
+test_vwscnmsac_vv_i32 (vint64m2_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscnmsac_vv_i64m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwscnmsac_vv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwscnmsac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint64m2_t
+test_vwscnmsac_vv_i32_m (vbool32_t mask, vint64m2_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscnmsac_vv_i64m2_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscnmsac_vx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscnmsac_vx-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m2_t test_vwscnmsac_vx_i16 (vint32m2_t vd, int vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscnmsac_vx_i32m2 (vd, vs1, vs2, vl); }
-vint32m2_t test_vwscnmsac_vx_i16_m (vbool16_t mask, vint32m2_t vd, int vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscnmsac_vx_i32m2_m (mask, vd, vs1, vs2, vl); }
-vint64m2_t test_vwscnmsac_vx_i32 (vint64m2_t vd, int vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscnmsac_vx_i64m2 (vd, vs1, vs2, vl); }
-vint64m2_t test_vwscnmsac_vx_i32_m (vbool32_t mask, vint64m2_t vd, int vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscnmsac_vx_i64m2_m (mask, vd, vs1, vs2, vl); }
+/*
+** test_vwscnmsac_vx_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwscnmsac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint32m2_t
+test_vwscnmsac_vx_i16 (vint32m2_t vd, int vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscnmsac_vx_i32m2 (vd, vs1, vs2, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwscnmsac\\.vx" 4 } } */
+/*
+** test_vwscnmsac_vx_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwscnmsac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint32m2_t
+test_vwscnmsac_vx_i16_m (vbool16_t mask, vint32m2_t vd, int vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscnmsac_vx_i32m2_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwscnmsac_vx_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwscnmsac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint64m2_t
+test_vwscnmsac_vx_i32 (vint64m2_t vd, int vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscnmsac_vx_i64m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwscnmsac_vx_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwscnmsac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint64m2_t
+test_vwscnmsac_vx_i32_m (vbool32_t mask, vint64m2_t vd, int vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscnmsac_vx_i64m2_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscrdot_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscrdot_vv-compile-1.c
@@ -1,17 +1,53 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m1_t test_vwscrdot_vv_i16 (vint32m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscrdot_vv_i16m1_i32m1 (vd, vs1, vs2, vl); }
-vint32m1_t test_vwscrdot_vv_i16_m (vbool16_t mask, vint32m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscrdot_vv_i16m1_i32m1_m (mask, vd, vs1, vs2, vl); }
-vint64m1_t test_vwscrdot_vv_i32 (vint64m1_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscrdot_vv_i32m1_i64m1 (vd, vs1, vs2, vl); }
-vint64m1_t test_vwscrdot_vv_i32_m (vbool32_t mask, vint64m1_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwscrdot_vv_i32m1_i64m1_m (mask, vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vwscrdot\\.vv" 4 } } */
+/*
+** test_vwscrdot_vv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vwscrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m1_t test_vwscrdot_vv_i16 (vint32m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscrdot_vv_i16m1_i32m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwscrdot_vv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vwscrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_vwscrdot_vv_i16_m (vbool16_t mask, vint32m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscrdot_vv_i16m1_i32m1_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwscrdot_vv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vwscrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint64m1_t test_vwscrdot_vv_i32 (vint64m1_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscrdot_vv_i32m1_i64m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwscrdot_vv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vwscrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint64m1_t test_vwscrdot_vv_i32_m (vbool32_t mask, vint64m1_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwscrdot_vv_i32m1_i64m1_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vaddsub_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vaddsub_vv-compile-1.c
@@ -1,21 +1,75 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint16m1_t test_vaddsub_vv_i16 (vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
-  return __riscv_arcv_vaddsub_vv_i16m1 (vs2, vs1, vl); }
-vint16m1_t test_vaddsub_vv_i16_m (vbool16_t mask, vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
-  return __riscv_arcv_vaddsub_vv_i16m1_m (mask, vs2, vs1, vl); }
-vint32m1_t test_vaddsub_vv_i32 (vint32m1_t vs2, vint32m1_t vs1, size_t vl) {
-  return __riscv_arcv_vaddsub_vv_i32m1 (vs2, vs1, vl); }
-vint32m1_t test_vaddsub_vv_i32_m (vbool32_t mask, vint32m1_t vs2, vint32m1_t vs1, size_t vl) {
-  return __riscv_arcv_vaddsub_vv_i32m1_m (mask, vs2, vs1, vl); }
-vint64m1_t test_vaddsub_vv_i64 (vint64m1_t vs2, vint64m1_t vs1, size_t vl) {
-  return __riscv_arcv_vaddsub_vv_i64m1 (vs2, vs1, vl); }
-vint64m1_t test_vaddsub_vv_i64_m (vbool64_t mask, vint64m1_t vs2, vint64m1_t vs1, size_t vl) {
-  return __riscv_arcv_vaddsub_vv_i64m1_m (mask, vs2, vs1, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vaddsub\\.vv" 6 } } */
+/*
+** test_vaddsub_vv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vaddsub\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint16m1_t test_vaddsub_vv_i16 (vint16m1_t vs2, vint16m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vaddsub_vv_i16m1 (vs2, vs1, vl);
+}
+
+/*
+** test_vaddsub_vv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vaddsub\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint16m1_t test_vaddsub_vv_i16_m (vbool16_t mask, vint16m1_t vs2, vint16m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vaddsub_vv_i16m1_m (mask, vs2, vs1, vl);
+}
+
+/*
+** test_vaddsub_vv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vaddsub\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m1_t test_vaddsub_vv_i32 (vint32m1_t vs2, vint32m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vaddsub_vv_i32m1 (vs2, vs1, vl);
+}
+
+/*
+** test_vaddsub_vv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vaddsub\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_vaddsub_vv_i32_m (vbool32_t mask, vint32m1_t vs2, vint32m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vaddsub_vv_i32m1_m (mask, vs2, vs1, vl);
+}
+
+/*
+** test_vaddsub_vv_i64:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m1,\s*t[au],\s*m[au]
+**  arcv\.vaddsub\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint64m1_t test_vaddsub_vv_i64 (vint64m1_t vs2, vint64m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vaddsub_vv_i64m1 (vs2, vs1, vl);
+}
+
+/*
+** test_vaddsub_vv_i64_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m1,\s*t[au],\s*m[au]
+**  arcv\.vaddsub\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint64m1_t test_vaddsub_vv_i64_m (vbool64_t mask, vint64m1_t vs2, vint64m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vaddsub_vv_i64m1_m (mask, vs2, vs1, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vclr_v_i-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vclr_v_i-compile-1.c
@@ -1,25 +1,97 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint8m1_t test_vclr_v_i_i8 (vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vclr_v_i_i8m1 (vs2, 1, vl); }
-vint8m1_t test_vclr_v_i_i8_m (vbool8_t mask, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vclr_v_i_i8m1_m (mask, vs2, 1, vl); }
-vint16m1_t test_vclr_v_i_i16 (vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vclr_v_i_i16m1 (vs2, 1, vl); }
-vint16m1_t test_vclr_v_i_i16_m (vbool16_t mask, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vclr_v_i_i16m1_m (mask, vs2, 1, vl); }
-vint32m1_t test_vclr_v_i_i32 (vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vclr_v_i_i32m1 (vs2, 1, vl); }
-vint32m1_t test_vclr_v_i_i32_m (vbool32_t mask, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vclr_v_i_i32m1_m (mask, vs2, 1, vl); }
-vint64m1_t test_vclr_v_i_i64 (vint64m1_t vs2, size_t vl) {
-  return __riscv_arcv_vclr_v_i_i64m1 (vs2, 1, vl); }
-vint64m1_t test_vclr_v_i_i64_m (vbool64_t mask, vint64m1_t vs2, size_t vl) {
-  return __riscv_arcv_vclr_v_i_i64m1_m (mask, vs2, 1, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vclr\\.v\\.i" 8 } } */
+/*
+** test_vclr_v_i_i8:
+**  vsetivli	zero,1,e8,m1,ta,ma
+**  arcv\.vclr\.v\.i4\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
+**  ret
+*/
+vint8m1_t test_vclr_v_i_i8 (vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vclr_v_i_i8m1 (vs2, 1, vl);
+}
+
+/*
+** test_vclr_v_i_i8_m:
+**  vsetivli	zero,1,e8,m1,ta,ma
+**  arcv\.vclr\.v\.i4\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1,\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint8m1_t test_vclr_v_i_i8_m (vbool8_t mask, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vclr_v_i_i8m1_m (mask, vs2, 1, vl);
+}
+
+/*
+** test_vclr_v_i_i16:
+**  vsetivli	zero,1,e16,m1,ta,ma
+**  arcv\.vclr\.v\.i4\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
+**  ret
+*/
+vint16m1_t test_vclr_v_i_i16 (vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vclr_v_i_i16m1 (vs2, 1, vl);
+}
+
+/*
+** test_vclr_v_i_i16_m:
+**  vsetivli	zero,1,e16,m1,ta,ma
+**  arcv\.vclr\.v\.i4\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1,\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint16m1_t test_vclr_v_i_i16_m (vbool16_t mask, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vclr_v_i_i16m1_m (mask, vs2, 1, vl);
+}
+
+/*
+** test_vclr_v_i_i32:
+**  vsetivli	zero,1,e32,m1,ta,ma
+**  arcv\.vclr\.v\.i4\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
+**  ret
+*/
+vint32m1_t test_vclr_v_i_i32 (vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vclr_v_i_i32m1 (vs2, 1, vl);
+}
+
+/*
+** test_vclr_v_i_i32_m:
+**  vsetivli	zero,1,e32,m1,ta,ma
+**  arcv\.vclr\.v\.i4\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1,\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_vclr_v_i_i32_m (vbool32_t mask, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vclr_v_i_i32m1_m (mask, vs2, 1, vl);
+}
+
+/*
+** test_vclr_v_i_i64:
+**  vsetivli	zero,1,e64,m1,ta,ma
+**  arcv\.vclr\.v\.i4\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
+**  ret
+*/
+vint64m1_t test_vclr_v_i_i64 (vint64m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vclr_v_i_i64m1 (vs2, 1, vl);
+}
+
+/*
+** test_vclr_v_i_i64_m:
+**  vsetivli	zero,1,e64,m1,ta,ma
+**  arcv\.vclr\.v\.i4\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1,\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint64m1_t test_vclr_v_i_i64_m (vbool64_t mask, vint64m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vclr_v_i_i64m1_m (mask, vs2, 1, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmv_s_v-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmv_s_v-compile-1.c
@@ -1,23 +1,79 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint8m1_t test_vmv_s_v_i8m1 (vint8m1_t vd, int vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_s_v_i8m1_i8m1 (vd, vs1, vs2, vl); }
-vint8m1_t test_vmv_s_v_i8m2 (vint8m1_t vd, int vs1, vint8m2_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_s_v_i8m2_i8m1 (vd, vs1, vs2, vl); }
-vint8m1_t test_vmv_s_v_i8m4 (vint8m1_t vd, int vs1, vint8m4_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_s_v_i8m4_i8m1 (vd, vs1, vs2, vl); }
-vint16m1_t test_vmv_s_v_i16m1 (vint16m1_t vd, int vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_s_v_i16m1_i16m1 (vd, vs1, vs2, vl); }
-vint32m1_t test_vmv_s_v_i32m1 (vint32m1_t vd, int vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_s_v_i32m1_i32m1 (vd, vs1, vs2, vl); }
-vint32m1_t test_vmv_s_v_i32m2 (vint32m1_t vd, int vs1, vint32m2_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_s_v_i32m2_i32m1 (vd, vs1, vs2, vl); }
-vint64m1_t test_vmv_s_v_i64m1 (vint64m1_t vd, int vs1, vint64m1_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_s_v_i64m1_i64m1 (vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vmv\\.s\\.v" 7 } } */
+/*
+** test_vmv_s_v_i8m1:
+**  arcv\.vmv\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint8m1_t test_vmv_s_v_i8m1 (vint8m1_t vd, int vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_s_v_i8m1_i8m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vmv_s_v_i8m2:
+**  arcv\.vmv\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint8m1_t test_vmv_s_v_i8m2 (vint8m1_t vd, int vs1, vint8m2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_s_v_i8m2_i8m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vmv_s_v_i8m4:
+**  arcv\.vmv\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint8m1_t test_vmv_s_v_i8m4 (vint8m1_t vd, int vs1, vint8m4_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_s_v_i8m4_i8m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vmv_s_v_i16m1:
+**  arcv\.vmv\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint16m1_t test_vmv_s_v_i16m1 (vint16m1_t vd, int vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_s_v_i16m1_i16m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vmv_s_v_i32m1:
+**  arcv\.vmv\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint32m1_t test_vmv_s_v_i32m1 (vint32m1_t vd, int vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_s_v_i32m1_i32m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vmv_s_v_i32m2:
+**  arcv\.vmv\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint32m1_t test_vmv_s_v_i32m2 (vint32m1_t vd, int vs1, vint32m2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_s_v_i32m2_i32m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vmv_s_v_i64m1:
+**  arcv\.vmv\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint64m1_t test_vmv_s_v_i64m1 (vint64m1_t vd, int vs1, vint64m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_s_v_i64m1_i64m1 (vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmv_v_s-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmv_v_s-compile-1.c
@@ -1,17 +1,49 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint8m1_t test_vmv_v_s_i8 (vint8m1_t vd, int vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_v_s_i8m1 (vd, vs1, vs2, vl); }
-vint16m1_t test_vmv_v_s_i16 (vint16m1_t vd, int vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_v_s_i16m1 (vd, vs1, vs2, vl); }
-vint32m1_t test_vmv_v_s_i32 (vint32m1_t vd, int vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_v_s_i32m1 (vd, vs1, vs2, vl); }
-vint64m1_t test_vmv_v_s_i64 (vint64m1_t vd, int vs1, vint64m1_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_v_s_i64m1 (vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vmv\\.v\\.s" 4 } } */
+/*
+** test_vmv_v_s_i8:
+**  arcv\.vmv\.v\.s\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint8m1_t test_vmv_v_s_i8 (vint8m1_t vd, int vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_i8m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vmv_v_s_i16:
+**  arcv\.vmv\.v\.s\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint16m1_t test_vmv_v_s_i16 (vint16m1_t vd, int vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_i16m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vmv_v_s_i32:
+**  arcv\.vmv\.v\.s\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint32m1_t test_vmv_v_s_i32 (vint32m1_t vd, int vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_i32m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vmv_v_s_i64:
+**  arcv\.vmv\.v\.s\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint64m1_t test_vmv_v_s_i64 (vint64m1_t vd, int vs1, vint64m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_i64m1 (vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmvi_s_v-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmvi_s_v-compile-1.c
@@ -1,23 +1,79 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint8m1_t test_vmv_s_v_i8m1 (vint8m1_t vd, int vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_s_v_i8m1_i8m1 (vd, 1, vs2, vl); }
-vint8m1_t test_vmv_s_v_i8m2 (vint8m1_t vd, int vs1, vint8m2_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_s_v_i8m2_i8m1 (vd, 1, vs2, vl); }
-vint8m1_t test_vmv_s_v_i8m4 (vint8m1_t vd, int vs1, vint8m4_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_s_v_i8m4_i8m1 (vd, 1, vs2, vl); }
-vint16m1_t test_vmv_s_v_i16m1 (vint16m1_t vd, int vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_s_v_i16m1_i16m1 (vd, 1, vs2, vl); }
-vint32m1_t test_vmv_s_v_i32m1 (vint32m1_t vd, int vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_s_v_i32m1_i32m1 (vd, 1, vs2, vl); }
-vint32m1_t test_vmv_s_v_i32m2 (vint32m1_t vd, int vs1, vint32m2_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_s_v_i32m2_i32m1 (vd, 1, vs2, vl); }
-vint64m1_t test_vmv_s_v_i64m1 (vint64m1_t vd, int vs1, vint64m1_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_s_v_i64m1_i64m1 (vd, 1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vmvi\\.s\\.v" 7 } } */
+/*
+** test_vmv_s_v_i8m1:
+**  arcv\.vmvi\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
+**  ret
+*/
+vint8m1_t test_vmv_s_v_i8m1 (vint8m1_t vd, int vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_s_v_i8m1_i8m1 (vd, 1, vs2, vl);
+}
+
+/*
+** test_vmv_s_v_i8m2:
+**  arcv\.vmvi\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
+**  ret
+*/
+vint8m1_t test_vmv_s_v_i8m2 (vint8m1_t vd, int vs1, vint8m2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_s_v_i8m2_i8m1 (vd, 1, vs2, vl);
+}
+
+/*
+** test_vmv_s_v_i8m4:
+**  arcv\.vmvi\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
+**  ret
+*/
+vint8m1_t test_vmv_s_v_i8m4 (vint8m1_t vd, int vs1, vint8m4_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_s_v_i8m4_i8m1 (vd, 1, vs2, vl);
+}
+
+/*
+** test_vmv_s_v_i16m1:
+**  arcv\.vmvi\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
+**  ret
+*/
+vint16m1_t test_vmv_s_v_i16m1 (vint16m1_t vd, int vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_s_v_i16m1_i16m1 (vd, 1, vs2, vl);
+}
+
+/*
+** test_vmv_s_v_i32m1:
+**  arcv\.vmvi\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
+**  ret
+*/
+vint32m1_t test_vmv_s_v_i32m1 (vint32m1_t vd, int vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_s_v_i32m1_i32m1 (vd, 1, vs2, vl);
+}
+
+/*
+** test_vmv_s_v_i32m2:
+**  arcv\.vmvi\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
+**  ret
+*/
+vint32m1_t test_vmv_s_v_i32m2 (vint32m1_t vd, int vs1, vint32m2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_s_v_i32m2_i32m1 (vd, 1, vs2, vl);
+}
+
+/*
+** test_vmv_s_v_i64m1:
+**  arcv\.vmvi\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
+**  ret
+*/
+vint64m1_t test_vmv_s_v_i64m1 (vint64m1_t vd, int vs1, vint64m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_s_v_i64m1_i64m1 (vd, 1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmvi_v_s-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmvi_v_s-compile-1.c
@@ -1,17 +1,49 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint8m1_t test_vmvi_v_s_i8 (vint8m1_t vd, int vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_v_s_i8m1 (vd, 1, vs2, vl); }
-vint16m1_t test_vmvi_v_s_i16 (vint16m1_t vd, int vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_v_s_i16m1 (vd, 1, vs2, vl); }
-vint32m1_t test_vmvi_v_s_i32 (vint32m1_t vd, int vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_v_s_i32m1 (vd, 1, vs2, vl); }
-vint64m1_t test_vmvi_v_s_i64 (vint64m1_t vd, int vs1, vint64m1_t vs2, size_t vl) {
-  return __riscv_arcv_vmv_v_s_i64m1 (vd, 1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vmvi\\.v\\.s" 4 } } */
+/*
+** test_vmvi_v_s_i8:
+**  arcv\.vmvi\.v\.s\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
+**  ret
+*/
+vint8m1_t test_vmvi_v_s_i8 (vint8m1_t vd, int vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_i8m1 (vd, 1, vs2, vl);
+}
+
+/*
+** test_vmvi_v_s_i16:
+**  arcv\.vmvi\.v\.s\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
+**  ret
+*/
+vint16m1_t test_vmvi_v_s_i16 (vint16m1_t vd, int vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_i16m1 (vd, 1, vs2, vl);
+}
+
+/*
+** test_vmvi_v_s_i32:
+**  arcv\.vmvi\.v\.s\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
+**  ret
+*/
+vint32m1_t test_vmvi_v_s_i32 (vint32m1_t vd, int vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_i32m1 (vd, 1, vs2, vl);
+}
+
+/*
+** test_vmvi_v_s_i64:
+**  arcv\.vmvi\.v\.s\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
+**  ret
+*/
+vint64m1_t test_vmvi_v_s_i64 (vint64m1_t vd, int vs1, vint64m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_i64m1 (vd, 1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnorm_v-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnorm_v-compile-1.c
@@ -1,21 +1,75 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint16m1_t test_vnorm_v_i16 (vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vnorm_v_i16m1 (vs2, vl); }
-vint16m1_t test_vnorm_v_i16_m (vbool16_t mask, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vnorm_v_i16m1_m (mask, vs2, vl); }
-vint32m1_t test_vnorm_v_i32 (vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vnorm_v_i32m1 (vs2, vl); }
-vint32m1_t test_vnorm_v_i32_m (vbool32_t mask, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vnorm_v_i32m1_m (mask, vs2, vl); }
-vint64m1_t test_vnorm_v_i64 (vint64m1_t vs2, size_t vl) {
-  return __riscv_arcv_vnorm_v_i64m1 (vs2, vl); }
-vint64m1_t test_vnorm_v_i64_m (vbool64_t mask, vint64m1_t vs2, size_t vl) {
-  return __riscv_arcv_vnorm_v_i64m1_m (mask, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vnorm\\.v" 6 } } */
+/*
+** test_vnorm_v_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vnorm\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint16m1_t test_vnorm_v_i16 (vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vnorm_v_i16m1 (vs2, vl);
+}
+
+/*
+** test_vnorm_v_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vnorm\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint16m1_t test_vnorm_v_i16_m (vbool16_t mask, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vnorm_v_i16m1_m (mask, vs2, vl);
+}
+
+/*
+** test_vnorm_v_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vnorm\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m1_t test_vnorm_v_i32 (vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vnorm_v_i32m1 (vs2, vl);
+}
+
+/*
+** test_vnorm_v_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vnorm\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_vnorm_v_i32_m (vbool32_t mask, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vnorm_v_i32m1_m (mask, vs2, vl);
+}
+
+/*
+** test_vnorm_v_i64:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m1,\s*t[au],\s*m[au]
+**  arcv\.vnorm\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint64m1_t test_vnorm_v_i64 (vint64m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vnorm_v_i64m1 (vs2, vl);
+}
+
+/*
+** test_vnorm_v_i64_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m1,\s*t[au],\s*m[au]
+**  arcv\.vnorm\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint64m1_t test_vnorm_v_i64_m (vbool64_t mask, vint64m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vnorm_v_i64m1_m (mask, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_2s_qi-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_2s_qi-compile-1.c
@@ -11,7 +11,7 @@
 ** test_vnsra_2s_qi_i8:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.qi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.qi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint8m1_t
@@ -24,7 +24,7 @@ test_vnsra_2s_qi_i8 (vint32m4_t vs2, vint8m1_t vs1, size_t vl)
 ** test_vnsra_2s_qi_i8_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.qi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.qi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint8m1_t
@@ -37,7 +37,7 @@ test_vnsra_2s_qi_i8_m (vbool8_t mask, vint32m4_t vs2, vint8m1_t vs1, size_t vl)
 ** test_vnsra_2s_qi_i16:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.qi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.qi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint16m1_t
@@ -50,7 +50,7 @@ test_vnsra_2s_qi_i16 (vint64m4_t vs2, vint16m1_t vs1, size_t vl)
 ** test_vnsra_2s_qi_i16_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.qi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.qi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint16m1_t

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_2s_qv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_2s_qv-compile-1.c
@@ -11,7 +11,7 @@
 ** test_vnsra_2s_qv_i8:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.qv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.qv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint8m1_t
@@ -24,7 +24,7 @@ test_vnsra_2s_qv_i8 (vint32m4_t vs2, vint8m1_t vs1, size_t vl)
 ** test_vnsra_2s_qv_i8_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.qv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.qv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint8m1_t
@@ -37,7 +37,7 @@ test_vnsra_2s_qv_i8_m (vbool8_t mask, vint32m4_t vs2, vint8m1_t vs1, size_t vl)
 ** test_vnsra_2s_qv_i16:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.qv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.qv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint16m1_t
@@ -50,7 +50,7 @@ test_vnsra_2s_qv_i16 (vint64m4_t vs2, vint16m1_t vs1, size_t vl)
 ** test_vnsra_2s_qv_i16_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.qv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.qv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint16m1_t

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_2s_qx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_2s_qx-compile-1.c
@@ -4,7 +4,6 @@
 /* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
-
 #include <stddef.h>
 #include <riscv_vector.h>
 
@@ -12,7 +11,7 @@
 ** test_vnsra_2s_qx_i8:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.qx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.qx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint8m1_t
@@ -25,7 +24,7 @@ test_vnsra_2s_qx_i8 (vint32m4_t vs2, int vs1, size_t vl)
 ** test_vnsra_2s_qx_i8_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.qx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.qx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint8m1_t
@@ -38,7 +37,7 @@ test_vnsra_2s_qx_i8_m (vbool8_t mask, vint32m4_t vs2, int vs1, size_t vl)
 ** test_vnsra_2s_qx_i16:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.qx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.qx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint16m1_t
@@ -51,7 +50,7 @@ test_vnsra_2s_qx_i16 (vint64m4_t vs2, int vs1, size_t vl)
 ** test_vnsra_2s_qx_i16_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.qx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.qx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint16m1_t

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_2s_wi-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_2s_wi-compile-1.c
@@ -4,7 +4,6 @@
 /* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
-
 #include <stddef.h>
 #include <riscv_vector.h>
 
@@ -12,7 +11,7 @@
 ** test_vnsra_2s_wi_i8:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint8m1_t
@@ -25,7 +24,7 @@ test_vnsra_2s_wi_i8 (vint16m2_t vs2, vint8m1_t vs1, size_t vl)
 ** test_vnsra_2s_wi_i8_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint8m1_t
@@ -38,7 +37,7 @@ test_vnsra_2s_wi_i8_m (vbool8_t mask, vint16m2_t vs2, vint8m1_t vs1, size_t vl)
 ** test_vnsra_2s_wi_i16:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint16m1_t
@@ -51,7 +50,7 @@ test_vnsra_2s_wi_i16 (vint32m2_t vs2, vint16m1_t vs1, size_t vl)
 ** test_vnsra_2s_wi_i16_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint16m1_t
@@ -64,7 +63,7 @@ test_vnsra_2s_wi_i16_m (vbool16_t mask, vint32m2_t vs2, vint16m1_t vs1, size_t v
 ** test_vnsra_2s_wi_i32:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint32m1_t
@@ -77,7 +76,7 @@ test_vnsra_2s_wi_i32 (vint64m2_t vs2, vint32m1_t vs1, size_t vl)
 ** test_vnsra_2s_wi_i32_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint32m1_t

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_2s_wv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_2s_wv-compile-1.c
@@ -11,7 +11,7 @@
 ** test_vnsra_2s_wv_i8:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint8m1_t
@@ -24,7 +24,7 @@ test_vnsra_2s_wv_i8 (vint16m2_t vs2, vint8m1_t vs1, size_t vl)
 ** test_vnsra_2s_wv_i8_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint8m1_t
@@ -37,7 +37,7 @@ test_vnsra_2s_wv_i8_m (vbool8_t mask, vint16m2_t vs2, vint8m1_t vs1, size_t vl)
 ** test_vnsra_2s_wv_i16:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint16m1_t
@@ -50,7 +50,7 @@ test_vnsra_2s_wv_i16 (vint32m2_t vs2, vint16m1_t vs1, size_t vl)
 ** test_vnsra_2s_wv_i16_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint16m1_t
@@ -63,7 +63,7 @@ test_vnsra_2s_wv_i16_m (vbool16_t mask, vint32m2_t vs2, vint16m1_t vs1, size_t v
 ** test_vnsra_2s_wv_i32:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint32m1_t
@@ -76,7 +76,7 @@ test_vnsra_2s_wv_i32 (vint64m2_t vs2, vint32m1_t vs1, size_t vl)
 ** test_vnsra_2s_wv_i32_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint32m1_t

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_2s_wx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_2s_wx-compile-1.c
@@ -11,7 +11,7 @@
 ** test_vnsra_2s_wx_i8:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint8m1_t
@@ -24,7 +24,7 @@ test_vnsra_2s_wx_i8 (vint16m2_t vs2, int vs1, size_t vl)
 ** test_vnsra_2s_wx_i8_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint8m1_t
@@ -37,7 +37,7 @@ test_vnsra_2s_wx_i8_m (vbool8_t mask, vint16m2_t vs2, int vs1, size_t vl)
 ** test_vnsra_2s_wx_i16:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint16m1_t
@@ -50,7 +50,7 @@ test_vnsra_2s_wx_i16 (vint32m2_t vs2, int vs1, size_t vl)
 ** test_vnsra_2s_wx_i16_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint16m1_t
@@ -63,7 +63,7 @@ test_vnsra_2s_wx_i16_m (vbool16_t mask, vint32m2_t vs2, int vs1, size_t vl)
 ** test_vnsra_2s_wx_i32:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint32m1_t
@@ -76,7 +76,7 @@ test_vnsra_2s_wx_i32 (vint64m2_t vs2, int vs1, size_t vl)
 ** test_vnsra_2s_wx_i32_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.2s.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.2s.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint32m1_t

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_qi-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_qi-compile-1.c
@@ -11,7 +11,7 @@
 ** test_vnsra_qi_i8:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.qi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.qi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint8m1_t
@@ -24,7 +24,7 @@ test_vnsra_qi_i8 (vint32m4_t vs2, vint8m1_t vs1, size_t vl)
 ** test_vnsra_qi_i8_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.qi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.qi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint8m1_t
@@ -37,7 +37,7 @@ test_vnsra_qi_i8_m (vbool8_t mask, vint32m4_t vs2, vint8m1_t vs1, size_t vl)
 ** test_vnsra_qi_i16:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.qi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.qi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint16m1_t
@@ -50,7 +50,7 @@ test_vnsra_qi_i16 (vint64m4_t vs2, vint16m1_t vs1, size_t vl)
 ** test_vnsra_qi_i16_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.qi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.qi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint16m1_t

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_qv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_qv-compile-1.c
@@ -11,7 +11,7 @@
 ** test_vnsra_qv_i8:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.qv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.qv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint8m1_t
@@ -24,7 +24,7 @@ test_vnsra_qv_i8 (vint32m4_t vs2, vint8m1_t vs1, size_t vl)
 ** test_vnsra_qv_i8_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.qv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.qv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint8m1_t
@@ -37,7 +37,7 @@ test_vnsra_qv_i8_m (vbool8_t mask, vint32m4_t vs2, vint8m1_t vs1, size_t vl)
 ** test_vnsra_qv_i16:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.qv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.qv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint16m1_t
@@ -50,7 +50,7 @@ test_vnsra_qv_i16 (vint64m4_t vs2, vint16m1_t vs1, size_t vl)
 ** test_vnsra_qv_i16_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.qv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.qv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint16m1_t

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_qx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_qx-compile-1.c
@@ -11,7 +11,7 @@
 ** test_vnsra_qx_i8:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.qx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.qx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint8m1_t
@@ -24,7 +24,7 @@ test_vnsra_qx_i8 (vint32m4_t vs2, int vs1, size_t vl)
 ** test_vnsra_qx_i8_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.qx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.qx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint8m1_t
@@ -37,7 +37,7 @@ test_vnsra_qx_i8_m (vbool8_t mask, vint32m4_t vs2, int vs1, size_t vl)
 ** test_vnsra_qx_i16:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.qx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.qx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint16m1_t
@@ -50,7 +50,7 @@ test_vnsra_qx_i16 (vint64m4_t vs2, int vs1, size_t vl)
 ** test_vnsra_qx_i16_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.qx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.qx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint16m1_t

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_s_qi-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_s_qi-compile-1.c
@@ -11,7 +11,7 @@
 ** test_vnsra_s_qi_i8:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.qi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.qi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint8m1_t
@@ -24,7 +24,7 @@ test_vnsra_s_qi_i8 (vint32m4_t vs2, vint8m1_t vs1, size_t vl)
 ** test_vnsra_s_qi_i8_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.qi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.qi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint8m1_t
@@ -37,7 +37,7 @@ test_vnsra_s_qi_i8_m (vbool8_t mask, vint32m4_t vs2, vint8m1_t vs1, size_t vl)
 ** test_vnsra_s_qi_i16:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.qi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.qi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint16m1_t
@@ -50,7 +50,7 @@ test_vnsra_s_qi_i16 (vint64m4_t vs2, vint16m1_t vs1, size_t vl)
 ** test_vnsra_s_qi_i16_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.qi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.qi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint16m1_t

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_s_qv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_s_qv-compile-1.c
@@ -11,7 +11,7 @@
 ** test_vnsra_s_qv_i8:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.qv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.qv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint8m1_t
@@ -24,7 +24,7 @@ test_vnsra_s_qv_i8 (vint32m4_t vs2, vint8m1_t vs1, size_t vl)
 ** test_vnsra_s_qv_i8_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.qv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.qv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint8m1_t
@@ -37,7 +37,7 @@ test_vnsra_s_qv_i8_m (vbool8_t mask, vint32m4_t vs2, vint8m1_t vs1, size_t vl)
 ** test_vnsra_s_qv_i16:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.qv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.qv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint16m1_t
@@ -50,7 +50,7 @@ test_vnsra_s_qv_i16 (vint64m4_t vs2, vint16m1_t vs1, size_t vl)
 ** test_vnsra_s_qv_i16_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.qv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.qv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint16m1_t

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_s_qx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_s_qx-compile-1.c
@@ -11,7 +11,7 @@
 ** test_vnsra_s_qx_i8:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.qx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.qx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint8m1_t
@@ -24,7 +24,7 @@ test_vnsra_s_qx_i8 (vint32m4_t vs2, int vs1, size_t vl)
 ** test_vnsra_s_qx_i8_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.qx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.qx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint8m1_t
@@ -37,7 +37,7 @@ test_vnsra_s_qx_i8_m (vbool8_t mask, vint32m4_t vs2, int vs1, size_t vl)
 ** test_vnsra_s_qx_i16:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.qx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.qx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint16m1_t
@@ -50,7 +50,7 @@ test_vnsra_s_qx_i16 (vint64m4_t vs2, int vs1, size_t vl)
 ** test_vnsra_s_qx_i16_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.qx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.qx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint16m1_t

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_s_wi-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_s_wi-compile-1.c
@@ -11,7 +11,7 @@
 ** test_vnsra_s_wi_i8:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint8m1_t
@@ -24,7 +24,7 @@ test_vnsra_s_wi_i8 (vint16m2_t vs2, vint8m1_t vs1, size_t vl)
 ** test_vnsra_s_wi_i8_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint8m1_t
@@ -37,7 +37,7 @@ test_vnsra_s_wi_i8_m (vbool8_t mask, vint16m2_t vs2, vint8m1_t vs1, size_t vl)
 ** test_vnsra_s_wi_i16:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint16m1_t
@@ -50,7 +50,7 @@ test_vnsra_s_wi_i16 (vint32m2_t vs2, vint16m1_t vs1, size_t vl)
 ** test_vnsra_s_wi_i16_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint16m1_t
@@ -63,7 +63,7 @@ test_vnsra_s_wi_i16_m (vbool16_t mask, vint32m2_t vs2, vint16m1_t vs1, size_t vl
 ** test_vnsra_s_wi_i32:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint32m1_t
@@ -76,7 +76,7 @@ test_vnsra_s_wi_i32 (vint64m2_t vs2, vint32m1_t vs1, size_t vl)
 ** test_vnsra_s_wi_i32_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint32m1_t

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_s_wv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_s_wv-compile-1.c
@@ -11,7 +11,7 @@
 ** test_vnsra_s_wv_i8:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint8m1_t
@@ -24,7 +24,7 @@ test_vnsra_s_wv_i8 (vint16m2_t vs2, vint8m1_t vs1, size_t vl)
 ** test_vnsra_s_wv_i8_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint8m1_t
@@ -37,7 +37,7 @@ test_vnsra_s_wv_i8_m (vbool8_t mask, vint16m2_t vs2, vint8m1_t vs1, size_t vl)
 ** test_vnsra_s_wv_i16:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint16m1_t
@@ -50,7 +50,7 @@ test_vnsra_s_wv_i16 (vint32m2_t vs2, vint16m1_t vs1, size_t vl)
 ** test_vnsra_s_wv_i16_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint16m1_t
@@ -63,7 +63,7 @@ test_vnsra_s_wv_i16_m (vbool16_t mask, vint32m2_t vs2, vint16m1_t vs1, size_t vl
 ** test_vnsra_s_wv_i32:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint32m1_t
@@ -76,7 +76,7 @@ test_vnsra_s_wv_i32 (vint64m2_t vs2, vint32m1_t vs1, size_t vl)
 ** test_vnsra_s_wv_i32_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint32m1_t

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_s_wx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_s_wx-compile-1.c
@@ -11,7 +11,7 @@
 ** test_vnsra_s_wx_i8:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint8m1_t
@@ -24,7 +24,7 @@ test_vnsra_s_wx_i8 (vint16m2_t vs2, int vs1, size_t vl)
 ** test_vnsra_s_wx_i8_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint8m1_t
@@ -37,7 +37,7 @@ test_vnsra_s_wx_i8_m (vbool8_t mask, vint16m2_t vs2, int vs1, size_t vl)
 ** test_vnsra_s_wx_i16:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint16m1_t
@@ -50,7 +50,7 @@ test_vnsra_s_wx_i16 (vint32m2_t vs2, int vs1, size_t vl)
 ** test_vnsra_s_wx_i16_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint16m1_t
@@ -63,7 +63,7 @@ test_vnsra_s_wx_i16_m (vbool16_t mask, vint32m2_t vs2, int vs1, size_t vl)
 ** test_vnsra_s_wx_i32:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint32m1_t
@@ -76,7 +76,7 @@ test_vnsra_s_wx_i32 (vint64m2_t vs2, int vs1, size_t vl)
 ** test_vnsra_s_wx_i32_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.s.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.s.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint32m1_t

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_wi-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_wi-compile-1.c
@@ -11,7 +11,7 @@
 ** test_vnsra_wi_i8:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint8m1_t
@@ -24,7 +24,7 @@ test_vnsra_wi_i8 (vint16m2_t vs2, vint8m1_t vs1, size_t vl)
 ** test_vnsra_wi_i8_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint8m1_t
@@ -37,7 +37,7 @@ test_vnsra_wi_i8_m (vbool8_t mask, vint16m2_t vs2, vint8m1_t vs1, size_t vl)
 ** test_vnsra_wi_i16:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint16m1_t
@@ -50,7 +50,7 @@ test_vnsra_wi_i16 (vint32m2_t vs2, vint16m1_t vs1, size_t vl)
 ** test_vnsra_wi_i16_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint16m1_t
@@ -63,7 +63,7 @@ test_vnsra_wi_i16_m (vbool16_t mask, vint32m2_t vs2, vint16m1_t vs1, size_t vl)
 ** test_vnsra_wi_i32:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint32m1_t
@@ -76,7 +76,7 @@ test_vnsra_wi_i32 (vint64m2_t vs2, vint32m1_t vs1, size_t vl)
 ** test_vnsra_wi_i32_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.wi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint32m1_t

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_wv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_wv-compile-1.c
@@ -11,7 +11,7 @@
 ** test_vnsra_wv_i8:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint8m1_t
@@ -24,7 +24,7 @@ test_vnsra_wv_i8 (vint16m2_t vs2, vint8m1_t vs1, size_t vl)
 ** test_vnsra_wv_i8_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint8m1_t
@@ -37,7 +37,7 @@ test_vnsra_wv_i8_m (vbool8_t mask, vint16m2_t vs2, vint8m1_t vs1, size_t vl)
 ** test_vnsra_wv_i16:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint16m1_t
@@ -50,7 +50,7 @@ test_vnsra_wv_i16 (vint32m2_t vs2, vint16m1_t vs1, size_t vl)
 ** test_vnsra_wv_i16_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint16m1_t
@@ -63,7 +63,7 @@ test_vnsra_wv_i16_m (vbool16_t mask, vint32m2_t vs2, vint16m1_t vs1, size_t vl)
 ** test_vnsra_wv_i32:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint32m1_t
@@ -76,7 +76,7 @@ test_vnsra_wv_i32 (vint64m2_t vs2, vint32m1_t vs1, size_t vl)
 ** test_vnsra_wv_i32_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.wv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint32m1_t

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_wx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_wx-compile-1.c
@@ -11,7 +11,7 @@
 ** test_vnsra_wx_i8:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint8m1_t
@@ -24,7 +24,7 @@ test_vnsra_wx_i8 (vint16m2_t vs2, int vs1, size_t vl)
 ** test_vnsra_wx_i8_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint8m1_t
@@ -37,7 +37,7 @@ test_vnsra_wx_i8_m (vbool8_t mask, vint16m2_t vs2, int vs1, size_t vl)
 ** test_vnsra_wx_i16:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint16m1_t
@@ -50,7 +50,7 @@ test_vnsra_wx_i16 (vint32m2_t vs2, int vs1, size_t vl)
 ** test_vnsra_wx_i16_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint16m1_t
@@ -63,7 +63,7 @@ test_vnsra_wx_i16_m (vbool16_t mask, vint32m2_t vs2, int vs1, size_t vl)
 ** test_vnsra_wx_i32:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint32m1_t
@@ -76,7 +76,7 @@ test_vnsra_wx_i32 (vint64m2_t vs2, int vs1, size_t vl)
 ** test_vnsra_wx_i32_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
-**   arcv.vnsra.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vnsra.wx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint32m1_t

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vqrdot_2s_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vqrdot_2s_vv-compile-1.c
@@ -1,17 +1,53 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m1_t test_vqrdot_2s_vv_i8 (vint32m1_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqrdot_2s_vv_i8m1_i32m1 (vd, vs1, vs2, vl); }
-vint32m1_t test_vqrdot_2s_vv_i8_m (vbool8_t mask, vint32m1_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqrdot_2s_vv_i8m1_i32m1_m (mask, vd, vs1, vs2, vl); }
-vint64m1_t test_vqrdot_2s_vv_i16 (vint64m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqrdot_2s_vv_i16m1_i64m1 (vd, vs1, vs2, vl); }
-vint64m1_t test_vqrdot_2s_vv_i16_m (vbool16_t mask, vint64m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqrdot_2s_vv_i16m1_i64m1_m (mask, vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vqrdot\\.2s\\.vv" 4 } } */
+/*
+** test_vqrdot_2s_vv_i8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vqrdot\.2s\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m1_t test_vqrdot_2s_vv_i8 (vint32m1_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqrdot_2s_vv_i8m1_i32m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vqrdot_2s_vv_i8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vqrdot\.2s\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_vqrdot_2s_vv_i8_m (vbool8_t mask, vint32m1_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqrdot_2s_vv_i8m1_i32m1_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vqrdot_2s_vv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vqrdot\.2s\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint64m1_t test_vqrdot_2s_vv_i16 (vint64m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqrdot_2s_vv_i16m1_i64m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vqrdot_2s_vv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vqrdot\.2s\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint64m1_t test_vqrdot_2s_vv_i16_m (vbool16_t mask, vint64m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqrdot_2s_vv_i16m1_i64m1_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vqrdot_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vqrdot_vv-compile-1.c
@@ -1,17 +1,53 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m1_t test_vqrdot_vv_i8 (vint32m1_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqrdot_vv_i8m1_i32m1 (vd, vs1, vs2, vl); }
-vint32m1_t test_vqrdot_vv_i8_m (vbool8_t mask, vint32m1_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqrdot_vv_i8m1_i32m1_m (mask, vd, vs1, vs2, vl); }
-vint64m1_t test_vqrdot_vv_i16 (vint64m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqrdot_vv_i16m1_i64m1 (vd, vs1, vs2, vl); }
-vint64m1_t test_vqrdot_vv_i16_m (vbool16_t mask, vint64m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqrdot_vv_i16m1_i64m1_m (mask, vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vqrdot\\.vv" 4 } } */
+/*
+** test_vqrdot_vv_i8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vqrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m1_t test_vqrdot_vv_i8 (vint32m1_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqrdot_vv_i8m1_i32m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vqrdot_vv_i8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vqrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_vqrdot_vv_i8_m (vbool8_t mask, vint32m1_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqrdot_vv_i8m1_i32m1_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vqrdot_vv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vqrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint64m1_t test_vqrdot_vv_i16 (vint64m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqrdot_vv_i16m1_i64m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vqrdot_vv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vqrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint64m1_t test_vqrdot_vv_i16_m (vbool16_t mask, vint64m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqrdot_vv_i16m1_i64m1_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vqrdotsu_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vqrdotsu_vv-compile-1.c
@@ -1,17 +1,53 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m1_t test_vqrdotsu_vv_i8 (vint32m1_t vd, vint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqrdotsu_vv_i8m1_i32m1 (vd, vs1, vs2, vl); }
-vint32m1_t test_vqrdotsu_vv_i8_m (vbool8_t mask, vint32m1_t vd, vint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqrdotsu_vv_i8m1_i32m1_m (mask, vd, vs1, vs2, vl); }
-vint64m1_t test_vqrdotsu_vv_i16 (vint64m1_t vd, vint16m1_t vs1, vuint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqrdotsu_vv_i16m1_i64m1 (vd, vs1, vs2, vl); }
-vint64m1_t test_vqrdotsu_vv_i16_m (vbool16_t mask, vint64m1_t vd, vint16m1_t vs1, vuint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqrdotsu_vv_i16m1_i64m1_m (mask, vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vqrdotsu\\.vv" 4 } } */
+/*
+** test_vqrdotsu_vv_i8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vqrdotsu\.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint32m1_t test_vqrdotsu_vv_i8 (vint32m1_t vd, vint8m1_t vs1, vuint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqrdotsu_vv_i8m1_i32m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vqrdotsu_vv_i8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vqrdotsu\.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint32m1_t test_vqrdotsu_vv_i8_m (vbool8_t mask, vint32m1_t vd, vint8m1_t vs1, vuint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqrdotsu_vv_i8m1_i32m1_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vqrdotsu_vv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vqrdotsu\.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint64m1_t test_vqrdotsu_vv_i16 (vint64m1_t vd, vint16m1_t vs1, vuint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqrdotsu_vv_i16m1_i64m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vqrdotsu_vv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vqrdotsu\.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint64m1_t test_vqrdotsu_vv_i16_m (vbool16_t mask, vint64m1_t vd, vint16m1_t vs1, vuint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqrdotsu_vv_i16m1_i64m1_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vqrdotu_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vqrdotu_vv-compile-1.c
@@ -1,17 +1,53 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vuint32m1_t test_vqrdotu_vv_u8 (vuint32m1_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqrdotu_vv_u8m1_u32m1 (vd, vs1, vs2, vl); }
-vuint32m1_t test_vqrdotu_vv_u8_m (vbool8_t mask, vuint32m1_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqrdotu_vv_u8m1_u32m1_m (mask, vd, vs1, vs2, vl); }
-vuint64m1_t test_vqrdotu_vv_u16 (vuint64m1_t vd, vuint16m1_t vs1, vuint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqrdotu_vv_u16m1_u64m1 (vd, vs1, vs2, vl); }
-vuint64m1_t test_vqrdotu_vv_u16_m (vbool16_t mask, vuint64m1_t vd, vuint16m1_t vs1, vuint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqrdotu_vv_u16m1_u64m1_m (mask, vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vqrdotu\\.vv" 4 } } */
+/*
+** test_vqrdotu_vv_u8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vqrdotu\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vuint32m1_t test_vqrdotu_vv_u8 (vuint32m1_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqrdotu_vv_u8m1_u32m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vqrdotu_vv_u8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vqrdotu\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vuint32m1_t test_vqrdotu_vv_u8_m (vbool8_t mask, vuint32m1_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqrdotu_vv_u8m1_u32m1_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vqrdotu_vv_u16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vqrdotu\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vuint64m1_t test_vqrdotu_vv_u16 (vuint64m1_t vd, vuint16m1_t vs1, vuint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqrdotu_vv_u16m1_u64m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vqrdotu_vv_u16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vqrdotu\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vuint64m1_t test_vqrdotu_vv_u16_m (vbool16_t mask, vuint64m1_t vd, vuint16m1_t vs1, vuint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqrdotu_vv_u16m1_u64m1_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsaddsub_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsaddsub_vv-compile-1.c
@@ -1,21 +1,75 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint16m1_t test_vsaddsub_vv_i16 (vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
-  return __riscv_arcv_vsaddsub_vv_i16m1 (vs2, vs1, vl); }
-vint16m1_t test_vsaddsub_vv_i16_m (vbool16_t mask, vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
-  return __riscv_arcv_vsaddsub_vv_i16m1_m (mask, vs2, vs1, vl); }
-vint32m1_t test_vsaddsub_vv_i32 (vint32m1_t vs2, vint32m1_t vs1, size_t vl) {
-  return __riscv_arcv_vsaddsub_vv_i32m1 (vs2, vs1, vl); }
-vint32m1_t test_vsaddsub_vv_i32_m (vbool32_t mask, vint32m1_t vs2, vint32m1_t vs1, size_t vl) {
-  return __riscv_arcv_vsaddsub_vv_i32m1_m (mask, vs2, vs1, vl); }
-vint64m1_t test_vsaddsub_vv_i64 (vint64m1_t vs2, vint64m1_t vs1, size_t vl) {
-  return __riscv_arcv_vsaddsub_vv_i64m1 (vs2, vs1, vl); }
-vint64m1_t test_vsaddsub_vv_i64_m (vbool64_t mask, vint64m1_t vs2, vint64m1_t vs1, size_t vl) {
-  return __riscv_arcv_vsaddsub_vv_i64m1_m (mask, vs2, vs1, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vsaddsub\\.vv" 6 } } */
+/*
+** test_vsaddsub_vv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vsaddsub\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint16m1_t test_vsaddsub_vv_i16 (vint16m1_t vs2, vint16m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vsaddsub_vv_i16m1 (vs2, vs1, vl);
+}
+
+/*
+** test_vsaddsub_vv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vsaddsub\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint16m1_t test_vsaddsub_vv_i16_m (vbool16_t mask, vint16m1_t vs2, vint16m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vsaddsub_vv_i16m1_m (mask, vs2, vs1, vl);
+}
+
+/*
+** test_vsaddsub_vv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vsaddsub\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m1_t test_vsaddsub_vv_i32 (vint32m1_t vs2, vint32m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vsaddsub_vv_i32m1 (vs2, vs1, vl);
+}
+
+/*
+** test_vsaddsub_vv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vsaddsub\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_vsaddsub_vv_i32_m (vbool32_t mask, vint32m1_t vs2, vint32m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vsaddsub_vv_i32m1_m (mask, vs2, vs1, vl);
+}
+
+/*
+** test_vsaddsub_vv_i64:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m1,\s*t[au],\s*m[au]
+**  arcv\.vsaddsub\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint64m1_t test_vsaddsub_vv_i64 (vint64m1_t vs2, vint64m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vsaddsub_vv_i64m1 (vs2, vs1, vl);
+}
+
+/*
+** test_vsaddsub_vv_i64_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m1,\s*t[au],\s*m[au]
+**  arcv\.vsaddsub\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint64m1_t test_vsaddsub_vv_i64_m (vbool64_t mask, vint64m1_t vs2, vint64m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vsaddsub_vv_i64m1_m (mask, vs2, vs1, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsmulf_hv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsmulf_hv-compile-1.c
@@ -11,7 +11,7 @@
 ** test_vsmulf_hv_i16:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vsmulf.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vsmulf.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint16m1_t
@@ -24,7 +24,7 @@ test_vsmulf_hv_i16 (vint8mf2_t vs2, vint16m1_t vs1, size_t vl)
 ** test_vsmulf_hv_i16_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vsmulf.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vsmulf.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint16m1_t
@@ -37,7 +37,7 @@ test_vsmulf_hv_i16_m (vbool16_t mask, vint8mf2_t vs2, vint16m1_t vs1, size_t vl)
 ** test_vsmulf_hv_i32:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
-**   arcv.vsmulf.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vsmulf.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint32m1_t
@@ -50,7 +50,7 @@ test_vsmulf_hv_i32 (vint16mf2_t vs2, vint32m1_t vs1, size_t vl)
 ** test_vsmulf_hv_i32_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
-**   arcv.vsmulf.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vsmulf.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint32m1_t

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsmulf_hx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsmulf_hx-compile-1.c
@@ -11,7 +11,7 @@
 ** test_vsmulf_hx_i16:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vsmulf.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vsmulf.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint16m1_t
@@ -24,7 +24,7 @@ test_vsmulf_hx_i16 (vint8mf2_t vs2, int vs1, size_t vl)
 ** test_vsmulf_hx_i16_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
-**   arcv.vsmulf.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vsmulf.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint16m1_t
@@ -37,7 +37,7 @@ test_vsmulf_hx_i16_m (vbool16_t mask, vint8mf2_t vs2, int vs1, size_t vl)
 ** test_vsmulf_hx_i32:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
-**   arcv.vsmulf.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vsmulf.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint32m1_t
@@ -50,7 +50,7 @@ test_vsmulf_hx_i32 (vint16mf2_t vs2, int vs1, size_t vl)
 ** test_vsmulf_hx_i32_m:
 **   csrwi\s+vxrm,0
 **   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
-**   arcv.vsmulf.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vsmulf.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint32m1_t

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsneg_v-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsneg_v-compile-1.c
@@ -1,25 +1,97 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint8m1_t test_vsneg_v_i8 (vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vsneg_v_i8m1 (vs2, vl); }
-vint8m1_t test_vsneg_v_i8_m (vbool8_t mask, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vsneg_v_i8m1_m (mask, vs2, vl); }
-vint16m1_t test_vsneg_v_i16 (vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vsneg_v_i16m1 (vs2, vl); }
-vint16m1_t test_vsneg_v_i16_m (vbool16_t mask, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vsneg_v_i16m1_m (mask, vs2, vl); }
-vint32m1_t test_vsneg_v_i32 (vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vsneg_v_i32m1 (vs2, vl); }
-vint32m1_t test_vsneg_v_i32_m (vbool32_t mask, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vsneg_v_i32m1_m (mask, vs2, vl); }
-vint64m1_t test_vsneg_v_i64 (vint64m1_t vs2, size_t vl) {
-  return __riscv_arcv_vsneg_v_i64m1 (vs2, vl); }
-vint64m1_t test_vsneg_v_i64_m (vbool64_t mask, vint64m1_t vs2, size_t vl) {
-  return __riscv_arcv_vsneg_v_i64m1_m (mask, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vsneg\\.v" 8 } } */
+/*
+** test_vsneg_v_i8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vsneg\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint8m1_t test_vsneg_v_i8 (vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vsneg_v_i8m1 (vs2, vl);
+}
+
+/*
+** test_vsneg_v_i8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vsneg\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint8m1_t test_vsneg_v_i8_m (vbool8_t mask, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vsneg_v_i8m1_m (mask, vs2, vl);
+}
+
+/*
+** test_vsneg_v_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vsneg\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint16m1_t test_vsneg_v_i16 (vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vsneg_v_i16m1 (vs2, vl);
+}
+
+/*
+** test_vsneg_v_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vsneg\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint16m1_t test_vsneg_v_i16_m (vbool16_t mask, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vsneg_v_i16m1_m (mask, vs2, vl);
+}
+
+/*
+** test_vsneg_v_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vsneg\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m1_t test_vsneg_v_i32 (vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vsneg_v_i32m1 (vs2, vl);
+}
+
+/*
+** test_vsneg_v_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vsneg\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_vsneg_v_i32_m (vbool32_t mask, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vsneg_v_i32m1_m (mask, vs2, vl);
+}
+
+/*
+** test_vsneg_v_i64:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m1,\s*t[au],\s*m[au]
+**  arcv\.vsneg\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint64m1_t test_vsneg_v_i64 (vint64m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vsneg_v_i64m1 (vs2, vl);
+}
+
+/*
+** test_vsneg_v_i64_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m1,\s*t[au],\s*m[au]
+**  arcv\.vsneg\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint64m1_t test_vsneg_v_i64_m (vbool64_t mask, vint64m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vsneg_v_i64m1_m (mask, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsra_2s_vi-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsra_2s_vi-compile-1.c
@@ -4,7 +4,6 @@
 /* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
-
 #include <stddef.h>
 #include <riscv_vector.h>
 

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsra_s_vi-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsra_s_vi-compile-1.c
@@ -4,7 +4,6 @@
 /* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
-
 #include <stddef.h>
 #include <riscv_vector.h>
 

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsrat_vi-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsrat_vi-compile-1.c
@@ -1,25 +1,97 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint8m1_t test_vsrat_vi_i8 (vint8m1_t vs2, vint8m1_t vs1, size_t vl) {
-  return __riscv_arcv_vsrat_vx_i8m1 (vs2, 1, vl); }
-vint8m1_t test_vsrat_vi_i8_m (vbool8_t mask, vint8m1_t vs2, vint8m1_t vs1, size_t vl) {
-  return __riscv_arcv_vsrat_vx_i8m1_m (mask, vs2, 1, vl); }
-vint16m1_t test_vsrat_vi_i16 (vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
-  return __riscv_arcv_vsrat_vx_i16m1 (vs2, 1, vl); }
-vint16m1_t test_vsrat_vi_i16_m (vbool16_t mask, vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
-  return __riscv_arcv_vsrat_vx_i16m1_m (mask, vs2, 1, vl); }
-vint32m1_t test_vsrat_vi_i32 (vint32m1_t vs2, vint32m1_t vs1, size_t vl) {
-  return __riscv_arcv_vsrat_vx_i32m1 (vs2, 1, vl); }
-vint32m1_t test_vsrat_vi_i32_m (vbool32_t mask, vint32m1_t vs2, vint32m1_t vs1, size_t vl) {
-  return __riscv_arcv_vsrat_vx_i32m1_m (mask, vs2, 1, vl); }
-vint64m1_t test_vsrat_vi_i64 (vint64m1_t vs2, vint64m1_t vs1, size_t vl) {
-  return __riscv_arcv_vsrat_vx_i64m1 (vs2, 1, vl); }
-vint64m1_t test_vsrat_vi_i64_m (vbool64_t mask, vint64m1_t vs2, vint64m1_t vs1, size_t vl) {
-  return __riscv_arcv_vsrat_vx_i64m1_m (mask, vs2, 1, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vsrat\\.vi" 8 } } */
+/*
+** test_vsrat_vi_i8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vsrat\.vi\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
+**  ret
+*/
+vint8m1_t test_vsrat_vi_i8 (vint8m1_t vs2, vint8m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vsrat_vx_i8m1 (vs2, 1, vl);
+}
+
+/*
+** test_vsrat_vi_i8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vsrat\.vi\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1,\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint8m1_t test_vsrat_vi_i8_m (vbool8_t mask, vint8m1_t vs2, vint8m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vsrat_vx_i8m1_m (mask, vs2, 1, vl);
+}
+
+/*
+** test_vsrat_vi_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vsrat\.vi\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
+**  ret
+*/
+vint16m1_t test_vsrat_vi_i16 (vint16m1_t vs2, vint16m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vsrat_vx_i16m1 (vs2, 1, vl);
+}
+
+/*
+** test_vsrat_vi_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vsrat\.vi\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1,\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint16m1_t test_vsrat_vi_i16_m (vbool16_t mask, vint16m1_t vs2, vint16m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vsrat_vx_i16m1_m (mask, vs2, 1, vl);
+}
+
+/*
+** test_vsrat_vi_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vsrat\.vi\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
+**  ret
+*/
+vint32m1_t test_vsrat_vi_i32 (vint32m1_t vs2, vint32m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vsrat_vx_i32m1 (vs2, 1, vl);
+}
+
+/*
+** test_vsrat_vi_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vsrat\.vi\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1,\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_vsrat_vi_i32_m (vbool32_t mask, vint32m1_t vs2, vint32m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vsrat_vx_i32m1_m (mask, vs2, 1, vl);
+}
+
+/*
+** test_vsrat_vi_i64:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m1,\s*t[au],\s*m[au]
+**  arcv\.vsrat\.vi\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
+**  ret
+*/
+vint64m1_t test_vsrat_vi_i64 (vint64m1_t vs2, vint64m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vsrat_vx_i64m1 (vs2, 1, vl);
+}
+
+/*
+** test_vsrat_vi_i64_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m1,\s*t[au],\s*m[au]
+**  arcv\.vsrat\.vi\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1,\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint64m1_t test_vsrat_vi_i64_m (vbool64_t mask, vint64m1_t vs2, vint64m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vsrat_vx_i64m1_m (mask, vs2, 1, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsrat_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsrat_vv-compile-1.c
@@ -1,25 +1,97 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint8m1_t test_vsrat_vv_i8 (vint8m1_t vs2, vint8m1_t vs1, size_t vl) {
-  return __riscv_arcv_vsrat_vv_i8m1 (vs2, vs1, vl); }
-vint8m1_t test_vsrat_vv_i8_m (vbool8_t mask, vint8m1_t vs2, vint8m1_t vs1, size_t vl) {
-  return __riscv_arcv_vsrat_vv_i8m1_m (mask, vs2, vs1, vl); }
-vint16m1_t test_vsrat_vv_i16 (vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
-  return __riscv_arcv_vsrat_vv_i16m1 (vs2, vs1, vl); }
-vint16m1_t test_vsrat_vv_i16_m (vbool16_t mask, vint16m1_t vs2, vint16m1_t vs1, size_t vl) {
-  return __riscv_arcv_vsrat_vv_i16m1_m (mask, vs2, vs1, vl); }
-vint32m1_t test_vsrat_vv_i32 (vint32m1_t vs2, vint32m1_t vs1, size_t vl) {
-  return __riscv_arcv_vsrat_vv_i32m1 (vs2, vs1, vl); }
-vint32m1_t test_vsrat_vv_i32_m (vbool32_t mask, vint32m1_t vs2, vint32m1_t vs1, size_t vl) {
-  return __riscv_arcv_vsrat_vv_i32m1_m (mask, vs2, vs1, vl); }
-vint64m1_t test_vsrat_vv_i64 (vint64m1_t vs2, vint64m1_t vs1, size_t vl) {
-  return __riscv_arcv_vsrat_vv_i64m1 (vs2, vs1, vl); }
-vint64m1_t test_vsrat_vv_i64_m (vbool64_t mask, vint64m1_t vs2, vint64m1_t vs1, size_t vl) {
-  return __riscv_arcv_vsrat_vv_i64m1_m (mask, vs2, vs1, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vsrat\\.vv" 8 } } */
+/*
+** test_vsrat_vv_i8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vsrat\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint8m1_t test_vsrat_vv_i8 (vint8m1_t vs2, vint8m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vsrat_vv_i8m1 (vs2, vs1, vl);
+}
+
+/*
+** test_vsrat_vv_i8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vsrat\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint8m1_t test_vsrat_vv_i8_m (vbool8_t mask, vint8m1_t vs2, vint8m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vsrat_vv_i8m1_m (mask, vs2, vs1, vl);
+}
+
+/*
+** test_vsrat_vv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vsrat\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint16m1_t test_vsrat_vv_i16 (vint16m1_t vs2, vint16m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vsrat_vv_i16m1 (vs2, vs1, vl);
+}
+
+/*
+** test_vsrat_vv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vsrat\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint16m1_t test_vsrat_vv_i16_m (vbool16_t mask, vint16m1_t vs2, vint16m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vsrat_vv_i16m1_m (mask, vs2, vs1, vl);
+}
+
+/*
+** test_vsrat_vv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vsrat\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m1_t test_vsrat_vv_i32 (vint32m1_t vs2, vint32m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vsrat_vv_i32m1 (vs2, vs1, vl);
+}
+
+/*
+** test_vsrat_vv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vsrat\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_vsrat_vv_i32_m (vbool32_t mask, vint32m1_t vs2, vint32m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vsrat_vv_i32m1_m (mask, vs2, vs1, vl);
+}
+
+/*
+** test_vsrat_vv_i64:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m1,\s*t[au],\s*m[au]
+**  arcv\.vsrat\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint64m1_t test_vsrat_vv_i64 (vint64m1_t vs2, vint64m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vsrat_vv_i64m1 (vs2, vs1, vl);
+}
+
+/*
+** test_vsrat_vv_i64_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m1,\s*t[au],\s*m[au]
+**  arcv\.vsrat\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint64m1_t test_vsrat_vv_i64_m (vbool64_t mask, vint64m1_t vs2, vint64m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vsrat_vv_i64m1_m (mask, vs2, vs1, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsrat_vx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsrat_vx-compile-1.c
@@ -1,25 +1,101 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint8m1_t test_vsrat_vx_i8 (vint8m1_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vsrat_vx_i8m1 (vs2, vs1, vl); }
-vint8m1_t test_vsrat_vx_i8_m (vbool8_t mask, vint8m1_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vsrat_vx_i8m1_m (mask, vs2, vs1, vl); }
-vint16m1_t test_vsrat_vx_i16 (vint16m1_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vsrat_vx_i16m1 (vs2, vs1, vl); }
-vint16m1_t test_vsrat_vx_i16_m (vbool16_t mask, vint16m1_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vsrat_vx_i16m1_m (mask, vs2, vs1, vl); }
-vint32m1_t test_vsrat_vx_i32 (vint32m1_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vsrat_vx_i32m1 (vs2, vs1, vl); }
-vint32m1_t test_vsrat_vx_i32_m (vbool32_t mask, vint32m1_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vsrat_vx_i32m1_m (mask, vs2, vs1, vl); }
-vint64m1_t test_vsrat_vx_i64 (vint64m1_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vsrat_vx_i64m1 (vs2, vs1, vl); }
-vint64m1_t test_vsrat_vx_i64_m (vbool64_t mask, vint64m1_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vsrat_vx_i64m1_m (mask, vs2, vs1, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vsrat\\.vx" 8 } } */
+/*
+** test_vsrat_vx_i8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vsrat\.vx\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint8m1_t test_vsrat_vx_i8 (vint8m1_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vsrat_vx_i8m1 (vs2, vs1, vl);
+}
+
+/*
+** test_vsrat_vx_i8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vsrat\.vx\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint8m1_t test_vsrat_vx_i8_m (vbool8_t mask, vint8m1_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vsrat_vx_i8m1_m (mask, vs2, vs1, vl);
+}
+
+/*
+** test_vsrat_vx_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vsrat\.vx\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint16m1_t test_vsrat_vx_i16 (vint16m1_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vsrat_vx_i16m1 (vs2, vs1, vl);
+}
+
+/*
+** test_vsrat_vx_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vsrat\.vx\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint16m1_t test_vsrat_vx_i16_m (vbool16_t mask, vint16m1_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vsrat_vx_i16m1_m (mask, vs2, vs1, vl);
+}
+
+/*
+** test_vsrat_vx_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vsrat\.vx\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint32m1_t test_vsrat_vx_i32 (vint32m1_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vsrat_vx_i32m1 (vs2, vs1, vl);
+}
+
+/*
+** test_vsrat_vx_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vsrat\.vx\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_vsrat_vx_i32_m (vbool32_t mask, vint32m1_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vsrat_vx_i32m1_m (mask, vs2, vs1, vl);
+}
+
+/*
+** test_vsrat_vx_i64:
+**  mv	a4,a0
+**  srai	a5,a0,31
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m1,\s*t[au],\s*m[au]
+**  arcv\.vsrat\.vx\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint64m1_t test_vsrat_vx_i64 (vint64m1_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vsrat_vx_i64m1 (vs2, vs1, vl);
+}
+
+/*
+** test_vsrat_vx_i64_m:
+**  mv	a4,a0
+**  srai	a5,a0,31
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m1,\s*t[au],\s*m[au]
+**  arcv\.vsrat\.vx\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint64m1_t test_vsrat_vx_i64_m (vbool64_t mask, vint64m1_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vsrat_vx_i64m1_m (mask, vs2, vs1, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vssabs_v-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vssabs_v-compile-1.c
@@ -1,25 +1,97 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint8m1_t test_vssabs_v_i8 (vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vssabs_v_i8m1 (vs2, vl); }
-vint8m1_t test_vssabs_v_i8_m (vbool8_t mask, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vssabs_v_i8m1_m (mask, vs2, vl); }
-vint16m1_t test_vssabs_v_i16 (vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vssabs_v_i16m1 (vs2, vl); }
-vint16m1_t test_vssabs_v_i16_m (vbool16_t mask, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vssabs_v_i16m1_m (mask, vs2, vl); }
-vint32m1_t test_vssabs_v_i32 (vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vssabs_v_i32m1 (vs2, vl); }
-vint32m1_t test_vssabs_v_i32_m (vbool32_t mask, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vssabs_v_i32m1_m (mask, vs2, vl); }
-vint64m1_t test_vssabs_v_i64 (vint64m1_t vs2, size_t vl) {
-  return __riscv_arcv_vssabs_v_i64m1 (vs2, vl); }
-vint64m1_t test_vssabs_v_i64_m (vbool64_t mask, vint64m1_t vs2, size_t vl) {
-  return __riscv_arcv_vssabs_v_i64m1_m (mask, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vssabs\\.v" 8 } } */
+/*
+** test_vssabs_v_i8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vssabs\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint8m1_t test_vssabs_v_i8 (vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vssabs_v_i8m1 (vs2, vl);
+}
+
+/*
+** test_vssabs_v_i8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vssabs\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint8m1_t test_vssabs_v_i8_m (vbool8_t mask, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vssabs_v_i8m1_m (mask, vs2, vl);
+}
+
+/*
+** test_vssabs_v_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vssabs\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint16m1_t test_vssabs_v_i16 (vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vssabs_v_i16m1 (vs2, vl);
+}
+
+/*
+** test_vssabs_v_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vssabs\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint16m1_t test_vssabs_v_i16_m (vbool16_t mask, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vssabs_v_i16m1_m (mask, vs2, vl);
+}
+
+/*
+** test_vssabs_v_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vssabs\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m1_t test_vssabs_v_i32 (vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vssabs_v_i32m1 (vs2, vl);
+}
+
+/*
+** test_vssabs_v_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vssabs\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_vssabs_v_i32_m (vbool32_t mask, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vssabs_v_i32m1_m (mask, vs2, vl);
+}
+
+/*
+** test_vssabs_v_i64:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m1,\s*t[au],\s*m[au]
+**  arcv\.vssabs\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint64m1_t test_vssabs_v_i64 (vint64m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vssabs_v_i64m1 (vs2, vl);
+}
+
+/*
+** test_vssabs_v_i64_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m1,\s*t[au],\s*m[au]
+**  arcv\.vssabs\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint64m1_t test_vssabs_v_i64_m (vbool64_t mask, vint64m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vssabs_v_i64m1_m (mask, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmac_hv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmac_hv-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m2_t test_vwmac_hv_i16 (vint32m2_t vd, vint16m1_t vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwmac_hv_i32m2 (vd, vs1, vs2, vl); }
-vint32m2_t test_vwmac_hv_i16_m (vbool16_t mask, vint32m2_t vd, vint16m1_t vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwmac_hv_i32m2_m (mask, vd, vs1, vs2, vl); }
-vint64m2_t test_vwmac_hv_i32 (vint64m2_t vd, vint32m1_t vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwmac_hv_i64m2 (vd, vs1, vs2, vl); }
-vint64m2_t test_vwmac_hv_i32_m (vbool32_t mask, vint64m2_t vd, vint32m1_t vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwmac_hv_i64m2_m (mask, vd, vs1, vs2, vl); }
+/*
+** test_vwmac_hv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwmac.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint32m2_t
+test_vwmac_hv_i16 (vint32m2_t vd, vint16m1_t vs1, vint8mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwmac_hv_i32m2 (vd, vs1, vs2, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwmac\\.hv" 4 } } */
+/*
+** test_vwmac_hv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwmac.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint32m2_t
+test_vwmac_hv_i16_m (vbool16_t mask, vint32m2_t vd, vint16m1_t vs1, vint8mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwmac_hv_i32m2_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwmac_hv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwmac.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint64m2_t
+test_vwmac_hv_i32 (vint64m2_t vd, vint32m1_t vs1, vint16mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwmac_hv_i64m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwmac_hv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwmac.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint64m2_t
+test_vwmac_hv_i32_m (vbool32_t mask, vint64m2_t vd, vint32m1_t vs1, vint16mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwmac_hv_i64m2_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmac_hx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmac_hx-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m2_t test_vwmac_hx_i16 (vint32m2_t vd, int vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwmac_hx_i32m2 (vd, vs1, vs2, vl); }
-vint32m2_t test_vwmac_hx_i16_m (vbool16_t mask, vint32m2_t vd, int vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwmac_hx_i32m2_m (mask, vd, vs1, vs2, vl); }
-vint64m2_t test_vwmac_hx_i32 (vint64m2_t vd, int vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwmac_hx_i64m2 (vd, vs1, vs2, vl); }
-vint64m2_t test_vwmac_hx_i32_m (vbool32_t mask, vint64m2_t vd, int vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwmac_hx_i64m2_m (mask, vd, vs1, vs2, vl); }
+/*
+** test_vwmac_hx_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwmac.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint32m2_t
+test_vwmac_hx_i16 (vint32m2_t vd, int vs1, vint8mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwmac_hx_i32m2 (vd, vs1, vs2, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwmac\\.hx" 4 } } */
+/*
+** test_vwmac_hx_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwmac.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint32m2_t
+test_vwmac_hx_i16_m (vbool16_t mask, vint32m2_t vd, int vs1, vint8mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwmac_hx_i32m2_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwmac_hx_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwmac.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint64m2_t
+test_vwmac_hx_i32 (vint64m2_t vd, int vs1, vint16mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwmac_hx_i64m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwmac_hx_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwmac.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint64m2_t
+test_vwmac_hx_i32_m (vbool32_t mask, vint64m2_t vd, int vs1, vint16mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwmac_hx_i64m2_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmacu_hv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmacu_hv-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vuint32m2_t test_vwmacu_hv_u16 (vuint32m2_t vd, vuint16m1_t vs1, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwmacu_hv_u32m2 (vd, vs1, vs2, vl); }
-vuint32m2_t test_vwmacu_hv_u16_m (vbool16_t mask, vuint32m2_t vd, vuint16m1_t vs1, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwmacu_hv_u32m2_m (mask, vd, vs1, vs2, vl); }
-vuint64m2_t test_vwmacu_hv_u32 (vuint64m2_t vd, vuint32m1_t vs1, vuint16mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwmacu_hv_u64m2 (vd, vs1, vs2, vl); }
-vuint64m2_t test_vwmacu_hv_u32_m (vbool32_t mask, vuint64m2_t vd, vuint32m1_t vs1, vuint16mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwmacu_hv_u64m2_m (mask, vd, vs1, vs2, vl); }
+/*
+** test_vwmacu_hv_u16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwmacu.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vuint32m2_t
+test_vwmacu_hv_u16 (vuint32m2_t vd, vuint16m1_t vs1, vuint8mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwmacu_hv_u32m2 (vd, vs1, vs2, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwmacu\\.hv" 4 } } */
+/*
+** test_vwmacu_hv_u16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwmacu.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vuint32m2_t
+test_vwmacu_hv_u16_m (vbool16_t mask, vuint32m2_t vd, vuint16m1_t vs1, vuint8mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwmacu_hv_u32m2_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwmacu_hv_u32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwmacu.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vuint64m2_t
+test_vwmacu_hv_u32 (vuint64m2_t vd, vuint32m1_t vs1, vuint16mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwmacu_hv_u64m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwmacu_hv_u32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwmacu.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vuint64m2_t
+test_vwmacu_hv_u32_m (vbool32_t mask, vuint64m2_t vd, vuint32m1_t vs1, vuint16mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwmacu_hv_u64m2_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmacu_hx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmacu_hx-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vuint32m2_t test_vwmacu_hx_u16 (vuint32m2_t vd, int vs1, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwmacu_hx_u32m2 (vd, vs1, vs2, vl); }
-vuint32m2_t test_vwmacu_hx_u16_m (vbool16_t mask, vuint32m2_t vd, int vs1, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwmacu_hx_u32m2_m (mask, vd, vs1, vs2, vl); }
-vuint64m2_t test_vwmacu_hx_u32 (vuint64m2_t vd, int vs1, vuint16mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwmacu_hx_u64m2 (vd, vs1, vs2, vl); }
-vuint64m2_t test_vwmacu_hx_u32_m (vbool32_t mask, vuint64m2_t vd, int vs1, vuint16mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwmacu_hx_u64m2_m (mask, vd, vs1, vs2, vl); }
+/*
+** test_vwmacu_hx_u16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwmacu.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vuint32m2_t
+test_vwmacu_hx_u16 (vuint32m2_t vd, int vs1, vuint8mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwmacu_hx_u32m2 (vd, vs1, vs2, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwmacu\\.hx" 4 } } */
+/*
+** test_vwmacu_hx_u16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwmacu.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vuint32m2_t
+test_vwmacu_hx_u16_m (vbool16_t mask, vuint32m2_t vd, int vs1, vuint8mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwmacu_hx_u32m2_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwmacu_hx_u32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwmacu.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vuint64m2_t
+test_vwmacu_hx_u32 (vuint64m2_t vd, int vs1, vuint16mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwmacu_hx_u64m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwmacu_hx_u32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwmacu.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vuint64m2_t
+test_vwmacu_hx_u32_m (vbool32_t mask, vuint64m2_t vd, int vs1, vuint16mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwmacu_hx_u64m2_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmul_hv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmul_hv-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m2_t test_vwmul_hv_i16 (vint8mf2_t vs2, vint16m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwmul_hv_i32m2 (vs2, vs1, vl); }
-vint32m2_t test_vwmul_hv_i16_m (vbool16_t mask, vint8mf2_t vs2, vint16m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwmul_hv_i32m2_m (mask, vs2, vs1, vl); }
-vint64m2_t test_vwmul_hv_i32 (vint16mf2_t vs2, vint32m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwmul_hv_i64m2 (vs2, vs1, vl); }
-vint64m2_t test_vwmul_hv_i32_m (vbool32_t mask, vint16mf2_t vs2, vint32m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwmul_hv_i64m2_m (mask, vs2, vs1, vl); }
+/*
+** test_vwmul_hv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwmul.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint32m2_t
+test_vwmul_hv_i16 (vint8mf2_t vs2, vint16m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vwmul_hv_i32m2 (vs2, vs1, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwmul\\.hv" 4 } } */
+/*
+** test_vwmul_hv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwmul.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint32m2_t
+test_vwmul_hv_i16_m (vbool16_t mask, vint8mf2_t vs2, vint16m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vwmul_hv_i32m2_m (mask, vs2, vs1, vl);
+}
+
+/*
+** test_vwmul_hv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwmul.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint64m2_t
+test_vwmul_hv_i32 (vint16mf2_t vs2, vint32m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vwmul_hv_i64m2 (vs2, vs1, vl);
+}
+
+/*
+** test_vwmul_hv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwmul.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint64m2_t
+test_vwmul_hv_i32_m (vbool32_t mask, vint16mf2_t vs2, vint32m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vwmul_hv_i64m2_m (mask, vs2, vs1, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmul_hx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmul_hx-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m2_t test_vwmul_hx_i16 (vint8mf2_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vwmul_hx_i32m2 (vs2, vs1, vl); }
-vint32m2_t test_vwmul_hx_i16_m (vbool16_t mask, vint8mf2_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vwmul_hx_i32m2_m (mask, vs2, vs1, vl); }
-vint64m2_t test_vwmul_hx_i32 (vint16mf2_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vwmul_hx_i64m2 (vs2, vs1, vl); }
-vint64m2_t test_vwmul_hx_i32_m (vbool32_t mask, vint16mf2_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vwmul_hx_i64m2_m (mask, vs2, vs1, vl); }
+/*
+** test_vwmul_hx_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwmul.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint32m2_t
+test_vwmul_hx_i16 (vint8mf2_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vwmul_hx_i32m2 (vs2, vs1, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwmul\\.hx" 4 } } */
+/*
+** test_vwmul_hx_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwmul.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**  ret
+*/
+vint32m2_t
+test_vwmul_hx_i16_m (vbool16_t mask, vint8mf2_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vwmul_hx_i32m2_m (mask, vs2, vs1, vl);
+}
+
+/*
+** test_vwmul_hx_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwmul.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint64m2_t
+test_vwmul_hx_i32 (vint16mf2_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vwmul_hx_i64m2 (vs2, vs1, vl);
+}
+
+/*
+** test_vwmul_hx_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwmul.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**  ret
+*/
+vint64m2_t
+test_vwmul_hx_i32_m (vbool32_t mask, vint16mf2_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vwmul_hx_i64m2_m (mask, vs2, vs1, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmulf_hv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmulf_hv-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m2_t test_vwmulf_hv_i16 (vint8mf2_t vs2, vint16m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwmulf_hv_i32m2 (vs2, vs1, vl); }
-vint32m2_t test_vwmulf_hv_i16_m (vbool16_t mask, vint8mf2_t vs2, vint16m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwmulf_hv_i32m2_m (mask, vs2, vs1, vl); }
-vint64m2_t test_vwmulf_hv_i32 (vint16mf2_t vs2, vint32m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwmulf_hv_i64m2 (vs2, vs1, vl); }
-vint64m2_t test_vwmulf_hv_i32_m (vbool32_t mask, vint16mf2_t vs2, vint32m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwmulf_hv_i64m2_m (mask, vs2, vs1, vl); }
+/*
+** test_vwmulf_hv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwmulf.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint32m2_t
+test_vwmulf_hv_i16 (vint8mf2_t vs2, vint16m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vwmulf_hv_i32m2 (vs2, vs1, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwmulf\\.hv" 4 } } */
+/*
+** test_vwmulf_hv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwmulf.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint32m2_t
+test_vwmulf_hv_i16_m (vbool16_t mask, vint8mf2_t vs2, vint16m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vwmulf_hv_i32m2_m (mask, vs2, vs1, vl);
+}
+
+/*
+** test_vwmulf_hv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwmulf.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint64m2_t
+test_vwmulf_hv_i32 (vint16mf2_t vs2, vint32m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vwmulf_hv_i64m2 (vs2, vs1, vl);
+}
+
+/*
+** test_vwmulf_hv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwmulf.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint64m2_t
+test_vwmulf_hv_i32_m (vbool32_t mask, vint16mf2_t vs2, vint32m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vwmulf_hv_i64m2_m (mask, vs2, vs1, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmulf_hx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmulf_hx-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m2_t test_vwmulf_hx_i16 (vint8mf2_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vwmulf_hx_i32m2 (vs2, vs1, vl); }
-vint32m2_t test_vwmulf_hx_i16_m (vbool16_t mask, vint8mf2_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vwmulf_hx_i32m2_m (mask, vs2, vs1, vl); }
-vint64m2_t test_vwmulf_hx_i32 (vint16mf2_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vwmulf_hx_i64m2 (vs2, vs1, vl); }
-vint64m2_t test_vwmulf_hx_i32_m (vbool32_t mask, vint16mf2_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vwmulf_hx_i64m2_m (mask, vs2, vs1, vl); }
+/*
+** test_vwmulf_hx_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwmulf.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint32m2_t
+test_vwmulf_hx_i16 (vint8mf2_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vwmulf_hx_i32m2 (vs2, vs1, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwmulf\\.hx" 4 } } */
+/*
+** test_vwmulf_hx_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwmulf.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**  ret
+*/
+vint32m2_t
+test_vwmulf_hx_i16_m (vbool16_t mask, vint8mf2_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vwmulf_hx_i32m2_m (mask, vs2, vs1, vl);
+}
+
+/*
+** test_vwmulf_hx_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwmulf.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint64m2_t
+test_vwmulf_hx_i32 (vint16mf2_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vwmulf_hx_i64m2 (vs2, vs1, vl);
+}
+
+/*
+** test_vwmulf_hx_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwmulf.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**  ret
+*/
+vint64m2_t
+test_vwmulf_hx_i32_m (vbool32_t mask, vint16mf2_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vwmulf_hx_i64m2_m (mask, vs2, vs1, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmulu_hv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmulu_hv-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vuint32m2_t test_vwmulu_hv_u16 (vuint8mf2_t vs2, vuint16m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwmulu_hv_u32m2 (vs2, vs1, vl); }
-vuint32m2_t test_vwmulu_hv_u16_m (vbool16_t mask, vuint8mf2_t vs2, vuint16m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwmulu_hv_u32m2_m (mask, vs2, vs1, vl); }
-vuint64m2_t test_vwmulu_hv_u32 (vuint16mf2_t vs2, vuint32m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwmulu_hv_u64m2 (vs2, vs1, vl); }
-vuint64m2_t test_vwmulu_hv_u32_m (vbool32_t mask, vuint16mf2_t vs2, vuint32m1_t vs1, size_t vl) {
-  return __riscv_arcv_vwmulu_hv_u64m2_m (mask, vs2, vs1, vl); }
+/*
+** test_vwmulu_hv_u16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwmulu.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vuint32m2_t
+test_vwmulu_hv_u16 (vuint8mf2_t vs2, vuint16m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vwmulu_hv_u32m2 (vs2, vs1, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwmulu\\.hv" 4 } } */
+/*
+** test_vwmulu_hv_u16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwmulu.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vuint32m2_t
+test_vwmulu_hv_u16_m (vbool16_t mask, vuint8mf2_t vs2, vuint16m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vwmulu_hv_u32m2_m (mask, vs2, vs1, vl);
+}
+
+/*
+** test_vwmulu_hv_u32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwmulu.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vuint64m2_t
+test_vwmulu_hv_u32 (vuint16mf2_t vs2, vuint32m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vwmulu_hv_u64m2 (vs2, vs1, vl);
+}
+
+/*
+** test_vwmulu_hv_u32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwmulu.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vuint64m2_t
+test_vwmulu_hv_u32_m (vbool32_t mask, vuint16mf2_t vs2, vuint32m1_t vs1, size_t vl)
+{
+  return __riscv_arcv_vwmulu_hv_u64m2_m (mask, vs2, vs1, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmulu_hx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmulu_hx-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vuint32m2_t test_vwmulu_hx_u16 (vuint8mf2_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vwmulu_hx_u32m2 (vs2, vs1, vl); }
-vuint32m2_t test_vwmulu_hx_u16_m (vbool16_t mask, vuint8mf2_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vwmulu_hx_u32m2_m (mask, vs2, vs1, vl); }
-vuint64m2_t test_vwmulu_hx_u32 (vuint16mf2_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vwmulu_hx_u64m2 (vs2, vs1, vl); }
-vuint64m2_t test_vwmulu_hx_u32_m (vbool32_t mask, vuint16mf2_t vs2, int vs1, size_t vl) {
-  return __riscv_arcv_vwmulu_hx_u64m2_m (mask, vs2, vs1, vl); }
+/*
+** test_vwmulu_hx_u16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwmulu.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vuint32m2_t
+test_vwmulu_hx_u16 (vuint8mf2_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vwmulu_hx_u32m2 (vs2, vs1, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwmulu\\.hx" 4 } } */
+/*
+** test_vwmulu_hx_u16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwmulu.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**  ret
+*/
+vuint32m2_t
+test_vwmulu_hx_u16_m (vbool16_t mask, vuint8mf2_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vwmulu_hx_u32m2_m (mask, vs2, vs1, vl);
+}
+
+/*
+** test_vwmulu_hx_u32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwmulu.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vuint64m2_t
+test_vwmulu_hx_u32 (vuint16mf2_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vwmulu_hx_u64m2 (vs2, vs1, vl);
+}
+
+/*
+** test_vwmulu_hx_u32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwmulu.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**  ret
+*/
+vuint64m2_t
+test_vwmulu_hx_u32_m (vbool32_t mask, vuint16mf2_t vs2, int vs1, size_t vl)
+{
+  return __riscv_arcv_vwmulu_hx_u64m2_m (mask, vs2, vs1, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwrdot_hv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwrdot_hv-compile-1.c
@@ -1,17 +1,53 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m1_t test_vwrdot_hv_i16 (vint32m1_t vd, vint16m1_t vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwrdot_hv_i16m1_i32m1 (vd, vs1, vs2, vl); }
-vint32m1_t test_vwrdot_hv_i16_m (vbool16_t mask, vint32m1_t vd, vint16m1_t vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwrdot_hv_i16m1_i32m1_m (mask, vd, vs1, vs2, vl); }
-vint64m1_t test_vwrdot_hv_i32 (vint64m1_t vd, vint32m1_t vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwrdot_hv_i32m1_i64m1 (vd, vs1, vs2, vl); }
-vint64m1_t test_vwrdot_hv_i32_m (vbool32_t mask, vint64m1_t vd, vint32m1_t vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwrdot_hv_i32m1_i64m1_m (mask, vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vwrdot\\.hv" 4 } } */
+/*
+** test_vwrdot_hv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vwrdot\.hv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m1_t test_vwrdot_hv_i16 (vint32m1_t vd, vint16m1_t vs1, vint8mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwrdot_hv_i16m1_i32m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwrdot_hv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vwrdot\.hv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_vwrdot_hv_i16_m (vbool16_t mask, vint32m1_t vd, vint16m1_t vs1, vint8mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwrdot_hv_i16m1_i32m1_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwrdot_hv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vwrdot\.hv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint64m1_t test_vwrdot_hv_i32 (vint64m1_t vd, vint32m1_t vs1, vint16mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwrdot_hv_i32m1_i64m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwrdot_hv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vwrdot\.hv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint64m1_t test_vwrdot_hv_i32_m (vbool32_t mask, vint64m1_t vd, vint32m1_t vs1, vint16mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwrdot_hv_i32m1_i64m1_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwrdot_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwrdot_vv-compile-1.c
@@ -1,21 +1,75 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint16m1_t test_vwrdot_vv_i8 (vint16m1_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwrdot_vv_i8m1_i16m1 (vd, vs1, vs2, vl); }
-vint16m1_t test_vwrdot_vv_i8_m (vbool8_t mask, vint16m1_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwrdot_vv_i8m1_i16m1_m (mask, vd, vs1, vs2, vl); }
-vint32m1_t test_vwrdot_vv_i16 (vint32m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwrdot_vv_i16m1_i32m1 (vd, vs1, vs2, vl); }
-vint32m1_t test_vwrdot_vv_i16_m (vbool16_t mask, vint32m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwrdot_vv_i16m1_i32m1_m (mask, vd, vs1, vs2, vl); }
-vint64m1_t test_vwrdot_vv_i32 (vint64m1_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwrdot_vv_i32m1_i64m1 (vd, vs1, vs2, vl); }
-vint64m1_t test_vwrdot_vv_i32_m (vbool32_t mask, vint64m1_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwrdot_vv_i32m1_i64m1_m (mask, vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vwrdot\\.vv" 6 } } */
+/*
+** test_vwrdot_vv_i8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vwrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint16m1_t test_vwrdot_vv_i8 (vint16m1_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwrdot_vv_i8m1_i16m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwrdot_vv_i8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vwrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint16m1_t test_vwrdot_vv_i8_m (vbool8_t mask, vint16m1_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwrdot_vv_i8m1_i16m1_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwrdot_vv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vwrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m1_t test_vwrdot_vv_i16 (vint32m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwrdot_vv_i16m1_i32m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwrdot_vv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vwrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_vwrdot_vv_i16_m (vbool16_t mask, vint32m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwrdot_vv_i16m1_i32m1_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwrdot_vv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vwrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint64m1_t test_vwrdot_vv_i32 (vint64m1_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwrdot_vv_i32m1_i64m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwrdot_vv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vwrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint64m1_t test_vwrdot_vv_i32_m (vbool32_t mask, vint64m1_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwrdot_vv_i32m1_i64m1_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwrdotsu_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwrdotsu_vv-compile-1.c
@@ -1,21 +1,75 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint16m1_t test_vwrdotsu_vv_i8 (vint16m1_t vd, vint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwrdotsu_vv_i8m1_i16m1 (vd, vs1, vs2, vl); }
-vint16m1_t test_vwrdotsu_vv_i8_m (vbool8_t mask, vint16m1_t vd, vint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwrdotsu_vv_i8m1_i16m1_m (mask, vd, vs1, vs2, vl); }
-vint32m1_t test_vwrdotsu_vv_i16 (vint32m1_t vd, vint16m1_t vs1, vuint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwrdotsu_vv_i16m1_i32m1 (vd, vs1, vs2, vl); }
-vint32m1_t test_vwrdotsu_vv_i16_m (vbool16_t mask, vint32m1_t vd, vint16m1_t vs1, vuint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwrdotsu_vv_i16m1_i32m1_m (mask, vd, vs1, vs2, vl); }
-vint64m1_t test_vwrdotsu_vv_i32 (vint64m1_t vd, vint32m1_t vs1, vuint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwrdotsu_vv_i32m1_i64m1 (vd, vs1, vs2, vl); }
-vint64m1_t test_vwrdotsu_vv_i32_m (vbool32_t mask, vint64m1_t vd, vint32m1_t vs1, vuint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwrdotsu_vv_i32m1_i64m1_m (mask, vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vwrdotsu\\.vv" 6 } } */
+/*
+** test_vwrdotsu_vv_i8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vwrdotsu\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint16m1_t test_vwrdotsu_vv_i8 (vint16m1_t vd, vint8m1_t vs1, vuint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwrdotsu_vv_i8m1_i16m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwrdotsu_vv_i8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vwrdotsu\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint16m1_t test_vwrdotsu_vv_i8_m (vbool8_t mask, vint16m1_t vd, vint8m1_t vs1, vuint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwrdotsu_vv_i8m1_i16m1_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwrdotsu_vv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vwrdotsu\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m1_t test_vwrdotsu_vv_i16 (vint32m1_t vd, vint16m1_t vs1, vuint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwrdotsu_vv_i16m1_i32m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwrdotsu_vv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vwrdotsu\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_vwrdotsu_vv_i16_m (vbool16_t mask, vint32m1_t vd, vint16m1_t vs1, vuint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwrdotsu_vv_i16m1_i32m1_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwrdotsu_vv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vwrdotsu\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint64m1_t test_vwrdotsu_vv_i32 (vint64m1_t vd, vint32m1_t vs1, vuint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwrdotsu_vv_i32m1_i64m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwrdotsu_vv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vwrdotsu\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint64m1_t test_vwrdotsu_vv_i32_m (vbool32_t mask, vint64m1_t vd, vint32m1_t vs1, vuint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwrdotsu_vv_i32m1_i64m1_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwrdotu_hv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwrdotu_hv-compile-1.c
@@ -1,17 +1,53 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vuint32m1_t test_vwrdotu_hv_u16 (vuint32m1_t vd, vuint16m1_t vs1, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwrdotu_hv_u16m1_u32m1 (vd, vs1, vs2, vl); }
-vuint32m1_t test_vwrdotu_hv_u16_m (vbool16_t mask, vuint32m1_t vd, vuint16m1_t vs1, vuint8mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwrdotu_hv_u16m1_u32m1_m (mask, vd, vs1, vs2, vl); }
-vuint64m1_t test_vwrdotu_hv_u32 (vuint64m1_t vd, vuint32m1_t vs1, vuint16mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwrdotu_hv_u32m1_u64m1 (vd, vs1, vs2, vl); }
-vuint64m1_t test_vwrdotu_hv_u32_m (vbool32_t mask, vuint64m1_t vd, vuint32m1_t vs1, vuint16mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwrdotu_hv_u32m1_u64m1_m (mask, vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vwrdotu\\.hv" 4 } } */
+/*
+** test_vwrdotu_hv_u16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vwrdotu\.hv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vuint32m1_t test_vwrdotu_hv_u16 (vuint32m1_t vd, vuint16m1_t vs1, vuint8mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwrdotu_hv_u16m1_u32m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwrdotu_hv_u16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vwrdotu\.hv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vuint32m1_t test_vwrdotu_hv_u16_m (vbool16_t mask, vuint32m1_t vd, vuint16m1_t vs1, vuint8mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwrdotu_hv_u16m1_u32m1_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwrdotu_hv_u32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vwrdotu\.hv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vuint64m1_t test_vwrdotu_hv_u32 (vuint64m1_t vd, vuint32m1_t vs1, vuint16mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwrdotu_hv_u32m1_u64m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwrdotu_hv_u32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vwrdotu\.hv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vuint64m1_t test_vwrdotu_hv_u32_m (vbool32_t mask, vuint64m1_t vd, vuint32m1_t vs1, vuint16mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwrdotu_hv_u32m1_u64m1_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwrdotu_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwrdotu_vv-compile-1.c
@@ -1,21 +1,75 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vuint16m1_t test_vwrdotu_vv_u8 (vuint16m1_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwrdotu_vv_u8m1_u16m1 (vd, vs1, vs2, vl); }
-vuint16m1_t test_vwrdotu_vv_u8_m (vbool8_t mask, vuint16m1_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwrdotu_vv_u8m1_u16m1_m (mask, vd, vs1, vs2, vl); }
-vuint32m1_t test_vwrdotu_vv_u16 (vuint32m1_t vd, vuint16m1_t vs1, vuint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwrdotu_vv_u16m1_u32m1 (vd, vs1, vs2, vl); }
-vuint32m1_t test_vwrdotu_vv_u16_m (vbool16_t mask, vuint32m1_t vd, vuint16m1_t vs1, vuint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwrdotu_vv_u16m1_u32m1_m (mask, vd, vs1, vs2, vl); }
-vuint64m1_t test_vwrdotu_vv_u32 (vuint64m1_t vd, vuint32m1_t vs1, vuint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwrdotu_vv_u32m1_u64m1 (vd, vs1, vs2, vl); }
-vuint64m1_t test_vwrdotu_vv_u32_m (vbool32_t mask, vuint64m1_t vd, vuint32m1_t vs1, vuint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwrdotu_vv_u32m1_u64m1_m (mask, vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vwrdotu\\.vv" 6 } } */
+/*
+** test_vwrdotu_vv_u8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vwrdotu\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vuint16m1_t test_vwrdotu_vv_u8 (vuint16m1_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwrdotu_vv_u8m1_u16m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwrdotu_vv_u8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vwrdotu\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vuint16m1_t test_vwrdotu_vv_u8_m (vbool8_t mask, vuint16m1_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwrdotu_vv_u8m1_u16m1_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwrdotu_vv_u16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vwrdotu\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vuint32m1_t test_vwrdotu_vv_u16 (vuint32m1_t vd, vuint16m1_t vs1, vuint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwrdotu_vv_u16m1_u32m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwrdotu_vv_u16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vwrdotu\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vuint32m1_t test_vwrdotu_vv_u16_m (vbool16_t mask, vuint32m1_t vd, vuint16m1_t vs1, vuint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwrdotu_vv_u16m1_u32m1_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwrdotu_vv_u32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vwrdotu\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vuint64m1_t test_vwrdotu_vv_u32 (vuint64m1_t vd, vuint32m1_t vs1, vuint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwrdotu_vv_u32m1_u64m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwrdotu_vv_u32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vwrdotu\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vuint64m1_t test_vwrdotu_vv_u32_m (vbool32_t mask, vuint64m1_t vd, vuint32m1_t vs1, vuint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwrdotu_vv_u32m1_u64m1_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsmac_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsmac_vv-compile-1.c
@@ -1,21 +1,80 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint16m2_t test_vwsmac_vv_i8 (vint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsmac_vv_i16m2 (vd, vs1, vs2, vl); }
-vint16m2_t test_vwsmac_vv_i8_m (vbool8_t mask, vint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsmac_vv_i16m2_m (mask, vd, vs1, vs2, vl); }
-vint32m2_t test_vwsmac_vv_i16 (vint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsmac_vv_i32m2 (vd, vs1, vs2, vl); }
-vint32m2_t test_vwsmac_vv_i16_m (vbool16_t mask, vint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsmac_vv_i32m2_m (mask, vd, vs1, vs2, vl); }
-vint64m2_t test_vwsmac_vv_i32 (vint64m2_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsmac_vv_i64m2 (vd, vs1, vs2, vl); }
-vint64m2_t test_vwsmac_vv_i32_m (vbool32_t mask, vint64m2_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsmac_vv_i64m2_m (mask, vd, vs1, vs2, vl); }
+/*
+** test_vwsmac_vv_i8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv.vwsmac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint16m2_t
+test_vwsmac_vv_i8 (vint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsmac_vv_i16m2 (vd, vs1, vs2, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwsmac\\.vv" 6 } } */
+/*
+** test_vwsmac_vv_i8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv.vwsmac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint16m2_t
+test_vwsmac_vv_i8_m (vbool8_t mask, vint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsmac_vv_i16m2_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsmac_vv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwsmac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint32m2_t
+test_vwsmac_vv_i16 (vint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsmac_vv_i32m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsmac_vv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwsmac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint32m2_t
+test_vwsmac_vv_i16_m (vbool16_t mask, vint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsmac_vv_i32m2_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsmac_vv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwsmac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint64m2_t
+test_vwsmac_vv_i32 (vint64m2_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsmac_vv_i64m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsmac_vv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwsmac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint64m2_t
+test_vwsmac_vv_i32_m (vbool32_t mask, vint64m2_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsmac_vv_i64m2_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsmac_vx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsmac_vx-compile-1.c
@@ -1,21 +1,80 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint16m2_t test_vwsmac_vx_i8 (vint16m2_t vd, int vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsmac_vx_i16m2 (vd, vs1, vs2, vl); }
-vint16m2_t test_vwsmac_vx_i8_m (vbool8_t mask, vint16m2_t vd, int vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsmac_vx_i16m2_m (mask, vd, vs1, vs2, vl); }
-vint32m2_t test_vwsmac_vx_i16 (vint32m2_t vd, int vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsmac_vx_i32m2 (vd, vs1, vs2, vl); }
-vint32m2_t test_vwsmac_vx_i16_m (vbool16_t mask, vint32m2_t vd, int vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsmac_vx_i32m2_m (mask, vd, vs1, vs2, vl); }
-vint64m2_t test_vwsmac_vx_i32 (vint64m2_t vd, int vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsmac_vx_i64m2 (vd, vs1, vs2, vl); }
-vint64m2_t test_vwsmac_vx_i32_m (vbool32_t mask, vint64m2_t vd, int vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsmac_vx_i64m2_m (mask, vd, vs1, vs2, vl); }
+/*
+** test_vwsmac_vx_i8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv.vwsmac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint16m2_t
+test_vwsmac_vx_i8 (vint16m2_t vd, int vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsmac_vx_i16m2 (vd, vs1, vs2, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwsmac\\.vx" 6 } } */
+/*
+** test_vwsmac_vx_i8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv.vwsmac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint16m2_t
+test_vwsmac_vx_i8_m (vbool8_t mask, vint16m2_t vd, int vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsmac_vx_i16m2_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsmac_vx_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwsmac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint32m2_t
+test_vwsmac_vx_i16 (vint32m2_t vd, int vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsmac_vx_i32m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsmac_vx_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwsmac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint32m2_t
+test_vwsmac_vx_i16_m (vbool16_t mask, vint32m2_t vd, int vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsmac_vx_i32m2_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsmac_vx_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwsmac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint64m2_t
+test_vwsmac_vx_i32 (vint64m2_t vd, int vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsmac_vx_i64m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsmac_vx_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwsmac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint64m2_t
+test_vwsmac_vx_i32_m (vbool32_t mask, vint64m2_t vd, int vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsmac_vx_i64m2_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsmacf_hv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsmacf_hv-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m2_t test_vwsmacf_hv_i16 (vint32m2_t vd, vint16m1_t vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwsmacf_hv_i32m2 (vd, vs1, vs2, vl); }
-vint32m2_t test_vwsmacf_hv_i16_m (vbool16_t mask, vint32m2_t vd, vint16m1_t vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwsmacf_hv_i32m2_m (mask, vd, vs1, vs2, vl); }
-vint64m2_t test_vwsmacf_hv_i32 (vint64m2_t vd, vint32m1_t vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwsmacf_hv_i64m2 (vd, vs1, vs2, vl); }
-vint64m2_t test_vwsmacf_hv_i32_m (vbool32_t mask, vint64m2_t vd, vint32m1_t vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwsmacf_hv_i64m2_m (mask, vd, vs1, vs2, vl); }
+/*
+** test_vwsmacf_hv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwsmacf.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint32m2_t
+test_vwsmacf_hv_i16 (vint32m2_t vd, vint16m1_t vs1, vint8mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsmacf_hv_i32m2 (vd, vs1, vs2, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwsmacf\\.hv" 4 } } */
+/*
+** test_vwsmacf_hv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwsmacf.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint32m2_t
+test_vwsmacf_hv_i16_m (vbool16_t mask, vint32m2_t vd, vint16m1_t vs1, vint8mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsmacf_hv_i32m2_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsmacf_hv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwsmacf.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint64m2_t
+test_vwsmacf_hv_i32 (vint64m2_t vd, vint32m1_t vs1, vint16mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsmacf_hv_i64m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsmacf_hv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwsmacf.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint64m2_t
+test_vwsmacf_hv_i32_m (vbool32_t mask, vint64m2_t vd, vint32m1_t vs1, vint16mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsmacf_hv_i64m2_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsmacf_hx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsmacf_hx-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m2_t test_vwsmacf_hx_i16 (vint32m2_t vd, int vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwsmacf_hx_i32m2 (vd, vs1, vs2, vl); }
-vint32m2_t test_vwsmacf_hx_i16_m (vbool16_t mask, vint32m2_t vd, int vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwsmacf_hx_i32m2_m (mask, vd, vs1, vs2, vl); }
-vint64m2_t test_vwsmacf_hx_i32 (vint64m2_t vd, int vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwsmacf_hx_i64m2 (vd, vs1, vs2, vl); }
-vint64m2_t test_vwsmacf_hx_i32_m (vbool32_t mask, vint64m2_t vd, int vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwsmacf_hx_i64m2_m (mask, vd, vs1, vs2, vl); }
+/*
+** test_vwsmacf_hx_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwsmacf.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint32m2_t
+test_vwsmacf_hx_i16 (vint32m2_t vd, int vs1, vint8mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsmacf_hx_i32m2 (vd, vs1, vs2, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwsmacf\\.hx" 4 } } */
+/*
+** test_vwsmacf_hx_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwsmacf.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint32m2_t
+test_vwsmacf_hx_i16_m (vbool16_t mask, vint32m2_t vd, int vs1, vint8mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsmacf_hx_i32m2_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsmacf_hx_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwsmacf.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint64m2_t
+test_vwsmacf_hx_i32 (vint64m2_t vd, int vs1, vint16mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsmacf_hx_i64m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsmacf_hx_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwsmacf.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint64m2_t
+test_vwsmacf_hx_i32_m (vbool32_t mask, vint64m2_t vd, int vs1, vint16mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsmacf_hx_i64m2_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsnmsac_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsnmsac_vv-compile-1.c
@@ -1,21 +1,80 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint16m2_t test_vwsnmsac_vv_i8 (vint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsnmsac_vv_i16m2 (vd, vs1, vs2, vl); }
-vint16m2_t test_vwsnmsac_vv_i8_m (vbool8_t mask, vint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsnmsac_vv_i16m2_m (mask, vd, vs1, vs2, vl); }
-vint32m2_t test_vwsnmsac_vv_i16 (vint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsnmsac_vv_i32m2 (vd, vs1, vs2, vl); }
-vint32m2_t test_vwsnmsac_vv_i16_m (vbool16_t mask, vint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsnmsac_vv_i32m2_m (mask, vd, vs1, vs2, vl); }
-vint64m2_t test_vwsnmsac_vv_i32 (vint64m2_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsnmsac_vv_i64m2 (vd, vs1, vs2, vl); }
-vint64m2_t test_vwsnmsac_vv_i32_m (vbool32_t mask, vint64m2_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsnmsac_vv_i64m2_m (mask, vd, vs1, vs2, vl); }
+/*
+** test_vwsnmsac_vv_i8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv.vwsnmsac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint16m2_t
+test_vwsnmsac_vv_i8 (vint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsnmsac_vv_i16m2 (vd, vs1, vs2, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwsnmsac\\.vv" 6 } } */
+/*
+** test_vwsnmsac_vv_i8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv.vwsnmsac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint16m2_t
+test_vwsnmsac_vv_i8_m (vbool8_t mask, vint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsnmsac_vv_i16m2_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsnmsac_vv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwsnmsac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint32m2_t
+test_vwsnmsac_vv_i16 (vint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsnmsac_vv_i32m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsnmsac_vv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwsnmsac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint32m2_t
+test_vwsnmsac_vv_i16_m (vbool16_t mask, vint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsnmsac_vv_i32m2_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsnmsac_vv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwsnmsac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint64m2_t
+test_vwsnmsac_vv_i32 (vint64m2_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsnmsac_vv_i64m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsnmsac_vv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwsnmsac.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint64m2_t
+test_vwsnmsac_vv_i32_m (vbool32_t mask, vint64m2_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsnmsac_vv_i64m2_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsnmsac_vx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsnmsac_vx-compile-1.c
@@ -1,21 +1,80 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint16m2_t test_vwsnmsac_vx_i8 (vint16m2_t vd, int vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsnmsac_vx_i16m2 (vd, vs1, vs2, vl); }
-vint16m2_t test_vwsnmsac_vx_i8_m (vbool8_t mask, vint16m2_t vd, int vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsnmsac_vx_i16m2_m (mask, vd, vs1, vs2, vl); }
-vint32m2_t test_vwsnmsac_vx_i16 (vint32m2_t vd, int vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsnmsac_vx_i32m2 (vd, vs1, vs2, vl); }
-vint32m2_t test_vwsnmsac_vx_i16_m (vbool16_t mask, vint32m2_t vd, int vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsnmsac_vx_i32m2_m (mask, vd, vs1, vs2, vl); }
-vint64m2_t test_vwsnmsac_vx_i32 (vint64m2_t vd, int vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsnmsac_vx_i64m2 (vd, vs1, vs2, vl); }
-vint64m2_t test_vwsnmsac_vx_i32_m (vbool32_t mask, vint64m2_t vd, int vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsnmsac_vx_i64m2_m (mask, vd, vs1, vs2, vl); }
+/*
+** test_vwsnmsac_vx_i8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv.vwsnmsac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint16m2_t
+test_vwsnmsac_vx_i8 (vint16m2_t vd, int vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsnmsac_vx_i16m2 (vd, vs1, vs2, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwsnmsac\\.vx" 6 } } */
+/*
+** test_vwsnmsac_vx_i8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv.vwsnmsac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint16m2_t
+test_vwsnmsac_vx_i8_m (vbool8_t mask, vint16m2_t vd, int vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsnmsac_vx_i16m2_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsnmsac_vx_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwsnmsac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint32m2_t
+test_vwsnmsac_vx_i16 (vint32m2_t vd, int vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsnmsac_vx_i32m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsnmsac_vx_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwsnmsac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint32m2_t
+test_vwsnmsac_vx_i16_m (vbool16_t mask, vint32m2_t vd, int vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsnmsac_vx_i32m2_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsnmsac_vx_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwsnmsac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint64m2_t
+test_vwsnmsac_vx_i32 (vint64m2_t vd, int vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsnmsac_vx_i64m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsnmsac_vx_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwsnmsac.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint64m2_t
+test_vwsnmsac_vx_i32_m (vbool32_t mask, vint64m2_t vd, int vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsnmsac_vx_i64m2_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsnmsacf_hv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsnmsacf_hv-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m2_t test_vwsnmsacf_hv_i16 (vint32m2_t vd, vint16m1_t vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwsnmsacf_hv_i32m2 (vd, vs1, vs2, vl); }
-vint32m2_t test_vwsnmsacf_hv_i16_m (vbool16_t mask, vint32m2_t vd, vint16m1_t vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwsnmsacf_hv_i32m2_m (mask, vd, vs1, vs2, vl); }
-vint64m2_t test_vwsnmsacf_hv_i32 (vint64m2_t vd, vint32m1_t vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwsnmsacf_hv_i64m2 (vd, vs1, vs2, vl); }
-vint64m2_t test_vwsnmsacf_hv_i32_m (vbool32_t mask, vint64m2_t vd, vint32m1_t vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwsnmsacf_hv_i64m2_m (mask, vd, vs1, vs2, vl); }
+/*
+** test_vwsnmsacf_hv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwsnmsacf.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint32m2_t
+test_vwsnmsacf_hv_i16 (vint32m2_t vd, vint16m1_t vs1, vint8mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsnmsacf_hv_i32m2 (vd, vs1, vs2, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwsnmsacf\\.hv" 4 } } */
+/*
+** test_vwsnmsacf_hv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwsnmsacf.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint32m2_t
+test_vwsnmsacf_hv_i16_m (vbool16_t mask, vint32m2_t vd, vint16m1_t vs1, vint8mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsnmsacf_hv_i32m2_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsnmsacf_hv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwsnmsacf.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint64m2_t
+test_vwsnmsacf_hv_i32 (vint64m2_t vd, vint32m1_t vs1, vint16mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsnmsacf_hv_i64m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsnmsacf_hv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwsnmsacf.hv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint64m2_t
+test_vwsnmsacf_hv_i32_m (vbool32_t mask, vint64m2_t vd, vint32m1_t vs1, vint16mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsnmsacf_hv_i64m2_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsnmsacf_hx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsnmsacf_hx-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m2_t test_vwsnmsacf_hx_i16 (vint32m2_t vd, int vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwsnmsacf_hx_i32m2 (vd, vs1, vs2, vl); }
-vint32m2_t test_vwsnmsacf_hx_i16_m (vbool16_t mask, vint32m2_t vd, int vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwsnmsacf_hx_i32m2_m (mask, vd, vs1, vs2, vl); }
-vint64m2_t test_vwsnmsacf_hx_i32 (vint64m2_t vd, int vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwsnmsacf_hx_i64m2 (vd, vs1, vs2, vl); }
-vint64m2_t test_vwsnmsacf_hx_i32_m (vbool32_t mask, vint64m2_t vd, int vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwsnmsacf_hx_i64m2_m (mask, vd, vs1, vs2, vl); }
+/*
+** test_vwsnmsacf_hx_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwsnmsacf.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint32m2_t
+test_vwsnmsacf_hx_i16 (vint32m2_t vd, int vs1, vint8mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsnmsacf_hx_i32m2 (vd, vs1, vs2, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwsnmsacf\\.hx" 4 } } */
+/*
+** test_vwsnmsacf_hx_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv.vwsnmsacf.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint32m2_t
+test_vwsnmsacf_hx_i16_m (vbool16_t mask, vint32m2_t vd, int vs1, vint8mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsnmsacf_hx_i32m2_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsnmsacf_hx_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwsnmsacf.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vint64m2_t
+test_vwsnmsacf_hx_i32 (vint64m2_t vd, int vs1, vint16mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsnmsacf_hx_i64m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsnmsacf_hx_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv.vwsnmsacf.hx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vint64m2_t
+test_vwsnmsacf_hx_i32_m (vbool32_t mask, vint64m2_t vd, int vs1, vint16mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsnmsacf_hx_i64m2_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsra_vi-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsra_vi-compile-1.c
@@ -10,9 +10,9 @@
 /*
 ** test_vwsra_vi_i8:
 **   csrwi\s+vxrm,0
-**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m2,\s*t[au],\s*m[au]
-**   arcv.vwsra.vi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
-**   ret
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwsra.vi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[0-9]+
+**  ret
 */
 vint16m2_t
 test_vwsra_vi_i8 (vint8m1_t vs2, vint8m1_t vs1, size_t vl)
@@ -23,8 +23,8 @@ test_vwsra_vi_i8 (vint8m1_t vs2, vint8m1_t vs1, size_t vl)
 /*
 ** test_vwsra_vi_i8_m:
 **   csrwi\s+vxrm,0
-**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m2,\s*t[au],\s*m[au]
-**   arcv.vwsra.vi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwsra.vi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint16m2_t
@@ -36,8 +36,8 @@ test_vwsra_vi_i8_m (vbool8_t mask, vint8m1_t vs2, vint8m1_t vs1, size_t vl)
 /*
 ** test_vwsra_vi_i16:
 **   csrwi\s+vxrm,0
-**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m2,\s*t[au],\s*m[au]
-**   arcv.vwsra.vi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwsra.vi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint32m2_t
@@ -49,8 +49,8 @@ test_vwsra_vi_i16 (vint16m1_t vs2, vint16m1_t vs1, size_t vl)
 /*
 ** test_vwsra_vi_i16_m:
 **   csrwi\s+vxrm,0
-**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m2,\s*t[au],\s*m[au]
-**   arcv.vwsra.vi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwsra.vi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint32m2_t
@@ -62,8 +62,8 @@ test_vwsra_vi_i16_m (vbool16_t mask, vint16m1_t vs2, vint16m1_t vs1, size_t vl)
 /*
 ** test_vwsra_vi_i32:
 **   csrwi\s+vxrm,0
-**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m2,\s*t[au],\s*m[au]
-**   arcv.vwsra.vi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwsra.vi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint64m2_t
@@ -75,8 +75,8 @@ test_vwsra_vi_i32 (vint32m1_t vs2, vint32m1_t vs1, size_t vl)
 /*
 ** test_vwsra_vi_i32_m:
 **   csrwi\s+vxrm,0
-**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m2,\s*t[au],\s*m[au]
-**   arcv.vwsra.vi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwsra.vi\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint64m2_t

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsra_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsra_vv-compile-1.c
@@ -10,9 +10,9 @@
 /*
 ** test_vwsra_vv_i8:
 **   csrwi\s+vxrm,0
-**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m2,\s*t[au],\s*m[au]
-**   arcv.vwsra.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
-**   ret
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwsra.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
 */
 vint16m2_t
 test_vwsra_vv_i8 (vint8m1_t vs2, vint8m1_t vs1, size_t vl)
@@ -23,8 +23,8 @@ test_vwsra_vv_i8 (vint8m1_t vs2, vint8m1_t vs1, size_t vl)
 /*
 ** test_vwsra_vv_i8_m:
 **   csrwi\s+vxrm,0
-**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m2,\s*t[au],\s*m[au]
-**   arcv.vwsra.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwsra.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint16m2_t
@@ -36,8 +36,8 @@ test_vwsra_vv_i8_m (vbool8_t mask, vint8m1_t vs2, vint8m1_t vs1, size_t vl)
 /*
 ** test_vwsra_vv_i16:
 **   csrwi\s+vxrm,0
-**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m2,\s*t[au],\s*m[au]
-**   arcv.vwsra.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwsra.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint32m2_t
@@ -49,8 +49,8 @@ test_vwsra_vv_i16 (vint16m1_t vs2, vint16m1_t vs1, size_t vl)
 /*
 ** test_vwsra_vv_i16_m:
 **   csrwi\s+vxrm,0
-**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m2,\s*t[au],\s*m[au]
-**   arcv.vwsra.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwsra.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint32m2_t
@@ -62,8 +62,8 @@ test_vwsra_vv_i16_m (vbool16_t mask, vint16m1_t vs2, vint16m1_t vs1, size_t vl)
 /*
 ** test_vwsra_vv_i32:
 **   csrwi\s+vxrm,0
-**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m2,\s*t[au],\s*m[au]
-**   arcv.vwsra.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwsra.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint64m2_t
@@ -75,8 +75,8 @@ test_vwsra_vv_i32 (vint32m1_t vs2, vint32m1_t vs1, size_t vl)
 /*
 ** test_vwsra_vv_i32_m:
 **   csrwi\s+vxrm,0
-**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m2,\s*t[au],\s*m[au]
-**   arcv.vwsra.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwsra.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint64m2_t

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsra_vx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsra_vx-compile-1.c
@@ -10,9 +10,9 @@
 /*
 ** test_vwsra_vx_i8:
 **   csrwi\s+vxrm,0
-**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m2,\s*t[au],\s*m[au]
-**   arcv.vwsra.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
-**   ret
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwsra.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**  ret
 */
 vint16m2_t
 test_vwsra_vx_i8 (vint8m1_t vs2, int vs1, size_t vl)
@@ -23,8 +23,8 @@ test_vwsra_vx_i8 (vint8m1_t vs2, int vs1, size_t vl)
 /*
 ** test_vwsra_vx_i8_m:
 **   csrwi\s+vxrm,0
-**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m2,\s*t[au],\s*m[au]
-**   arcv.vwsra.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwsra.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint16m2_t
@@ -36,8 +36,8 @@ test_vwsra_vx_i8_m (vbool8_t mask, vint8m1_t vs2, int vs1, size_t vl)
 /*
 ** test_vwsra_vx_i16:
 **   csrwi\s+vxrm,0
-**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m2,\s*t[au],\s*m[au]
-**   arcv.vwsra.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwsra.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint32m2_t
@@ -49,8 +49,8 @@ test_vwsra_vx_i16 (vint16m1_t vs2, int vs1, size_t vl)
 /*
 ** test_vwsra_vx_i16_m:
 **   csrwi\s+vxrm,0
-**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m2,\s*t[au],\s*m[au]
-**   arcv.vwsra.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwsra.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint32m2_t
@@ -62,8 +62,8 @@ test_vwsra_vx_i16_m (vbool16_t mask, vint16m1_t vs2, int vs1, size_t vl)
 /*
 ** test_vwsra_vx_i32:
 **   csrwi\s+vxrm,0
-**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m2,\s*t[au],\s*m[au]
-**   arcv.vwsra.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
+**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwsra.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+
 **   ret
 */
 vint64m2_t
@@ -75,8 +75,8 @@ test_vwsra_vx_i32 (vint32m1_t vs2, int vs1, size_t vl)
 /*
 ** test_vwsra_vx_i32_m:
 **   csrwi\s+vxrm,0
-**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m2,\s*t[au],\s*m[au]
-**   arcv.vwsra.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
+**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**   (?:vmv[0-9]*r\.v\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])\n\s+)+arcv.vwsra.vx\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*[a-x0-9]+,\s*v0\.t
 **   ret
 */
 vint64m2_t

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsrdot_2s_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsrdot_2s_vv-compile-1.c
@@ -1,21 +1,75 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint16m1_t test_vwsrdot_2s_vv_i8 (vint16m1_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsrdot_2s_vv_i8m1_i16m1 (vd, vs1, vs2, vl); }
-vint16m1_t test_vwsrdot_2s_vv_i8_m (vbool8_t mask, vint16m1_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsrdot_2s_vv_i8m1_i16m1_m (mask, vd, vs1, vs2, vl); }
-vint32m1_t test_vwsrdot_2s_vv_i16 (vint32m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsrdot_2s_vv_i16m1_i32m1 (vd, vs1, vs2, vl); }
-vint32m1_t test_vwsrdot_2s_vv_i16_m (vbool16_t mask, vint32m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsrdot_2s_vv_i16m1_i32m1_m (mask, vd, vs1, vs2, vl); }
-vint64m1_t test_vwsrdot_2s_vv_i32 (vint64m1_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsrdot_2s_vv_i32m1_i64m1 (vd, vs1, vs2, vl); }
-vint64m1_t test_vwsrdot_2s_vv_i32_m (vbool32_t mask, vint64m1_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsrdot_2s_vv_i32m1_i64m1_m (mask, vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vwsrdot\\.2s\\.vv" 6 } } */
+/*
+** test_vwsrdot_2s_vv_i8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vwsrdot\.2s\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint16m1_t test_vwsrdot_2s_vv_i8 (vint16m1_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsrdot_2s_vv_i8m1_i16m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsrdot_2s_vv_i8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vwsrdot\.2s\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint16m1_t test_vwsrdot_2s_vv_i8_m (vbool8_t mask, vint16m1_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsrdot_2s_vv_i8m1_i16m1_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsrdot_2s_vv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vwsrdot\.2s\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m1_t test_vwsrdot_2s_vv_i16 (vint32m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsrdot_2s_vv_i16m1_i32m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsrdot_2s_vv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vwsrdot\.2s\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_vwsrdot_2s_vv_i16_m (vbool16_t mask, vint32m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsrdot_2s_vv_i16m1_i32m1_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsrdot_2s_vv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vwsrdot\.2s\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint64m1_t test_vwsrdot_2s_vv_i32 (vint64m1_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsrdot_2s_vv_i32m1_i64m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsrdot_2s_vv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vwsrdot\.2s\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint64m1_t test_vwsrdot_2s_vv_i32_m (vbool32_t mask, vint64m1_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsrdot_2s_vv_i32m1_i64m1_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsrdot_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsrdot_vv-compile-1.c
@@ -1,21 +1,75 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint16m1_t test_vwsrdot_vv_i8 (vint16m1_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsrdot_vv_i8m1_i16m1 (vd, vs1, vs2, vl); }
-vint16m1_t test_vwsrdot_vv_i8_m (vbool8_t mask, vint16m1_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsrdot_vv_i8m1_i16m1_m (mask, vd, vs1, vs2, vl); }
-vint32m1_t test_vwsrdot_vv_i16 (vint32m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsrdot_vv_i16m1_i32m1 (vd, vs1, vs2, vl); }
-vint32m1_t test_vwsrdot_vv_i16_m (vbool16_t mask, vint32m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsrdot_vv_i16m1_i32m1_m (mask, vd, vs1, vs2, vl); }
-vint64m1_t test_vwsrdot_vv_i32 (vint64m1_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsrdot_vv_i32m1_i64m1 (vd, vs1, vs2, vl); }
-vint64m1_t test_vwsrdot_vv_i32_m (vbool32_t mask, vint64m1_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsrdot_vv_i32m1_i64m1_m (mask, vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vwsrdot\\.vv" 6 } } */
+/*
+** test_vwsrdot_vv_i8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vwsrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint16m1_t test_vwsrdot_vv_i8 (vint16m1_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsrdot_vv_i8m1_i16m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsrdot_vv_i8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vwsrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint16m1_t test_vwsrdot_vv_i8_m (vbool8_t mask, vint16m1_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsrdot_vv_i8m1_i16m1_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsrdot_vv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vwsrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m1_t test_vwsrdot_vv_i16 (vint32m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsrdot_vv_i16m1_i32m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsrdot_vv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vwsrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_vwsrdot_vv_i16_m (vbool16_t mask, vint32m1_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsrdot_vv_i16m1_i32m1_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsrdot_vv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vwsrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint64m1_t test_vwsrdot_vv_i32 (vint64m1_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsrdot_vv_i32m1_i64m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsrdot_vv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vwsrdot\.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint64m1_t test_vwsrdot_vv_i32_m (vbool32_t mask, vint64m1_t vd, vint32m1_t vs1, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsrdot_vv_i32m1_i64m1_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsrdotf_hv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsrdotf_hv-compile-1.c
@@ -1,17 +1,53 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m1_t test_vwsrdotf_hv_i16 (vint32m1_t vd, vint16m1_t vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwsrdotf_hv_i16m1_i32m1 (vd, vs1, vs2, vl); }
-vint32m1_t test_vwsrdotf_hv_i16_m (vbool16_t mask, vint32m1_t vd, vint16m1_t vs1, vint8mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwsrdotf_hv_i16m1_i32m1_m (mask, vd, vs1, vs2, vl); }
-vint64m1_t test_vwsrdotf_hv_i32 (vint64m1_t vd, vint32m1_t vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwsrdotf_hv_i32m1_i64m1 (vd, vs1, vs2, vl); }
-vint64m1_t test_vwsrdotf_hv_i32_m (vbool32_t mask, vint64m1_t vd, vint32m1_t vs1, vint16mf2_t vs2, size_t vl) {
-  return __riscv_arcv_vwsrdotf_hv_i32m1_i64m1_m (mask, vd, vs1, vs2, vl); }
 
-/* { dg-final { scan-assembler-times "arcv\\.vwsrdotf\\.hv" 4 } } */
+/*
+** test_vwsrdotf_hv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vwsrdotf\.hv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint32m1_t test_vwsrdotf_hv_i16 (vint32m1_t vd, vint16m1_t vs1, vint8mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsrdotf_hv_i16m1_i32m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsrdotf_hv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vwsrdotf\.hv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint32m1_t test_vwsrdotf_hv_i16_m (vbool16_t mask, vint32m1_t vd, vint16m1_t vs1, vint8mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsrdotf_hv_i16m1_i32m1_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsrdotf_hv_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vwsrdotf\.hv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**  ret
+*/
+vint64m1_t test_vwsrdotf_hv_i32 (vint64m1_t vd, vint32m1_t vs1, vint16mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsrdotf_hv_i32m1_i64m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsrdotf_hv_i32_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vwsrdotf\.hv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  ret
+*/
+vint64m1_t test_vwsrdotf_hv_i32_m (vbool32_t mask, vint64m1_t vd, vint32m1_t vs1, vint16mf2_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsrdotf_hv_i32m1_i64m1_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vsad-vwsad_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vsad-vwsad_vv-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vsad } */
-/* { dg-options "-march=rv32im_xarcvvsad -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvsad -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vuint16m2_t test_vwsad_vv_i8 (vuint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsad_vv_u16m2 (vd, vs1, vs2, vl); }
-vuint16m2_t test_vwsad_vv_i8_m (vbool8_t mask, vuint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsad_vv_u16m2_m (mask, vd, vs1, vs2, vl); }
-vuint32m2_t test_vwsad_vv_i16 (vuint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsad_vv_u32m2 (vd, vs1, vs2, vl); }
-vuint32m2_t test_vwsad_vv_i16_m (vbool16_t mask, vuint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsad_vv_u32m2_m (mask, vd, vs1, vs2, vl); }
+/*
+** test_vwsad_vv_i8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,\s*m1,\s*t[au],\s*m[au]
+**  arcv\.vwsad\.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vuint16m2_t
+test_vwsad_vv_i8 (vuint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsad_vv_u16m2 (vd, vs1, vs2, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwsad\\.vv" 4 } } */
+/*
+** test_vwsad_vv_i8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,\s*m1,\s*t[au],\s*m[au]
+**  arcv\.vwsad\.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vuint16m2_t
+test_vwsad_vv_i8_m (vbool8_t mask, vuint16m2_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsad_vv_u16m2_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsad_vv_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,\s*m1,\s*t[au],\s*m[au]
+**  arcv\.vwsad\.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vuint32m2_t
+test_vwsad_vv_i16 (vuint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsad_vv_u32m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsad_vv_i16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,\s*m1,\s*t[au],\s*m[au]
+**  arcv\.vwsad\.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vuint32m2_t
+test_vwsad_vv_i16_m (vbool16_t mask, vuint32m2_t vd, vint16m1_t vs1, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsad_vv_u32m2_m (mask, vd, vs1, vs2, vl);
+}

--- a/gcc/testsuite/gcc.target/riscv/arcv-vsad-vwsadu_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vsad-vwsadu_vv-compile-1.c
@@ -1,17 +1,56 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vsad } */
-/* { dg-options "-march=rv32im_xarcvvsad -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvvsad -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vuint16m2_t test_vwsadu_vv_u8 (vuint16m2_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsadu_vv_u16m2 (vd, vs1, vs2, vl); }
-vuint16m2_t test_vwsadu_vv_u8_m (vbool8_t mask, vuint16m2_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsadu_vv_u16m2_m (mask, vd, vs1, vs2, vl); }
-vuint32m2_t test_vwsadu_vv_u16 (vuint32m2_t vd, vuint16m1_t vs1, vuint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsadu_vv_u32m2 (vd, vs1, vs2, vl); }
-vuint32m2_t test_vwsadu_vv_u16_m (vbool16_t mask, vuint32m2_t vd, vuint16m1_t vs1, vuint16m1_t vs2, size_t vl) {
-  return __riscv_arcv_vwsadu_vv_u32m2_m (mask, vd, vs1, vs2, vl); }
+/*
+** test_vwsadu_vv_u8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,\s*m1,\s*t[au],\s*m[au]
+**  arcv\.vwsadu\.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vuint16m2_t
+test_vwsadu_vv_u8 (vuint16m2_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsadu_vv_u16m2 (vd, vs1, vs2, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vwsadu\\.vv" 4 } } */
+/*
+** test_vwsadu_vv_u8_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,\s*m1,\s*t[au],\s*m[au]
+**  arcv\.vwsadu\.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vuint16m2_t
+test_vwsadu_vv_u8_m (vbool8_t mask, vuint16m2_t vd, vuint8m1_t vs1, vuint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsadu_vv_u16m2_m (mask, vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsadu_vv_u16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,\s*m1,\s*t[au],\s*m[au]
+**  arcv\.vwsadu\.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1])
+**  ret
+*/
+vuint32m2_t
+test_vwsadu_vv_u16 (vuint32m2_t vd, vuint16m1_t vs1, vuint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsadu_vv_u32m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vwsadu_vv_u16_m:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,\s*m1,\s*t[au],\s*m[au]
+**  arcv\.vwsadu\.vv\s+(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|v3[0-1]),\s*v0\.t
+**  ret
+*/
+vuint32m2_t
+test_vwsadu_vv_u16_m (vbool16_t mask, vuint32m2_t vd, vuint16m1_t vs1, vuint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vwsadu_vv_u32m2_m (mask, vd, vs1, vs2, vl);
+}


### PR DESCRIPTION
- Widening/narrowing instructions now use the correct mode. The correct
  vsetvli parameters will now be emitted
- All of the assembly templates now refer to the correct operands.
- The tests have been updated to be more precise and also verify that
  the correct vsetvli parameters are emitted.