### PR TITLE
arcv: Don't make xarcv imply v

### DIFF
--- a/gcc/common/config/riscv/riscv-common.cc
+++ b/gcc/common/config/riscv/riscv-common.cc
@@ -261,14 +261,12 @@ static const riscv_implied_info_t riscv_implied_info[] =
 
   {"xsfvcp", "zve32x"},
 
-  {"xarcvbitrev", "v"},
-  {"xarcvbitstream", "v"},
-  {"xarcvvdsp", "v"},
-  {"xarcvvcplx", "v"},
-  {"xarcvvsad", "v"},
-  {"xarcvmxmb", "v"},
-  {"xarcvmxmc", "v"},
-  {"xarcvmxmd", "v"},
+  {"xarcvvdsp", "zve32x"},
+  {"xarcvvcplx", "zve32x"},
+  {"xarcvvsad", "zve32x"},
+  {"xarcvmxmb", "zve32x"},
+  {"xarcvmxmc", "zve32x"},
+  {"xarcvmxmd", "zve32x"},
 
   {NULL, NULL}
 };

--- a/gcc/testsuite/gcc.target/riscv/arcv-bitrev-bitrev-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-bitrev-bitrev-compile-1.c
@@ -3,9 +3,10 @@
 /* { dg-options "-march=rv32im_xarcvbitrev -mabi=ilp32" } */
 
 #include <stddef.h>
-#include <riscv_vector.h>
 
-int test_bitrev (int vs2, int vs1) {
-  return __builtin_riscv_arcv_bitrev (vs2, vs1); }
+int test_bitrev (int vs2, int vs1)
+{
+  return __builtin_riscv_arcv_bitrev (vs2, vs1);
+}
 
 /* { dg-final { scan-assembler-times "arcv\\.bitrev" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/arcv-bitstream-bspeek-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-bitstream-bspeek-compile-1.c
@@ -3,9 +3,10 @@
 /* { dg-options "-march=rv32im_xarcvbitstream -mabi=ilp32" } */
 
 #include <stddef.h>
-#include <riscv_vector.h>
 
-int test_bspeek (int vs2) {
-  return __builtin_riscv_arcv_bspeek (vs2); }
+int test_bspeek (int vs2)
+{
+  return __builtin_riscv_arcv_bspeek (vs2);
+}
 
 /* { dg-final { scan-assembler-times "arcv\\.bspeek" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/arcv-bitstream-bspop-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-bitstream-bspop-compile-1.c
@@ -3,9 +3,10 @@
 /* { dg-options "-march=rv32im_xarcvbitstream -mabi=ilp32" } */
 
 #include <stddef.h>
-#include <riscv_vector.h>
 
-int test_bspop (int vs2) {
-  return __builtin_riscv_arcv_bspop (vs2); }
+int test_bspop (int vs2)
+{
+  return __builtin_riscv_arcv_bspop (vs2);
+}
 
 /* { dg-final { scan-assembler-times "arcv\\.bspop" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/arcv-bitstream-bspush-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-bitstream-bspush-compile-1.c
@@ -3,9 +3,10 @@
 /* { dg-options "-march=rv32im_xarcvbitstream -mabi=ilp32" } */
 
 #include <stddef.h>
-#include <riscv_vector.h>
 
