### PR TITLE
arc: Fix wrong vector ordering on big-endian architecture

### DIFF
--- a/gcc/config/arc/simdext.md
+++ b/gcc/config/arc/simdext.md
@@ -1438,11 +1438,12 @@
   "reload_completed && GET_CODE (operands[1]) == CONST_VECTOR"
   [(set (match_dup 0) (match_dup 2))]
   {
-   HOST_WIDE_INT intval = INTVAL (XVECEXP (operands[1], 0, 1)) << 16;
-   intval |= INTVAL (XVECEXP (operands[1], 0, 0)) & 0xFFFF;
-
-   operands[0] = gen_rtx_REG (SImode, REGNO (operands[0]));
-   operands[2] = GEN_INT (trunc_int_for_mode (intval, SImode));
+    int hi = !TARGET_BIG_ENDIAN;
+    int lo = !hi;
+    HOST_WIDE_INT intval = INTVAL (XVECEXP (operands[1], 0, hi)) << 16;
+    intval |= INTVAL (XVECEXP (operands[1], 0, lo)) & 0xFFFF;
+    operands[0] = gen_rtx_REG (SImode, REGNO (operands[0]));
+    operands[2] = GEN_INT (trunc_int_for_mode (intval, SImode));
   }
   [(set_attr "type" "move,move,load,store")
    (set_attr "predicable" "yes,yes,no,no")

--- a/gcc/match.pd
+++ b/gcc/match.pd
@@ -3518,6 +3518,17 @@ DEFINE_INT_AND_FLOAT_ROUND_FN (RINT)
 	 || (wi::eq_p (int_cst_1, itype_max) && wi::eq_p (int_cst_2, limit_1)))
 	 && wi::eq_p (int_cst_3, otype_max)))))))
 
+/* The boundary condition for case 10: IMM = 1:
+   SAT_U_SUB = X >= IMM ? (X - IMM) : 0.
+   simplify (X != 0 ? X + ~0 : 0) to X - (X != 0).  */
+(simplify
+ (cond (ne@1 @0 integer_zerop)
+       (nop_convert1? (plus (nop_convert2?@2 @0) integer_all_onesp))
+       integer_zerop)
+ (if (INTEGRAL_TYPE_P (type))
+   (with { tree itype = TREE_TYPE (@2); }
+    (convert (minus @2 (convert:itype @1))))))
+
 /* x >  y  &&  x != XXX_MIN  -->  x > y
    x >  y  &&  x == XXX_MIN  -->  false . */
 (for eqne (eq ne)

--- a/gcc/testsuite/gcc.dg/tree-ssa/phi-opt-44.c
+++ b/gcc/testsuite/gcc.dg/tree-ssa/phi-opt-44.c
@@ -1,0 +1,26 @@
+/* { dg-do compile } */
+/* { dg-options "-O2 -fdump-tree-phiopt1" } */
+
+#include <stdint.h>
+
+uint8_t f1 (uint8_t x)
+{
+  return x >= (uint8_t)1 ? x - (uint8_t)1 : 0;
+}
+
+uint16_t f2 (uint16_t x)
+{
+  return x >= (uint16_t)1 ? x - (uint16_t)1 : 0;
+}
+
+uint32_t f3 (uint32_t x)
+{
+  return x >= (uint32_t)1 ? x - (uint32_t)1 : 0;
+}
+
+uint64_t f4 (uint64_t x)
+{
+  return x >= (uint64_t)1 ? x - (uint64_t)1 : 0;
+}
+
+/* { dg-final { scan-tree-dump-not "goto" "phiopt1" } } */

--- a/gcc/testsuite/gcc.dg/tree-ssa/phi-opt-45.c
+++ b/gcc/testsuite/gcc.dg/tree-ssa/phi-opt-45.c
@@ -1,0 +1,26 @@
+/* { dg-do compile } */
+/* { dg-options "-O2 -fdump-tree-phiopt1" } */
+
+#include <stdint.h>
+
+int8_t f1 (int8_t x)
+{
+  return x != 0 ? x - (int8_t)1 : 0;
+}
+
+int16_t f2 (int16_t x)
+{
+  return x != 0 ? x - (int16_t)1 : 0;
+}
+
+int32_t f3 (int32_t x)
+{
+  return x != 0 ? x - (int32_t)1 : 0;
+}
+
+int64_t f4 (int64_t x)
+{
+  return x != 0 ? x - (int64_t)1 : 0;
+}
+
+/* { dg-final { scan-tree-dump-not "goto" "phiopt1" } } */

--- a/gcc/testsuite/gcc.target/arc/movv2hi-be.c
+++ b/gcc/testsuite/gcc.target/arc/movv2hi-be.c
@@ -1,0 +1,32 @@
+/* { dg-do run } */
+/* { dg-options "-O2" } */
+
+typedef short v2hi __attribute__((vector_size(4)));
+
+__attribute__((noinline)) void foo3(short a)
+{
+    if (a != 520)
+    {
+        __builtin_abort();
+    }
+}
+
+__attribute__((noinline)) void foo2(v2hi v)
+{
+    foo3(v[0]);
+}
+
+__attribute__((noinline)) void foo(v2hi *v)
+{
+    foo2(*v);
+}
+
+int main (void)
+{
+    v2hi v;
+    v[0] = 520;
+    v[1] = -1;
+    foo(&v);
+    foo2(v);
+    return 0;
+}


### PR DESCRIPTION
V2HI vectors, explicitly or auto-generated, could be stored in memory
wrongly due to endianness. This caused 2 values to be swapped in the
snprintf.c for big-endian hs38_linux cpu.

This patch swaps the 2 values if the target is big-endian.