### PR TITLE
Convert zero_extract_fused to insn_and_split

### DIFF
--- a/gcc/config/riscv/arcv.cc
+++ b/gcc/config/riscv/arcv.cc
@@ -681,15 +681,11 @@ arcv_sched_reorder2 (rtx_insn **ready, int *n_readyp)
 	&& (insn_type == TYPE_LOAD || insn_type == TYPE_STORE))
     {
       sched_state.pipeB_scheduled_p = 1;
-      sched_state.cached_can_issue_more = 1;
-      return 1;
     }
     /* Non-memory operations go to ALU pipe.  */
     else if (insn_type != TYPE_LOAD && insn_type != TYPE_STORE)
     {
       sched_state.alu_pipe_scheduled_p = 1;
-      sched_state.cached_can_issue_more = 1;
-      return 1;
     }
   }
 

--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -11805,7 +11805,7 @@ riscv_sched_fusion_priority (rtx_insn *insn, int max_pri, int *fusion_pri,
    we currently only perform the adjustment when -madjust-lmul-cost is given.
    */
 static int
-riscv_sched_adjust_cost (rtx_insn *, int dep_type, rtx_insn *insn, int cost,
+riscv_sched_adjust_cost (rtx_insn *insn, int dep_type, rtx_insn *dep_insn, int cost,
 			 unsigned int)
 {
   /* Use ARCV-specific cost adjustment for RHX-100.  */
@@ -11816,10 +11816,10 @@ riscv_sched_adjust_cost (rtx_insn *, int dep_type, rtx_insn *insn, int cost,
   if (!TARGET_VECTOR || riscv_microarchitecture != generic_ooo)
     return cost;
 
-  if (recog_memoized (insn) < 0)
+  if (recog_memoized (dep_insn) < 0)
     return cost;
 
-  enum attr_type type = get_attr_type (insn);
+  enum attr_type type = get_attr_type (dep_insn);
 
   if (type == TYPE_VFREDO || type == TYPE_VFWREDO)
     {
@@ -11837,7 +11837,7 @@ riscv_sched_adjust_cost (rtx_insn *, int dep_type, rtx_insn *insn, int cost,
     return cost;
 
   enum riscv_vector::vlmul_type lmul =
-    (riscv_vector::vlmul_type)get_attr_vlmul (insn);
+    (riscv_vector::vlmul_type)get_attr_vlmul (dep_insn);
 
   double factor = 1;
   switch (lmul)

--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -4654,22 +4654,24 @@
   [(set_attr "type" "imul_fused")]
 )
 
-(define_insn "*zero_extract_fused"
+(define_insn_and_split "*zero_extract_fused"
   [(set (match_operand:SI 0 "register_operand" "=r")
 	(zero_extract:SI (match_operand:SI 1 "register_operand" "r")
 			 (match_operand 2 "const_int_operand")
 			 (match_operand 3 "const_int_operand")))]
   "TARGET_ARCV_RHX100 && !TARGET_64BIT
      && (INTVAL (operands[2]) > 1 || !TARGET_ZBS)"
-  {
+  "#"
+  "&& reload_completed"
+  [(set (match_dup 0) (ashift:SI   (match_dup 1) (match_dup 2)))
+   (set (match_dup 0) (lshiftrt:SI (match_dup 0) (match_dup 3)))]
+  "{
      int amount = INTVAL (operands[2]);
      int end = INTVAL (operands[3]) + amount;
      operands[2] = GEN_INT (BITS_PER_WORD - end);
      operands[3] = GEN_INT (BITS_PER_WORD - amount);
-     return "slli\t%0,%1,%2\n\tsrli\t%0,%0,%3";
-  }
-  [(set_attr "type" "alu_fused")]
-)
+  }"
+  [(set_attr "type" "alu_fused")])
 
 ;; String compare with length insn.
 ;; Argument 0 is the target (result)

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-xbfu.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-xbfu.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
 /* { dg-require-effective-target rv32 } */
 /* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-Oz" "-Os" } } */
-/* { dg-options "-mtune=arc-v-rhx-100-series -march=rv32im_zbs -mabi=ilp32 -dp" } */
+/* { dg-options "-mtune=arc-v-rhx-100-series -march=rv32im_zbs -mabi=ilp32" } */
 
 #define bit_extract(x,start,amt) (((x)>>(start)) & (~(0xffffffff << (amt))))
 
@@ -11,4 +11,4 @@ f (int x)
   return bit_extract(x,10,14) + bit_extract(x,1,1);
 }
 
-/* { dg-final { scan-assembler {\sslli\s([ast][0-9]+),a0,8.*zero_extract_fused\n\ssrli\s([ast][0-9]+),\1,18\n\sbexti\sa0,a0,1.*\n\sadd\sa0,\2,a0.*\n} } } */
+/* { dg-final { scan-assembler {\sslli\s([ast][0-9]+),a0,8\n\ssrli\s([ast][0-9]+),\1,18\n\sbexti\sa0,a0,1.*\n\sadd\sa0,\2,a0.*\n} } } */


### PR DESCRIPTION
When 2 zero_extract's were scheduled back to back (4 instructions total), these should fit in a single cycle.
When `zero_extract_fused` was split, GCC assumed those 4 instructions would take 3 cycles.

`arcv_sched_adjust_cost` incorrectly increased the cost of fused instructions.
`arcv_sched_reorder2` would prematurely end the cycle if 2 fused instructions were scheduled, not taking into account that the 3rd instruction could be fused with a 4th.