### PR TITLE
Address upstream review for "Check if the addend fits when referencing small data"

### DIFF
--- a/gcc/config/arc/arc.cc
+++ b/gcc/config/arc/arc.cc
@@ -405,9 +405,15 @@ legitimate_small_data_address_p (rtx x, machine_mode mode)
 	  case 1:
 	    break;
 	  case 2:
-	    if ((offset & 0x1) == 0) break; else return false;
+	    if ((offset & 0x1) == 0)
+	      break;
+	    else
+	      return false;
 	  case 4:
-	    if ((offset & 0x3) == 0) break; else return false;
+	    if ((offset & 0x3) == 0)
+	      break;
+	    else
+	      return false;
 	  default:
 	    return false;
 	  }

--- a/gcc/testsuite/gcc.target/arc/sdata-6.c
+++ b/gcc/testsuite/gcc.target/arc/sdata-6.c
@@ -1,17 +1,49 @@
 /* { dg-do compile } */
 /* { dg-options "-O2 -msdata" } */
 
+#include <stdint.h>
+
 __attribute__((section(".sdata"))) int a[300];
 
-int f (void)
-{
-  return a[255];
-}
+#define TEST(optype, threshold)                                                \
+  void consume##optype (int, int, int, int, optype);                           \
+  optype test_r0_fit_##optype (void) {                                         \
+    return ((optype *)a)[threshold];                                           \
+  }                                                                            \
+  optype test_r0_no_fit_##optype (void)                                        \
+  {                                                                            \
+    return ((optype *)a)[threshold + 1];                                       \
+  }                                                                            \
+  void test_r4_fit_##optype (void)                                             \
+  {                                                                            \
+    return consume##optype (0, 0, 0, 0, ((optype *)a)[threshold]);             \
+  }                                                                            \
+  void test_r4_no_fit_##optype (void)                                          \
+  {                                                                            \
+    return consume##optype (0, 0, 0, 0, ((optype *)a)[threshold + 1]);         \
+  }
 
-int g (void)
-{
-  return a[256];
-}
+TEST (char,    255)
+TEST (short,   255)
+TEST (int,     255)
+TEST (int64_t, 127)
+
+/* { dg-final { scan-assembler "ldb_s\\s+r0,\\\[gp,@a@sda\\+255\\\]" } } */
+/* { dg-final { scan-assembler "ldb\\s+r0,\\\[@a\\+256\\\]" } } */
+/* { dg-final { scan-assembler "ldb\\s+r4,\\\[gp,@a@sda\\+255\\\]" } } */
+/* { dg-final { scan-assembler "ldb\\s+r4,\\\[@a\\+256\\\]" } } */
+
+/* { dg-final { scan-assembler "ld\[hw\].x.as\\s+r0,\\\[gp,@a@sda\\+510\\\]" } } */
+/* { dg-final { scan-assembler "ld\[hw\].x\\s+r0,\\\[@a\\+512\\\]" } } */
+/* { dg-final { scan-assembler "ld\[hw\].x.as\\s+r4,\\\[gp,@a@sda\\+510\\\]" } } */
+/* { dg-final { scan-assembler "ld\[hw\].x\\s+r4,\\\[@a\\+512\\\]" } } */
 
 /* { dg-final { scan-assembler "ld_s\\s+r0,\\\[gp,@a@sda\\+1020\\\]" } } */
 /* { dg-final { scan-assembler "ld\\s+r0,\\\[@a\\+1024\\\]" } } */
+/* { dg-final { scan-assembler "ld.as\\s+r4,\\\[gp,@a@sda\\+1020\\\]" } } */
+/* { dg-final { scan-assembler "ld\\s+r4,\\\[@a\\+1024\\\]" } } */
+
+/* { dg-final { scan-assembler "ldd.as\\s+r0,\\\[gp,@a@sda\\+1016\\\]" { target ll64} } } */
+/* { dg-final { scan-assembler "ldd\\s+r0,\\\[@a\\+1024\\\]" { target ll64} } } */
+/* { dg-final { scan-assembler "ldd.as\\s+r4,\\\[gp,@a@sda\\+1016\\\]" { target ll64} } } */
+/* { dg-final { scan-assembler "ldd\\s+r4,\\\[@a\\+1024\\\]" { target ll64} } } */


### PR DESCRIPTION
remarks: https://gcc.gnu.org/pipermail/gcc-patches/2025-December/702662.html

Fix the formatting in legitimate_small_data_address_p
Extended the test
  - with differently sized loads
  - both ld_s (dest reg = r0-r3) and ld.as (dest reg = r4-)