### PR TITLE
arcv: Fix LMUL type mismatch in arcv_vmv_v_s intrinsics.

### DIFF
--- a/gcc/config/riscv/arcv-vector.md
+++ b/gcc/config/riscv/arcv-vector.md
@@ -138,18 +138,18 @@
   [(set_attr "type" "arith")])
 
 (define_insn "@pred_arcv_vmv_v_s_scalar<V_VLSI:mode><P:mode>"
-  [(set (match_operand:<V_VLSI:MODE> 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
-	(if_then_else:<V_VLSI:MODE>
+  [(set (match_operand:V_VLSI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")
+	(if_then_else:V_VLSI
 	  (unspec:<V_VLSI:VM>
 	    [(match_operand 4 "vector_length_operand" " rK, rK, rK, rK, rK, rK, rK, rK, rK, rK, rK, rK")
 	     (match_operand 5 "const_int_operand"     "  i,  i,  i,  i,  i,  i,  i,  i,  i,  i,  i,  i")
 	     (reg:SI VL_REGNUM)
 	     (reg:SI VTYPE_REGNUM)] UNSPEC_VPREDICATE)
 	  (unspec:<V_VLSI:MODE>
-	    [(match_operand:V_VLSI 2 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
+	    [(match_operand:<V_LMUL1> 2 "register_operand" "vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr,vr")
 	     (match_operand:P 3 "reg_or_int_operand" "r,r,r,r,r,r,i,i,i,i,i,i")]
 	    UNSPEC_ARCV_VMV_V_S)
-	  (match_operand:<V_VLSI:MODE> 1 "register_operand" "0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0")))]
+	  (match_operand:V_VLSI 1 "register_operand" "0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0")))]
   "TARGET_XARCVVDSP"
   { return which_alternative < 6 ? "arcv.vmv.v.sx\t%0,%2,%3" : "arcv.vmv.v.si\t%0,%2,%3"; }
   [(set_attr "type" "viwmuladd")

--- a/gcc/config/riscv/riscv-vector-builtins-bases.cc
+++ b/gcc/config/riscv/riscv-vector-builtins-bases.cc
@@ -2247,7 +2247,7 @@ public:
       rtx vs1 = expand_normal (CALL_EXPR_ARG (e.exp, arg_offset++));
 
       e.add_input_operand (mode, vd);
-      e.add_input_operand (mode, vs2);
+      e.add_input_operand (e.arg_mode (1), vs2);
       e.add_input_operand (Pmode, vs1);
     }
 

--- a/gcc/config/riscv/riscv-vector-builtins.cc
+++ b/gcc/config/riscv/riscv-vector-builtins.cc
@@ -1225,7 +1225,7 @@ static CONSTEXPR const rvv_arg_type_info rqqvv_args[]
      rvv_arg_type_info_end};
 static CONSTEXPR const rvv_arg_type_info v_sx_args[]
  = { rvv_arg_type_info (RVV_BASE_vector),
-     rvv_arg_type_info (RVV_BASE_vector),
+     rvv_arg_type_info (RVV_BASE_lmul1_vector),
      rvv_arg_type_info (RVV_BASE_size),
      rvv_arg_type_info_end};
 static CONSTEXPR const rvv_arg_type_info ss_wwvv_args[]

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmv_v_s-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmv_v_s-compile-1.c
@@ -20,6 +20,50 @@ vint8m1_t test_vmv_v_s_i8 (vint8m1_t vd, vint8m1_t vs1, int vs2, size_t vl)
 }
 
 /*
+** test_vmv_v_s_i8m2:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m2,\s*t[au],\s*m[au]
+**  arcv\.vmv\.v\.sx\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint8m2_t test_vmv_v_s_i8m2 (vint8m2_t vd, vint8m1_t vs1, int vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_i8m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vmv_v_s_i8m8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m8,\s*t[au],\s*m[au]
+**  arcv\.vmv\.v\.sx\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint8m8_t test_vmv_v_s_i8m8 (vint8m8_t vd, vint8m1_t vs1, int vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_i8m8 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vmv_v_s_u8m1:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m1,\s*t[au],\s*m[au]
+**  arcv\.vmv\.v\.sx\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vuint8m1_t test_vmv_v_s_u8m1 (vuint8m1_t vd, vuint8m1_t vs1, int vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_u8m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vmv_v_s_u8m4:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m4,\s*t[au],\s*m[au]
+**  arcv\.vmv\.v\.sx\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vuint8m4_t test_vmv_v_s_u8m4 (vuint8m4_t vd, vuint8m1_t vs1, int vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_u8m4 (vd, vs1, vs2, vl);
+}
+
+/*
 ** test_vmv_v_s_i16:
 **  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
 **  arcv\.vmv\.v\.sx\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
@@ -28,6 +72,50 @@ vint8m1_t test_vmv_v_s_i8 (vint8m1_t vd, vint8m1_t vs1, int vs2, size_t vl)
 vint16m1_t test_vmv_v_s_i16 (vint16m1_t vd, vint16m1_t vs1, int vs2, size_t vl)
 {
   return __riscv_arcv_vmv_v_s_i16m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vmv_v_s_i16m4:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m4,\s*t[au],\s*m[au]
+**  arcv\.vmv\.v\.sx\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint16m4_t test_vmv_v_s_i16m4 (vint16m4_t vd, vint16m1_t vs1, int vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_i16m4 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vmv_v_s_i16m8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m8,\s*t[au],\s*m[au]
+**  arcv\.vmv\.v\.sx\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint16m8_t test_vmv_v_s_i16m8 (vint16m8_t vd, vint16m1_t vs1, int vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_i16m8 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vmv_v_s_u16m1:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
+**  arcv\.vmv\.v\.sx\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vuint16m1_t test_vmv_v_s_u16m1 (vuint16m1_t vd, vuint16m1_t vs1, int vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_u16m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vmv_v_s_u16m2:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m2,\s*t[au],\s*m[au]
+**  arcv\.vmv\.v\.sx\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vuint16m2_t test_vmv_v_s_u16m2 (vuint16m2_t vd, vuint16m1_t vs1, int vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_u16m2 (vd, vs1, vs2, vl);
 }
 
 /*
@@ -42,6 +130,50 @@ vint32m1_t test_vmv_v_s_i32 (vint32m1_t vd, vint32m1_t vs1, int vs2, size_t vl)
 }
 
 /*
+** test_vmv_v_s_i32m2:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m2,\s*t[au],\s*m[au]
+**  arcv\.vmv\.v\.sx\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint32m2_t test_vmv_v_s_i32m2 (vint32m2_t vd, vint32m1_t vs1, int vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_i32m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vmv_v_s_i32m8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m8,\s*t[au],\s*m[au]
+**  arcv\.vmv\.v\.sx\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint32m8_t test_vmv_v_s_i32m8 (vint32m8_t vd, vint32m1_t vs1, int vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_i32m8 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vmv_v_s_u32m1:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m1,\s*t[au],\s*m[au]
+**  arcv\.vmv\.v\.sx\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vuint32m1_t test_vmv_v_s_u32m1 (vuint32m1_t vd, vuint32m1_t vs1, int vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_u32m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vmv_v_s_u32m4:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m4,\s*t[au],\s*m[au]
+**  arcv\.vmv\.v\.sx\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vuint32m4_t test_vmv_v_s_u32m4 (vuint32m4_t vd, vuint32m1_t vs1, int vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_u32m4 (vd, vs1, vs2, vl);
+}
+
+/*
 ** test_vmv_v_s_i64:
 **  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m1,\s*t[au],\s*m[au]
 **  arcv\.vmv\.v\.sx\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
@@ -50,4 +182,48 @@ vint32m1_t test_vmv_v_s_i32 (vint32m1_t vd, vint32m1_t vs1, int vs2, size_t vl)
 vint64m1_t test_vmv_v_s_i64 (vint64m1_t vd, vint64m1_t vs1, int vs2, size_t vl)
 {
   return __riscv_arcv_vmv_v_s_i64m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vmv_v_s_i64m2:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m2,\s*t[au],\s*m[au]
+**  arcv\.vmv\.v\.sx\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint64m2_t test_vmv_v_s_i64m2 (vint64m2_t vd, vint64m1_t vs1, int vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_i64m2 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vmv_v_s_i64m4:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m4,\s*t[au],\s*m[au]
+**  arcv\.vmv\.v\.sx\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vint64m4_t test_vmv_v_s_i64m4 (vint64m4_t vd, vint64m1_t vs1, int vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_i64m4 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vmv_v_s_u64m1:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m1,\s*t[au],\s*m[au]
+**  arcv\.vmv\.v\.sx\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vuint64m1_t test_vmv_v_s_u64m1 (vuint64m1_t vd, vuint64m1_t vs1, int vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_u64m1 (vd, vs1, vs2, vl);
+}
+
+/*
+** test_vmv_v_s_u64m8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m8,\s*t[au],\s*m[au]
+**  arcv\.vmv\.v\.sx\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*[a-x0-9]+
+**  ret
+*/
+vuint64m8_t test_vmv_v_s_u64m8 (vuint64m8_t vd, vuint64m1_t vs1, int vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_u64m8 (vd, vs1, vs2, vl);
 }

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmv_v_si-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vmv_v_si-compile-1.c
@@ -20,6 +20,28 @@ vint8m1_t test_vmv_v_si_i8 (vint8m1_t vd, vint8m1_t vs2, size_t vl)
 }
 
 /*
+** test_vmv_v_si_i8m4:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m4,\s*t[au],\s*m[au]
+**  arcv\.vmv\.v\.si\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*-1
+**  ret
+*/
+vint8m4_t test_vmv_v_si_i8m4 (vint8m4_t vd, vint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_i8m4 (vd, vs2, -1, vl);
+}
+
+/*
+** test_vmv_v_si_u8m2:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e8,m2,\s*t[au],\s*m[au]
+**  arcv\.vmv\.v\.si\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*3
+**  ret
+*/
+vuint8m2_t test_vmv_v_si_u8m2 (vuint8m2_t vd, vuint8m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_u8m2 (vd, vs2, 3, vl);
+}
+
+/*
 ** test_vmv_v_si_i16:
 **  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m1,\s*t[au],\s*m[au]
 **  arcv\.vmv\.v\.si\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
@@ -28,6 +50,28 @@ vint8m1_t test_vmv_v_si_i8 (vint8m1_t vd, vint8m1_t vs2, size_t vl)
 vint16m1_t test_vmv_v_si_i16 (vint16m1_t vd, vint16m1_t vs2, size_t vl)
 {
   return __riscv_arcv_vmv_v_s_i16m1 (vd, vs2, 1, vl);
+}
+
+/*
+** test_vmv_v_si_i16m2:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m2,\s*t[au],\s*m[au]
+**  arcv\.vmv\.v\.si\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*15
+**  ret
+*/
+vint16m2_t test_vmv_v_si_i16m2 (vint16m2_t vd, vint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_i16m2 (vd, vs2, 15, vl);
+}
+
+/*
+** test_vmv_v_si_u16m8:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e16,m8,\s*t[au],\s*m[au]
+**  arcv\.vmv\.v\.si\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*-8
+**  ret
+*/
+vuint16m8_t test_vmv_v_si_u16m8 (vuint16m8_t vd, vuint16m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_u16m8 (vd, vs2, -8, vl);
 }
 
 /*
@@ -42,6 +86,28 @@ vint32m1_t test_vmv_v_si_i32 (vint32m1_t vd, vint32m1_t vs2, size_t vl)
 }
 
 /*
+** test_vmv_v_si_i32m4:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m4,\s*t[au],\s*m[au]
+**  arcv\.vmv\.v\.si\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*7
+**  ret
+*/
+vint32m4_t test_vmv_v_si_i32m4 (vint32m4_t vd, vint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_i32m4 (vd, vs2, 7, vl);
+}
+
+/*
+** test_vmv_v_si_u32m2:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e32,m2,\s*t[au],\s*m[au]
+**  arcv\.vmv\.v\.si\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*12
+**  ret
+*/
+vuint32m2_t test_vmv_v_si_u32m2 (vuint32m2_t vd, vuint32m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_u32m2 (vd, vs2, 12, vl);
+}
+
+/*
 ** test_vmv_v_si_i64:
 **  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m1,\s*t[au],\s*m[au]
 **  arcv\.vmv\.v\.si\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
@@ -50,4 +116,15 @@ vint32m1_t test_vmv_v_si_i32 (vint32m1_t vd, vint32m1_t vs2, size_t vl)
 vint64m1_t test_vmv_v_si_i64 (vint64m1_t vd, vint64m1_t vs2, size_t vl)
 {
   return __riscv_arcv_vmv_v_s_i64m1 (vd, vs2, 1, vl);
+}
+
+/*
+** test_vmv_v_si_u64m4:
+**  vsetvli\s+zero,\s*[a-x0-9]+,\s*e64,m4,\s*t[au],\s*m[au]
+**  arcv\.vmv\.v\.si\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*-5
+**  ret
+*/
+vuint64m4_t test_vmv_v_si_u64m4 (vuint64m4_t vd, vuint64m1_t vs2, size_t vl)
+{
+  return __riscv_arcv_vmv_v_s_u64m4 (vd, vs2, -5, vl);
 }


### PR DESCRIPTION
According to the latest spec, the __riscv_arcv_vmv_v_s_* intrinsics incorrectly required the vs2 operand to match the destination LMUL.  Per the instruction semantics, vs2 should always be LMUL=1 regardless of destination LMUL.
```
This caused type errors like:
  vint8m2_t result = __riscv_arcv_vmv_v_s_i8m2(vd, vs2, rs1, vl);
                                                    ^~~
  error: incompatible type for argument 2
  note: expected 'vint8m2_t' but argument is of type 'vint8m1_t'
```
This patch changed v_sx_args to use RVV_BASE_lmul1_vector for the second argument and added subreg conversion in the expander to reinterpret LMUL=1 operands as the full LMUL mode required by the MD pattern.