### PR TITLE
arcv: Fix missing vsetvli generation for arcv_vmv instructions.

### DIFF
--- a/gcc/config/riscv/arcv-vector.md
+++ b/gcc/config/riscv/arcv-vector.md
@@ -139,13 +139,17 @@
 
 (define_insn "@pred_arcv_vmv_v_s_scalar<V_VLSI:mode><P:mode>"
   [(set (match_operand:<V_VLSI:MODE> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
-	(unspec:<V_VLSI:MODE>
-	  [(match_operand:V_VLSI 2 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
-	  (match_operand:P 3 "reg_or_int_operand" "r,r,r,r,r,r,i,i,i,i,i,i")
-	  (match_operand 4 "vector_length_operand" " rK, rK, rK, rK, rK, rK, rK, rK, rK, rK, rK, rK")
-	  (match_operand 5 "const_int_operand" " i,i,i,i,i,i,i,i,i,i,i,i")
-	  (match_operand:<V_VLSI:MODE> 1 "register_operand" "0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0")]
-	  UNSPEC_ARCV_VMV_V_S))]
+	(if_then_else:<V_VLSI:MODE>
+	  (unspec:<V_VLSI:VM>
+	    [(match_operand 4 "vector_length_operand" " rK, rK, rK, rK, rK, rK, rK, rK, rK, rK, rK, rK")
+	     (match_operand 5 "const_int_operand"     "  i,  i,  i,  i,  i,  i,  i,  i,  i,  i,  i,  i")
+	     (reg:SI VL_REGNUM)
+	     (reg:SI VTYPE_REGNUM)] UNSPEC_VPREDICATE)
+	  (unspec:<V_VLSI:MODE>
+	    [(match_operand:V_VLSI 2 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
+	     (match_operand:P 3 "reg_or_int_operand" "r,r,r,r,r,r,i,i,i,i,i,i")]
+	    UNSPEC_ARCV_VMV_V_S)
+	  (match_operand:<V_VLSI:MODE> 1 "register_operand" "0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0")))]
   "TARGET_XARCVVDSP"
   { return which_alternative < 6 ? "arcv.vmv.v.s\t%0,%2,%3" : "arcv.vmvi.v.s\t%0,%2,%3"; }
   [(set_attr "type" "viwmuladd")
@@ -157,13 +161,17 @@
 
 (define_insn "@pred_arcv_vmv_s_v_scalar<V_VLSI:mode><P:mode>"
   [(set (match_operand:<V_LMUL1> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
-	(unspec:<V_LMUL1>
-	  [(match_operand:V_VLSI 2 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
-	  (match_operand:P 3 "reg_or_int_operand" "r,r,r,r,r,r,i,i,i,i,i,i")
-	  (match_operand 4 "vector_length_operand" " rK, rK, rK, rK, rK, rK, rK, rK, rK, rK, rK, rK")
-	  (match_operand 5 "const_int_operand" " i,i,i,i,i,i,i,i,i,i,i,i")
-	  (match_operand:<V_LMUL1> 1 "register_operand" "0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0")]
-	  UNSPEC_ARCV_VMV_S_V))]
+	(if_then_else:<V_LMUL1>
+	  (unspec:<V_VLSI:VM>
+	    [(match_operand 4 "vector_length_operand" " rK, rK, rK, rK, rK, rK, rK, rK, rK, rK, rK, rK")
+	     (match_operand 5 "const_int_operand"     "  i,  i,  i,  i,  i,  i,  i,  i,  i,  i,  i,  i")
+	     (reg:SI VL_REGNUM)
+	     (reg:SI VTYPE_REGNUM)] UNSPEC_VPREDICATE)
+	  (unspec:<V_LMUL1>
+	    [(match_operand:V_VLSI 2 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
+	     (match_operand:P 3 "reg_or_int_operand" "r,r,r,r,r,r,i,i,i,i,i,i")]
+	    UNSPEC_ARCV_VMV_S_V)
+	  (match_operand:<V_LMUL1> 1 "register_operand" "0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0")))]
   "TARGET_XARCVVDSP"
   { return which_alternative < 6 ? "arcv.vmv.s.v\t%0,%2,%3" : "arcv.vmvi.s.v\t%0,%2,%3"; }
   [(set_attr "type" "viwmuladd")

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmv_s_v-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmv_s_v-compile-1.c
@@ -10,6 +10,7 @@
 
 /*
 ** test_vmv_s_v_i8m1:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
 **  arcv\.vmv\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
 **  ret
 */
@@ -20,6 +21,7 @@ vint8m1_t test_vmv_s_v_i8m1 (vint8m1_t vd, int vs1, vint8m1_t vs2, size_t vl)
 
 /*
 ** test_vmv_s_v_i8m2:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m2,\s*t[au],\s*m[au]
 **  arcv\.vmv\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
 **  ret
 */
@@ -30,6 +32,7 @@ vint8m1_t test_vmv_s_v_i8m2 (vint8m1_t vd, int vs1, vint8m2_t vs2, size_t vl)
 
 /*
 ** test_vmv_s_v_i8m4:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m4,\s*t[au],\s*m[au]
 **  arcv\.vmv\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
 **  ret
 */
@@ -40,6 +43,7 @@ vint8m1_t test_vmv_s_v_i8m4 (vint8m1_t vd, int vs1, vint8m4_t vs2, size_t vl)
 
 /*
 ** test_vmv_s_v_i16m1:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
 **  arcv\.vmv\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
 **  ret
 */
@@ -50,6 +54,7 @@ vint16m1_t test_vmv_s_v_i16m1 (vint16m1_t vd, int vs1, vint16m1_t vs2, size_t vl
 
 /*
 ** test_vmv_s_v_i32m1:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
 **  arcv\.vmv\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
 **  ret
 */
@@ -60,6 +65,7 @@ vint32m1_t test_vmv_s_v_i32m1 (vint32m1_t vd, int vs1, vint32m1_t vs2, size_t vl
 
 /*
 ** test_vmv_s_v_i32m2:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m2,\s*t[au],\s*m[au]
 **  arcv\.vmv\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
 **  ret
 */
@@ -70,6 +76,7 @@ vint32m1_t test_vmv_s_v_i32m2 (vint32m1_t vd, int vs1, vint32m2_t vs2, size_t vl
 
 /*
 ** test_vmv_s_v_i64m1:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m1,\s*t[au],\s*m[au]
 **  arcv\.vmv\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
 **  ret
 */

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmv_v_s-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmv_v_s-compile-1.c
@@ -10,6 +10,7 @@
 
 /*
 ** test_vmv_v_s_i8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
 **  arcv\.vmv\.v\.s\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
 **  ret
 */
@@ -20,6 +21,7 @@ vint8m1_t test_vmv_v_s_i8 (vint8m1_t vd, int vs1, vint8m1_t vs2, size_t vl)
 
 /*
 ** test_vmv_v_s_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
 **  arcv\.vmv\.v\.s\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
 **  ret
 */
@@ -30,6 +32,7 @@ vint16m1_t test_vmv_v_s_i16 (vint16m1_t vd, int vs1, vint16m1_t vs2, size_t vl)
 
 /*
 ** test_vmv_v_s_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
 **  arcv\.vmv\.v\.s\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
 **  ret
 */
@@ -40,6 +43,7 @@ vint32m1_t test_vmv_v_s_i32 (vint32m1_t vd, int vs1, vint32m1_t vs2, size_t vl)
 
 /*
 ** test_vmv_v_s_i64:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m1,\s*t[au],\s*m[au]
 **  arcv\.vmv\.v\.s\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
 **  ret
 */

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmvi_s_v-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmvi_s_v-compile-1.c
@@ -10,6 +10,7 @@
 
 /*
 ** test_vmv_s_v_i8m1:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
 **  arcv\.vmvi\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
 **  ret
 */
@@ -20,6 +21,7 @@ vint8m1_t test_vmv_s_v_i8m1 (vint8m1_t vd, int vs1, vint8m1_t vs2, size_t vl)
 
 /*
 ** test_vmv_s_v_i8m2:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m2,\s*t[au],\s*m[au]
 **  arcv\.vmvi\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
 **  ret
 */
@@ -30,6 +32,7 @@ vint8m1_t test_vmv_s_v_i8m2 (vint8m1_t vd, int vs1, vint8m2_t vs2, size_t vl)
 
 /*
 ** test_vmv_s_v_i8m4:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m4,\s*t[au],\s*m[au]
 **  arcv\.vmvi\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
 **  ret
 */
@@ -40,6 +43,7 @@ vint8m1_t test_vmv_s_v_i8m4 (vint8m1_t vd, int vs1, vint8m4_t vs2, size_t vl)
 
 /*
 ** test_vmv_s_v_i16m1:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
 **  arcv\.vmvi\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
 **  ret
 */
@@ -50,6 +54,7 @@ vint16m1_t test_vmv_s_v_i16m1 (vint16m1_t vd, int vs1, vint16m1_t vs2, size_t vl
 
 /*
 ** test_vmv_s_v_i32m1:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
 **  arcv\.vmvi\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
 **  ret
 */
@@ -60,6 +65,7 @@ vint32m1_t test_vmv_s_v_i32m1 (vint32m1_t vd, int vs1, vint32m1_t vs2, size_t vl
 
 /*
 ** test_vmv_s_v_i32m2:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m2,\s*t[au],\s*m[au]
 **  arcv\.vmvi\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
 **  ret
 */
@@ -70,6 +76,7 @@ vint32m1_t test_vmv_s_v_i32m2 (vint32m1_t vd, int vs1, vint32m2_t vs2, size_t vl
 
 /*
 ** test_vmv_s_v_i64m1:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m1,\s*t[au],\s*m[au]
 **  arcv\.vmvi\.s\.v\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
 **  ret
 */

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmvi_v_s-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmvi_v_s-compile-1.c
@@ -10,6 +10,7 @@
 
 /*
 ** test_vmvi_v_s_i8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
 **  arcv\.vmvi\.v\.s\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
 **  ret
 */
@@ -20,6 +21,7 @@ vint8m1_t test_vmvi_v_s_i8 (vint8m1_t vd, int vs1, vint8m1_t vs2, size_t vl)
 
 /*
 ** test_vmvi_v_s_i16:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
 **  arcv\.vmvi\.v\.s\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
 **  ret
 */
@@ -30,6 +32,7 @@ vint16m1_t test_vmvi_v_s_i16 (vint16m1_t vd, int vs1, vint16m1_t vs2, size_t vl)
 
 /*
 ** test_vmvi_v_s_i32:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
 **  arcv\.vmvi\.v\.s\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
 **  ret
 */
@@ -40,6 +43,7 @@ vint32m1_t test_vmvi_v_s_i32 (vint32m1_t vd, int vs1, vint32m1_t vs2, size_t vl)
 
 /*
 ** test_vmvi_v_s_i64:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m1,\s*t[au],\s*m[au]
 **  arcv\.vmvi\.v\.s\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
 **  ret
 */


### PR DESCRIPTION
The arcv_vmv RTL patterns were not generating vsetvli instructions because they lacked the proper RVV predication structure.  This caused the vector configuration to not be set up before executing the arcv.vmv.v.s and arcv.vmv.s.v instructions.

This patch restructures the arcv_vmv patterns to follow the standard RVV predicated instruction format by:
- Wrapping the instruction in an if_then_else with UNSPEC_VPREDICATE.
- Adding VL_REGNUM and VTYPE_REGNUM registers to the predication.
- Moving the actual instruction logic to an inner unspec.

This structure matches other ARCV vector instructions (like vnorm) and enables the vsetvl pass to properly insert vsetvli instructions before the arcv_vmv operations.
