### PR TITLE
arcv: Constrain vclr source operand to match destination.

### DIFF
--- a/gcc/config/riscv/arcv-vector.md
+++ b/gcc/config/riscv/arcv-vector.md
@@ -265,12 +265,12 @@
 	     (reg:SI VL_REGNUM)
 	     (reg:SI VTYPE_REGNUM)] UNSPEC_VPREDICATE)
 	(unspec:V_VLSI
-	[(match_operand:V_VLSI 3 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
+	[(match_operand:V_VLSI 3 "register_operand" "0,0,0,0,0,0,0,0,0,0,0,0")
 	(match_operand:V_VLSI 4 "imm5_operand" "i,i,i,i,i,i,i,i,i,i,i,i")]
 	  UNSPEC_ARCV_VCLR)
 	(match_operand:V_VLSI 2 "vector_merge_operand"     "vu,0,vu,0,vu,0,vu,0,vu,0,vu,0")))]
   "TARGET_XARCVVDSP"
-  "arcv.vclr.v.i4\t%0,%3,%4%p1"
+  "arcv.vclr.v.i\t%0,%4%p1"
   [(set_attr "type" "viwmuladd")
    (set_attr "mode" "<MODE>")
    (set_attr "vl_op_idx" "4")

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vclr_v_i-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vclr_v_i-compile-1.c
@@ -11,7 +11,7 @@
 /*
 ** test_vclr_v_i_i8:
 **  vsetivli	zero,1,e8,m1,ta,ma
-**  arcv\.vclr\.v\.i4\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
+**  arcv\.vclr\.v\.i\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
 **  ret
 */
 vint8m1_t test_vclr_v_i_i8 (vint8m1_t vs2, size_t vl)
@@ -22,7 +22,7 @@ vint8m1_t test_vclr_v_i_i8 (vint8m1_t vs2, size_t vl)
 /*
 ** test_vclr_v_i_i8_m:
 **  vsetivli	zero,1,e8,m1,ta,ma
-**  arcv\.vclr\.v\.i4\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1,\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  arcv\.vclr\.v\.i\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1,\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
 **  ret
 */
 vint8m1_t test_vclr_v_i_i8_m (vbool8_t mask, vint8m1_t vs2, size_t vl)
@@ -33,7 +33,7 @@ vint8m1_t test_vclr_v_i_i8_m (vbool8_t mask, vint8m1_t vs2, size_t vl)
 /*
 ** test_vclr_v_i_i16:
 **  vsetivli	zero,1,e16,m1,ta,ma
-**  arcv\.vclr\.v\.i4\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
+**  arcv\.vclr\.v\.i\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
 **  ret
 */
 vint16m1_t test_vclr_v_i_i16 (vint16m1_t vs2, size_t vl)
@@ -44,7 +44,7 @@ vint16m1_t test_vclr_v_i_i16 (vint16m1_t vs2, size_t vl)
 /*
 ** test_vclr_v_i_i16_m:
 **  vsetivli	zero,1,e16,m1,ta,ma
-**  arcv\.vclr\.v\.i4\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1,\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  arcv\.vclr\.v\.i\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1,\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
 **  ret
 */
 vint16m1_t test_vclr_v_i_i16_m (vbool16_t mask, vint16m1_t vs2, size_t vl)
@@ -55,7 +55,7 @@ vint16m1_t test_vclr_v_i_i16_m (vbool16_t mask, vint16m1_t vs2, size_t vl)
 /*
 ** test_vclr_v_i_i32:
 **  vsetivli	zero,1,e32,m1,ta,ma
-**  arcv\.vclr\.v\.i4\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
+**  arcv\.vclr\.v\.i\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
 **  ret
 */
 vint32m1_t test_vclr_v_i_i32 (vint32m1_t vs2, size_t vl)
@@ -66,7 +66,7 @@ vint32m1_t test_vclr_v_i_i32 (vint32m1_t vs2, size_t vl)
 /*
 ** test_vclr_v_i_i32_m:
 **  vsetivli	zero,1,e32,m1,ta,ma
-**  arcv\.vclr\.v\.i4\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1,\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  arcv\.vclr\.v\.i\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1,\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
 **  ret
 */
 vint32m1_t test_vclr_v_i_i32_m (vbool32_t mask, vint32m1_t vs2, size_t vl)
@@ -77,7 +77,7 @@ vint32m1_t test_vclr_v_i_i32_m (vbool32_t mask, vint32m1_t vs2, size_t vl)
 /*
 ** test_vclr_v_i_i64:
 **  vsetivli	zero,1,e64,m1,ta,ma
-**  arcv\.vclr\.v\.i4\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
+**  arcv\.vclr\.v\.i\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
 **  ret
 */
 vint64m1_t test_vclr_v_i_i64 (vint64m1_t vs2, size_t vl)
@@ -88,7 +88,7 @@ vint64m1_t test_vclr_v_i_i64 (vint64m1_t vs2, size_t vl)
 /*
 ** test_vclr_v_i_i64_m:
 **  vsetivli	zero,1,e64,m1,ta,ma
-**  arcv\.vclr\.v\.i4\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1,\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
+**  arcv\.vclr\.v\.i\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1,\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
 **  ret
 */
 vint64m1_t test_vclr_v_i_i64_m (vbool64_t mask, vint64m1_t vs2, size_t vl)


### PR DESCRIPTION
The vclr instruction from ARCVvdsp operates in-place on vd,
clearing the lower imm5 elements while preserving the rest.
Fix the RTL pattern to constrain the source operand (operand 3)
to match the destination (operand 0).

Also update the assembly output template to the correct format
"arcv.vclr.v.i vd, imm5" without explicitly showing the source
register, and update test validations accordingly.

Note: the current intrinsic form may change in the future,
as vclr does not depend on LMUL or VL.
