### PR TITLE
arcv: use correct costs and latencies for the RMX-500

### DIFF
--- a/gcc/config/riscv/arcv-rmx500.md
+++ b/gcc/config/riscv/arcv-rmx500.md
@@ -42,7 +42,7 @@
 		condmove,mvpair,zicond,cpop,clmul"))
   "((arcv_rmx500_issueA_fuse0 + arcv_rmx500_ALU_A_fuse0_early) | (arcv_rmx500_issueA_fuse1 + arcv_rmx500_ALU_A_fuse1_early)) | ((arcv_rmx500_issueB_fuse0 + arcv_rmx500_ALU_B_fuse0_early) | (arcv_rmx500_issueB_fuse1 + arcv_rmx500_ALU_B_fuse1_early))")
 
-(define_insn_reservation "arcv_rmx500_imul_fused" 1
+(define_insn_reservation "arcv_rmx500_imul_fused" 3
   (and (eq_attr "tune" "arcv_rmx500")
        (eq_attr "type" "imul_fused"))
   "(arcv_rmx500_issueA_fuse0 + arcv_rmx500_issueA_fuse1 + arcv_rmx500_ALU_A_fuse0_early + arcv_rmx500_ALU_A_fuse1_early + arcv_rmx500_MPY32)")
@@ -63,12 +63,12 @@
        (eq_attr "type" "idiv"))
   "arcv_rmx500_issueA_fuse0 + arcv_rmx500_DIV, nothing*21")
 
-(define_insn_reservation "arcv_rmx500_mpy32_insn" 10
+(define_insn_reservation "arcv_rmx500_mpy32_insn" 3
   (and (eq_attr "tune" "arcv_rmx500")
        (eq_attr "type" "imul"))
-  "arcv_rmx500_issueA_fuse0 + arcv_rmx500_MPY32, nothing*9")
+  "arcv_rmx500_issueA_fuse0 + arcv_rmx500_MPY32, nothing*2")
 
-(define_insn_reservation "arcv_rmx500_load_insn" 1
+(define_insn_reservation "arcv_rmx500_load_insn" 2
   (and (eq_attr "tune" "arcv_rmx500")
        (eq_attr "type" "load,fpload"))
   "(arcv_rmx500_issueB_fuse0 + arcv_rmx500_DMP_fuse0) | (arcv_rmx500_issueB_fuse1 + arcv_rmx500_DMP_fuse1)")
@@ -101,5 +101,5 @@
 (define_bypass 1 "arcv_rmx500_load_insn" "arcv_rmx500_mpy*_insn")
 (define_bypass 1 "arcv_rmx500_load_insn" "arcv_rmx500_load_insn")
 (define_bypass 1 "arcv_rmx500_load_insn" "arcv_rmx500_div_insn")
-(define_bypass 9 "arcv_rmx500_mpy32_insn" "arcv_rmx500_mpy*_insn")
+(define_bypass 3 "arcv_rmx500_mpy32_insn" "arcv_rmx500_mpy*_insn")
 (define_bypass 9 "arcv_rmx500_mpy32_insn" "arcv_rmx500_div_insn")

--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -607,15 +607,15 @@ static const struct riscv_tune_param arcv_rmx100_tune_info = {
 
 /* Costs to use when optimizing for Synopsys RMX-500.  */
 static const struct riscv_tune_param arcv_rmx500_tune_info = {
-  {COSTS_N_INSNS (2), COSTS_N_INSNS (2)},	/* fp_add */
-  {COSTS_N_INSNS (2), COSTS_N_INSNS (2)},	/* fp_mul */
-  {COSTS_N_INSNS (17), COSTS_N_INSNS (17)},	/* fp_div */
-  {COSTS_N_INSNS (2), COSTS_N_INSNS (2)},	/* int_mul */
-  {COSTS_N_INSNS (17), COSTS_N_INSNS (17)},	/* int_div */
-  1,						/* issue_rate */
-  4,						/* branch_cost */
+  {COSTS_N_INSNS (4), COSTS_N_INSNS (5)},	/* fp_add */
+  {COSTS_N_INSNS (4), COSTS_N_INSNS (5)},	/* fp_mul */
+  {COSTS_N_INSNS (20), COSTS_N_INSNS (20)},	/* fp_div */
+  {COSTS_N_INSNS (4), COSTS_N_INSNS (4)},	/* int_mul */
+  {COSTS_N_INSNS (27), COSTS_N_INSNS (43)},	/* int_div */
+  4,						/* issue_rate */
+  9,						/* branch_cost */
   2,						/* memory_cost */
-  4,						/* fmv_cost */
+  8,						/* fmv_cost */
   false,					/* slow_unaligned_access */
   false,					/* vector_unaligned_access */
   false,					/* use_divmod_expansion */


### PR DESCRIPTION
The tune_info struct was just copied from RHX-100. Not sure it was entirely right.
But the issue rate and branch cost were obviously wrong and updating them gave a modest improvement.

Updating the MPY latency gave us slightly better results than using the RHX-100 mtune.