### PR TITLE
arcv: Fix ARCVvdsp vqmxm16su operand from unsigned to signed.

### DIFF
--- a/gcc/config/riscv/arcv-vector-builtins-functions.def
+++ b/gcc/config/riscv/arcv-vector-builtins-functions.def
@@ -145,5 +145,5 @@ DEF_RVV_FUNCTION (arcv_vqmxm8su, alu, none_m_preds, su_qqvv_ops)
 #define REQUIRED_EXTENSIONS XARCVMXMD_EXT
 DEF_RVV_FUNCTION (arcv_vqmxm16, alu, none_m_preds, i_qqvv_ops_prime)
 DEF_RVV_FUNCTION (arcv_vqmxm16u, alu, none_m_preds, u_qqvv_ops_prime)
-DEF_RVV_FUNCTION (arcv_vqmxm16su, alu, none_m_preds, su_qqvv_ops)
+DEF_RVV_FUNCTION (arcv_vqmxm16su, alu, none_m_preds, su_qvv_ops)
 #undef REQUIRED_EXTENSIONS

--- a/gcc/config/riscv/riscv-vector-builtins.cc
+++ b/gcc/config/riscv/riscv-vector-builtins.cc
@@ -1144,6 +1144,11 @@ static CONSTEXPR const rvv_arg_type_info suqqvv_args[]
      rvv_arg_type_info (RVV_BASE_quad_trunc_vector),
      rvv_arg_type_info (RVV_BASE_quad_trunc_unsigned_vector),
      rvv_arg_type_info_end};
+static CONSTEXPR const rvv_arg_type_info suqvv_args[]
+ = { rvv_arg_type_info (RVV_BASE_vector),
+     rvv_arg_type_info (RVV_BASE_quad_trunc_vector),
+     rvv_arg_type_info (RVV_BASE_quad_trunc_vector),
+     rvv_arg_type_info_end};
 static CONSTEXPR const rvv_arg_type_info hv_args[]
  = { rvv_arg_type_info (RVV_BASE_double_trunc_vector),
      rvv_arg_type_info (RVV_BASE_vector),
@@ -3327,6 +3332,12 @@ static CONSTEXPR const rvv_op_info su_qqvv_ops
     OP_TYPE_vv,			/* Suffix */
     rvv_arg_type_info (RVV_BASE_vector),	/* Return type */
     suqqvv_args			/* Args */};
+
+static CONSTEXPR const rvv_op_info su_qvv_ops
+ = {qexti_ops,			/* Types */
+    OP_TYPE_vv,			/* Suffix */
+    rvv_arg_type_info (RVV_BASE_vector),	/* Return type */
+    suqvv_args			/* Args */};
 
 static CONSTEXPR const rvv_op_info u_wwvh_ops
  = {qextu_ops,			/* Types */

--- a/gcc/testsuite/gcc.target/riscv/arcv-mxmd-vqmxm16su_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-mxmd-vqmxm16su_vv-compile-1.c
@@ -1,13 +1,32 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_mxmd } */
-/* { dg-options "-march=rv32im_xarcvmxmd -mabi=ilp32" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
+/* { dg-options "-march=rv32im_xarcvmxmd -mabi=ilp32 -O2" } */
+/* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>
 #include <riscv_vector.h>
 
-vint32m4_t test_vqmxm16su_vv_i8 (vint32m4_t vd, vint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqmxm16su_vv_i32m4 (vd, vs1, vs2, vl); }
-vint32m4_t test_vqmxm16su_vv_i8_m (vbool8_t mask, vint32m4_t vd, vint8m1_t vs1, vuint8m1_t vs2, size_t vl) {
-  return __riscv_arcv_vqmxm16su_vv_i32m4_m (mask, vd, vs1, vs2, vl); }
+/*
+** test_vqmxm16su_vv_i8:
+**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**   arcv.vqmxm16su.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])
+**   ret
+*/
+vint32m4_t
+test_vqmxm16su_vv_i8 (vint32m4_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqmxm16su_vv_i32m4 (vd, vs1, vs2, vl);
+}
 
-/* { dg-final { scan-assembler-times "arcv\\.vqmxm16su\\.vv" 2 } } */
+/*
+** test_vqmxm16su_vv_i8_m:
+**   vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**   arcv.vqmxm16su.vv\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**   ret
+*/
+vint32m4_t
+test_vqmxm16su_vv_i8_m (vbool8_t mask, vint32m4_t vd, vint8m1_t vs1, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vqmxm16su_vv_i32m4_m (mask, vd, vs1, vs2, vl);
+}


### PR DESCRIPTION
The vqmxm16su intrinsic was incorrectly defined with an unsigned operand (using su_qqvv_ops), but the instruction expects both operands to be signed.

This patch introduces su_qvv_ops which correctly specifies both narrow operands as signed quad-truncated vectors, and updates the vqmxm16su builtin definition to use it.  The test case has been corrected to use vint8m1_t instead of vuint8m1_t.

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
