### PR TITLE
arcv: Fix register overlap case for MAC fusion

### DIFF
--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -4515,7 +4515,7 @@
   {
      if (REGNO (operands[0]) == REGNO (operands[3]))
        {
-	 return "mul\t%4,%1,%2\n\tadd\t%4,%3,%4\n\tmv\t%0,%4";
+	 return "mul\t%4,%1,%2\n\tadd\t%4,%4,%3\n\tmv\t%0,%4";
        }
      else
        {
@@ -4538,7 +4538,7 @@
   {
      if (REGNO (operands[0]) == REGNO (operands[3]))
        {
-	 return "mulw\t%4,%1,%2\n\taddw\t%4,%3,%4\n\tmv\t%0,%4";
+	 return "mulw\t%4,%1,%2\n\taddw\t%4,%4,%3\n\tmv\t%0,%4";
        }
      else
        {


### PR DESCRIPTION
The MAC fusion requires a specific order in the input operands of add.