-int test_bspush (int vs2, int vs1) {
-  return __builtin_riscv_arcv_bspush (vs2, vs1); }
+int test_bspush (int vs2, int vs1)
+{
+  return __builtin_riscv_arcv_bspush (vs2, vs1);
+}
 
 /* { dg-final { scan-assembler-times "arcv\\.bspush" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/arcv-mxmb-vqmxm4_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-mxmb-vqmxm4_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_mxmb } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvmxmb -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvmxmb -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-mxmb-vqmxm4su_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-mxmb-vqmxm4su_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_mxmb } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvmxmb -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvmxmb -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-mxmb-vqmxm4u_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-mxmb-vqmxm4u_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_mxmb } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvmxmb -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvmxmb -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-mxmc-vqmxm8_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-mxmc-vqmxm8_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_mxmc } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvmxmc -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvmxmc -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-mxmc-vqmxm8su_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-mxmc-vqmxm8su_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_mxmc } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvmxmc -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvmxmc -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-mxmc-vqmxm8u_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-mxmc-vqmxm8u_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_mxmc } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvmxmc -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvmxmc -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-mxmd-vqmxm16_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-mxmd-vqmxm16_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_mxmd } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvmxmd -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvmxmd -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-mxmd-vqmxm16su_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-mxmd-vqmxm16su_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_mxmd } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvmxmd -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvmxmd -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-mxmd-vqmxm16u_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-mxmd-vqmxm16u_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_mxmd } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvmxmd -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvmxmd -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vcmuli_v-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vcmuli_v-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vcmulni_v-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vcmulni_v-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vconj_v-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vconj_v-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-veven_v-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-veven_v-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vinterleave_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vinterleave_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vodd_v-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vodd_v-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vqcjrdot_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vqcjrdot_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vqcrdot_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vqcrdot_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vscjmul_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vscjmul_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vscjmul_vx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vscjmul_vx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vscmul_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vscmul_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vscmul_vx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vscmul_vx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vscredsum_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vscredsum_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwcredsum_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwcredsum_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjmac_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjmac_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjmac_vx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjmac_vx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjmul_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjmul_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjmul_vx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjmul_vx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjnmsac_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjnmsac_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjnmsac_vx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjnmsac_vx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjrdot_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscjrdot_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscmac_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscmac_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscmac_vx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscmac_vx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscmul_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscmul_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscmul_vx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscmul_vx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscnmsac_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscnmsac_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscnmsac_vx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscnmsac_vx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscrdot_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vcplx-vwscrdot_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vcplx } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvcplx -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvcplx -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vaddsub_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vaddsub_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vclr_v_i-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vclr_v_i-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmv_s_v-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmv_s_v-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmv_v_s-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmv_v_s-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmvi_s_v-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmvi_s_v-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmvi_v_s-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmvi_v_s-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnorm_v-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnorm_v-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_2s_qi-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_2s_qi-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_2s_qv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_2s_qv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_2s_qx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_2s_qx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_2s_wi-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_2s_wi-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_2s_wv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_2s_wv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_2s_wx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_2s_wx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_qi-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_qi-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_qv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_qv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_qx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_qx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_s_qi-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_s_qi-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_s_qv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_s_qv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_s_qx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_s_qx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_s_wi-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_s_wi-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_s_wv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_s_wv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_s_wx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_s_wx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_wi-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_wi-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_wv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_wv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_wx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vnsra_wx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vqrdot_2s_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vqrdot_2s_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vqrdot_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vqrdot_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vqrdotsu_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vqrdotsu_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vqrdotu_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vqrdotu_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsaaddsub_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsaaddsub_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsaddsub_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsaddsub_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsmulf_hv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsmulf_hv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsmulf_hx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsmulf_hx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsneg_v-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsneg_v-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsra_2s_vi-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsra_2s_vi-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsra_2s_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsra_2s_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsra_2s_vx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsra_2s_vx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsra_s_vi-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsra_s_vi-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsra_s_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsra_s_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsra_s_vx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsra_s_vx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsra_vi-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsra_vi-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsra_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsra_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsra_vx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsra_vx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsrat_vi-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsrat_vi-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsrat_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsrat_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsrat_vx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vsrat_vx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vssabs_v-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vssabs_v-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmac_hv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmac_hv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmac_hx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmac_hx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmacu_hv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmacu_hv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmacu_hx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmacu_hx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmul_hv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmul_hv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmul_hx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmul_hx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmulf_hv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmulf_hv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmulf_hx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmulf_hx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmulu_hv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmulu_hv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmulu_hx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwmulu_hx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwrdot_hv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwrdot_hv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwrdot_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwrdot_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwrdotsu_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwrdotsu_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwrdotu_hv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwrdotu_hv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwrdotu_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwrdotu_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsmac_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsmac_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsmac_vx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsmac_vx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsmacf_hv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsmacf_hv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsmacf_hx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsmacf_hx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsnmsac_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsnmsac_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsnmsac_vx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsnmsac_vx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsnmsacf_hv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsnmsacf_hv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsnmsacf_hx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsnmsacf_hx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsra_vi-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsra_vi-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsra_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsra_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsra_vx-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsra_vx-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsrdot_2s_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsrdot_2s_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsrdot_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsrdot_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsrdotf_hv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vwsrdotf_hv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vdsp } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvdsp -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvdsp -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vsad-vwsad_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vsad-vwsad_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vsad } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvsad -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvsad -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>

--- a/gcc/testsuite/gcc.target/riscv/arcv-vsad-vwsadu_vv-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vsad-vwsadu_vv-compile-1.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target arcv_vsad } */
 /* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-O3" "-Os" "-Og" "-Oz" "-flto" } } */
-/* { dg-options "-march=rv32im_xarcvvsad -mabi=ilp32 -O2" } */
+/* { dg-options "-march=rv32imv_xarcvvsad -mabi=ilp32 -O2" } */
 /* { dg-final { check-function-bodies "**" "" } } */
 
 #include <stddef.h>


### PR DESCRIPTION
'v' implies 'zvl128b' and 'zve64d' while ARC-V hardware might be
configured to support smaller VLEN's or no FPU support.

- xarcvbit(rev|stream) are not RVV intrinsics
- other xarcv extensions now imply 'zve32x', the "smallest" RVV extension