### PR TITLE
arcv: fix for fused mul+add followed by mv

### DIFF
--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -4504,46 +4504,32 @@
 )
 
 (define_insn "madd_split_fused"
-  [(set (match_operand:SI 0 "register_operand" "=&r,r")
+  [(set (match_operand:SI 0 "register_operand" "=&r")
      (plus:SI
-	(mult:SI (match_operand:SI 1 "register_operand" "r,r")
-		 (match_operand:SI 2 "register_operand" "r,r"))
-	(match_operand:SI 3 "register_operand" "r,?0")))
-    (clobber (match_scratch:SI 4 "=&r,&r"))]
+	(mult:SI (match_operand:SI 1 "register_operand" "r")
+		 (match_operand:SI 2 "register_operand" "r"))
+	(match_operand:SI 3 "register_operand" "r")))
+]
   "TARGET_ARCV_ADVANCED_FUSION
    && (TARGET_ZMMUL || TARGET_MUL)"
   {
-     if (REGNO (operands[0]) == REGNO (operands[3]))
-       {
-	 return "mul\t%4,%1,%2\n\tadd\t%4,%4,%3\n\tmv\t%0,%4";
-       }
-     else
-       {
-	 return "mul\t%0,%1,%2\n\tadd\t%0,%0,%3";
-       }
+ return "mul\t%0,%1,%2\n\tadd\t%0,%0,%3";
   }
   [(set_attr "type" "imul_fused")]
 )
 
 (define_insn "madd_split_fused_extended"
-  [(set (match_operand:DI 0 "register_operand" "=&r,r")
+  [(set (match_operand:DI 0 "register_operand" "=&r")
      (sign_extend:DI
       (plus:SI
-	(mult:SI (match_operand:SI 1 "register_operand" "r,r")
-		 (match_operand:SI 2 "register_operand" "r,r"))
-	(match_operand:SI 3 "register_operand" "r,?0"))))
-    (clobber (match_scratch:SI 4 "=&r,&r"))]
+	(mult:SI (match_operand:SI 1 "register_operand" "r")
+		 (match_operand:SI 2 "register_operand" "r"))
+	(match_operand:SI 3 "register_operand" "r"))))
+    ]
   "TARGET_ARCV_ADVANCED_FUSION
    && (TARGET_ZMMUL || TARGET_MUL)"
   {
-     if (REGNO (operands[0]) == REGNO (operands[3]))
-       {
-	 return "mulw\t%4,%1,%2\n\taddw\t%4,%4,%3\n\tmv\t%0,%4";
-       }
-     else
-       {
-	 return "mulw\t%0,%1,%2\n\taddw\t%0,%0,%3";
-       }
+   return "mulw\t%0,%1,%2\n\taddw\t%0,%0,%3";
   }
   [(set_attr "type" "imul_fused")]
 )


### PR DESCRIPTION
the fix should impact cormark for rpx100

The patch refers to the case where due to a fused
mul+add there is need for an extra move operation
that is being placed at the end of the 2 operations. I prohibit the case where such move would be placed after the add move present at the end of the
2 instructions. In return sometimes there can be a move place at the beginning of the sequence.

jira P10019563-84761