### PR TITLE
riscv: rpx100: emit mulh(s/u) mul pairs in that order

### DIFF
--- a/gcc/config/riscv/arcv-rpx100.md
+++ b/gcc/config/riscv/arcv-rpx100.md
@@ -24,7 +24,7 @@
 (define_cpu_unit "arcv_rpx100_ALU_A_fuse1_early"	"arcv_rpx100")
 (define_cpu_unit "arcv_rpx100_ALU_B_fuse0_early"	"arcv_rpx100")
 (define_cpu_unit "arcv_rpx100_ALU_B_fuse1_early"	"arcv_rpx100")
-(define_cpu_unit "arcv_rpx100_MPY32"	"arcv_rpx100")
+(define_cpu_unit "arcv_rpx100_MPY"	"arcv_rpx100")
 (define_cpu_unit "arcv_rpx100_DIV"	"arcv_rpx100")
 (define_cpu_unit "arcv_rpx100_DMP_fuse0"	"arcv_rpx100")
 (define_cpu_unit "arcv_rpx100_DMP_fuse1"	"arcv_rpx100")
@@ -45,7 +45,7 @@
 (define_insn_reservation "arcv_rpx100_imul_fused" 4
   (and (eq_attr "tune" "arcv_rpx100")
        (eq_attr "type" "imul_fused"))
-  "(arcv_rpx100_issueA_fuse0 + arcv_rpx100_issueA_fuse1 + arcv_rpx100_ALU_A_fuse0_early + arcv_rpx100_ALU_A_fuse1_early + arcv_rpx100_MPY32), nothing*3")
+  "(arcv_rpx100_issueA_fuse0 + arcv_rpx100_issueA_fuse1 + arcv_rpx100_ALU_A_fuse0_early + arcv_rpx100_ALU_A_fuse1_early + arcv_rpx100_MPY), nothing*3")
 
 (define_insn_reservation "arcv_rpx100_alu_fused" 1
    (and (eq_attr "tune" "arcv_rpx100")
@@ -64,8 +64,26 @@
 
 (define_insn_reservation "arcv_rpx100_mpy32_insn" 4
   (and (eq_attr "tune" "arcv_rpx100")
-       (eq_attr "type" "imul"))
-  "arcv_rpx100_issueA_fuse0 + arcv_rpx100_MPY32, nothing*3")
+       (eq_attr "type" "imul")
+       (eq_attr "mode" "SI"))
+  "arcv_rpx100_issueA_fuse0 + arcv_rpx100_MPY, nothing*3")
+
+(define_insn_reservation "arcv_rpx100_mpy64l_insn" 6
+  (and (eq_attr "tune" "arcv_rpx100")
+       (eq_attr "type" "imul")
+       (eq_attr "mode" "DI")
+       (eq_attr "mul_part" "low"))
+  "arcv_rpx100_issueA_fuse0 + arcv_rpx100_MPY, arcv_rpx100_MPY*2, nothing * 3")
+
+;; The 1 cycle reservation of the multiplier is only correct for the bonded mul case.
+;; Mul high part is usually generated together with the low part.
+;; Otherwise, this is 3 cycles too optimistic about multiplier reservation.
+(define_insn_reservation "arcv_rpx100_mpy64h_insn" 7
+  (and (eq_attr "tune" "arcv_rpx100")
+       (eq_attr "type" "imul")
+       (eq_attr "mode" "DI")
+       (eq_attr "mul_part" "high"))
+  "arcv_rpx100_issueA_fuse0 + arcv_rpx100_MPY, nothing*6")
 
 (define_insn_reservation "arcv_rpx100_load_insn" 3
   (and (eq_attr "tune" "arcv_rpx100")

--- a/gcc/config/riscv/arcv.cc
+++ b/gcc/config/riscv/arcv.cc
@@ -336,6 +336,79 @@ arcv_memop_lui_pair_p (rtx_insn *prev, rtx_insn *curr)
   return false;
 }
 
+/* Check if RTX matches multiply-high pattern:
+   (set (reg:DI DEST)
+    (truncate:DI (lshiftrt:TI (mult:TI (extend:TI (OP0))
+					(extend:TI (OP1)))
+				(const_int 64)))  */
+
+static bool
+is_multiply_high_pattern_p (rtx src)
+{
+  if (GET_CODE (src) != SET)
+    return false;
+  rtx truncate = SET_SRC (src);
+
+  if (GET_CODE (truncate) != TRUNCATE)
+    return false;
+
+  rtx lshiftrt = XEXP (truncate, 0);
+  if (GET_CODE (lshiftrt) != LSHIFTRT)
+    return false;
+
+  rtx shift_amount = XEXP (lshiftrt, 1);
+  rtx mult = XEXP (lshiftrt, 0);
+
+  if (GET_CODE (shift_amount) != CONST_INT || INTVAL (shift_amount) != 64)
+    return false;
+
+  if (GET_CODE (mult) != MULT)
+    return false;
+
+  return true;
+}
+
+/* Extract register operands and destinition from multiply high-part pattern.
+  returns true if successful.
+*/
+
+static bool
+get_mulh_operands (rtx set_rtx, rtx *op0, rtx *op1, rtx *dest)
+{
+  if (!is_multiply_high_pattern_p (set_rtx)) return false;
+
+  rtx mulh_pattern = SET_SRC (set_rtx);
+
+  rtx lshiftrt = XEXP (mulh_pattern, 0);
+  rtx mult = XEXP (lshiftrt, 0);
+
+  rtx operand0 = XEXP (mult, 0);
+  rtx operand1 = XEXP (mult, 1);
+
+  /* Strip zero_extend/sign_extend.  */
+  if (GET_CODE (operand0) == ZERO_EXTEND || GET_CODE (operand0) == SIGN_EXTEND)
+    operand0 = XEXP (operand0, 0);
+  if (GET_CODE (operand1) == ZERO_EXTEND || GET_CODE (operand1) == SIGN_EXTEND)
+    operand1 = XEXP (operand1, 0);
+
+  /* Strip subreg.  */
+  if (GET_CODE (operand0) == SUBREG)
+    operand0 = SUBREG_REG (operand0);
+  if (GET_CODE (operand1) == SUBREG)
+    operand1 = SUBREG_REG (operand1);
+
+  if (!REG_P (operand0) || !REG_P (operand1))
+    return false;
+
+  rtx dest_reg = SET_DEST (set_rtx);
+  if (!REG_P (dest_reg))
+    return false;
+
+  *op0 = operand0;
+  *op1 = operand1;
+  *dest = dest_reg;
+  return true;
+}
 
 /* Return true if PREV and CURR should be kept together during scheduling.  */
 
@@ -521,6 +594,48 @@ arcv_macro_fusion_pair_p (rtx_insn *prev, rtx_insn *curr)
 	   fprintf (dump_file, "ARCV_FUSE_LI_STORE (subreg)\n");
 	 return true;
        }
+    }
+
+  return false;
+}
+
+bool
+arcv_macro_bonded_mul_pair_p (rtx_insn *prev, rtx_insn *curr)
+{
+  rtx prev_set = single_set (prev);
+  rtx curr_set = single_set (curr);
+
+  /* Bond mul hi part and mul low part pair:
+     prev: (set rd_hi (mulh(u/s) rs1 rs2))
+     curr: (set rd_lo (mul rs1 rs2))
+     where rd_hi != rs1 && rd_hi != rs2.  */
+  if (prev_set && curr_set
+      && GET_CODE (SET_SRC (curr_set)) == MULT)
+    {
+      rtx prev_op0, prev_op1, prev_dest, curr_dest;
+      if (get_mulh_operands (prev_set, &prev_op0, &prev_op1, &prev_dest))
+	{
+	  rtx curr_src = SET_SRC (curr_set);
+	  curr_dest = SET_DEST (curr_set);
+
+	  rtx curr_op0 = XEXP (curr_src, 0);
+	  rtx curr_op1 = XEXP (curr_src, 1);
+
+	  if (REG_P (prev_op0) && REG_P (prev_op1)
+		&& REG_P (curr_op0) && REG_P (curr_op1)
+		&& REGNO (prev_op0) == REGNO (curr_op0)
+		&& REGNO (prev_op1) == REGNO (curr_op1)
+		&& REGNO (prev_dest) != REGNO (prev_op0)
+		&& REGNO (prev_dest) != REGNO (prev_op1))
+	    {
+	      if (dump_file)
+		fprintf (dump_file,
+		      "ARCV_BONDED_MUL_HI_LO_PAIR high part: %d, low part: %d\n",
+		      INSN_UID (prev),
+		      INSN_UID (curr));
+	      return true;
+	    }
+	}
     }
 
   return false;
@@ -730,11 +845,37 @@ arcv_sched_adjust_priority (rtx_insn *insn, int priority)
   return priority;
 }
 
+bool
+arcv_rpx100_depends_on_lowpart_bonded_mul (rtx_insn *insn, int dep_type, rtx_insn *dep_insn)
+{
+  if (dep_type != REG_DEP_TRUE)
+    return false;
+
+  rtx_insn *prev_insn = prev_nondebug_insn (dep_insn);
+  if (!prev_insn)
+    return false;
+
+  if (!arcv_macro_bonded_mul_pair_p (prev_insn, dep_insn))
+    return false;
+
+  if (dump_file)
+    fprintf (dump_file,
+	"ARCV_BONDED_MUL_ADJUST_COST\t insn: %d, high_part: %d, low_part: %d\n",
+	INSN_UID (insn), INSN_UID (prev_insn), INSN_UID (dep_insn));
+
+  return true;
+}
+
 /* Adjust scheduling cost for ARCV fusion.  */
 
 int
-arcv_sched_adjust_cost (rtx_insn *insn, int dep_type, int cost)
+arcv_sched_adjust_cost (rtx_insn *insn, int dep_type, rtx_insn *dep_insn, int cost)
 {
+  /* Check for bonded 64-bit multiply pair on arcv_rpx100.  */
+  if (riscv_microarchitecture == arcv_rpx100
+      && arcv_rpx100_depends_on_lowpart_bonded_mul (insn, dep_type, dep_insn))
+    return cost - 1;
+
   if (dep_type == REG_DEP_ANTI && !SCHED_GROUP_P (insn))
     return cost + 1;
 

--- a/gcc/config/riscv/riscv-protos.h
+++ b/gcc/config/riscv/riscv-protos.h
@@ -831,11 +831,12 @@ extern bool th_print_operand_address (FILE *, machine_mode, rtx);
 
 /* Routines implemented in arcv.cc.  */
 extern bool arcv_macro_fusion_pair_p (rtx_insn *, rtx_insn *);
+extern bool arcv_macro_bonded_mul_pair_p (rtx_insn *, rtx_insn *);
 extern void arcv_sched_fusion_priority (rtx_insn *, int, int *, int *);
 extern void arcv_sched_init (void);
 extern int arcv_sched_reorder2 (rtx_insn **, int *);
 extern int arcv_sched_adjust_priority (rtx_insn *, int);
-extern int arcv_sched_adjust_cost (rtx_insn *, int, int);
+extern int arcv_sched_adjust_cost (rtx_insn *, int, rtx_insn *,int);
 extern bool arcv_can_issue_more_p (int, int);
 extern int arcv_sched_variable_issue (rtx_insn *, int);
 

--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -10333,7 +10333,7 @@ riscv_macro_fusion_pair_p (rtx_insn *prev, rtx_insn *curr)
 	}
     }
 
-  if (riscv_microarchitecture == rpx100 && arcv_macro_bonded_mul_pair_p(prev, curr))
+  if (riscv_microarchitecture == arcv_rpx100 && arcv_macro_bonded_mul_pair_p(prev, curr))
     return true;
 
   if (TARGET_ARCV_FUSION)

--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -10335,7 +10335,8 @@ riscv_macro_fusion_pair_p (rtx_insn *prev, rtx_insn *curr)
 
   if (TARGET_ARCV_FUSION)
     return (arcv_macro_fusion_pair_p (prev, curr)
-	    || arcv_macro_bonded_mul_pair_p (prev, curr));
+	    || (riscv_microarchitecture == rpx100 &&
+		arcv_macro_bonded_mul_pair_p (prev, curr)));
 
   return false;
 }

--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -10333,10 +10333,11 @@ riscv_macro_fusion_pair_p (rtx_insn *prev, rtx_insn *curr)
 	}
     }
 
+  if (riscv_microarchitecture == rpx100 && arcv_macro_bonded_mul_pair_p(prev, curr))
+    return true;
+
   if (TARGET_ARCV_FUSION)
-    return (arcv_macro_fusion_pair_p (prev, curr)
-	    || (riscv_microarchitecture == rpx100 &&
-		arcv_macro_bonded_mul_pair_p (prev, curr)));
+    return arcv_macro_fusion_pair_p(prev, curr);
 
   return false;
 }

--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -10334,7 +10334,8 @@ riscv_macro_fusion_pair_p (rtx_insn *prev, rtx_insn *curr)
     }
 
   if (TARGET_ARCV_FUSION)
-    return arcv_macro_fusion_pair_p (prev, curr);
+    return (arcv_macro_fusion_pair_p (prev, curr)
+	    || arcv_macro_bonded_mul_pair_p (prev, curr));
 
   return false;
 }
@@ -10367,7 +10368,7 @@ riscv_sched_adjust_cost (rtx_insn *insn, int dep_type, rtx_insn *dep_insn, int c
 {
   /* Use ARCV-specific cost adjustment for RHX-100.  */
   if (TARGET_ARCV_FUSION)
-    return arcv_sched_adjust_cost (insn, dep_type, cost);
+    return arcv_sched_adjust_cost (insn, dep_type, dep_insn, cost);
 
   /* Only do adjustments for the generic out-of-order scheduling model.  */
   if (!TARGET_VECTOR || riscv_microarchitecture != generic_ooo)

--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -667,6 +667,10 @@
 ;; Is copying of this instruction disallowed?
 (define_attr "cannot_copy" "no,yes" (const_string "no"))
 
+;; Multiply part attribute to distinguish mul (low) from mulh/mulhu/mulhsu (high)
+(define_attr "mul_part" "low,high"
+  (const_string "low"))
+
 ;; Microarchitectures we know how to tune for.
 ;; Keep this in sync with enum riscv_microarchitecture.
 (define_attr "tune"
@@ -1128,7 +1132,8 @@
   "TARGET_HARD_FLOAT  || TARGET_ZFINX"
   "fmul.<fmt>\t%0,%1,%2"
   [(set_attr "type" "fmul")
-   (set_attr "mode" "<UNITMODE>")])
+   (set_attr "mode" "<UNITMODE>")
+   (set_attr "mul_part" "low")])
 
 (define_insn "*mulsi3"
   [(set (match_operand:SI          0 "register_operand" "=r")
@@ -1137,7 +1142,8 @@
   "TARGET_ZMMUL || TARGET_MUL"
   "mul%~\t%0,%1,%2"
   [(set_attr "type" "imul")
-   (set_attr "mode" "SI")])
+   (set_attr "mode" "SI")
+   (set_attr "mul_part" "low")])
 
 (define_expand "mulsi3"
   [(set (match_operand:SI          0 "register_operand" "=r")
@@ -1164,7 +1170,8 @@
   "(TARGET_ZMMUL || TARGET_MUL) && TARGET_64BIT"
   "mul\t%0,%1,%2"
   [(set_attr "type" "imul")
-   (set_attr "mode" "DI")])
+   (set_attr "mode" "DI")
+   (set_attr "mul_part" "low")])
 
 (define_expand "mulv<mode>4"
   [(set (match_operand:GPR           0 "register_operand" "=r")
@@ -1265,7 +1272,8 @@
   "(TARGET_ZMMUL || TARGET_MUL) && TARGET_64BIT"
   "mulw\t%0,%1,%2"
   [(set_attr "type" "imul")
-   (set_attr "mode" "SI")])
+   (set_attr "mode" "SI")
+   (set_attr "mul_part" "low")])
 
 (define_insn "*mulsi3_extended2"
   [(set (match_operand:DI                       0 "register_operand" "=r")
@@ -1276,7 +1284,8 @@
   "(TARGET_ZMMUL || TARGET_MUL) && TARGET_64BIT"
   "mulw\t%0,%1,%2"
   [(set_attr "type" "imul")
-   (set_attr "mode" "SI")])
+   (set_attr "mode" "SI")
+   (set_attr "mul_part" "low")])
 
 ;;
 ;;  ........................
@@ -1294,15 +1303,55 @@
   "(TARGET_ZMMUL || TARGET_MUL) && TARGET_64BIT"
 {
   rtx low = gen_reg_rtx (DImode);
-  emit_insn (gen_muldi3 (low, operands[1], operands[2]));
-
   rtx high = gen_reg_rtx (DImode);
-  emit_insn (gen_<su>muldi3_highpart (high, operands[1], operands[2]));
+
+  if (riscv_microarchitecture == arcv_rpx100)
+    {
+      emit_insn (gen_<su>mulditi4_bonded_arcv_rpx100 (high,
+      						      operands[1],
+						      operands[2],
+						      low));
+    }
+  else
+    {
+      emit_insn (gen_muldi3 (low, operands[1], operands[2]));
+      emit_insn (gen_<su>muldi3_highpart (high, operands[1], operands[2]));
+    }
 
   emit_move_insn (gen_lowpart (DImode, operands[0]), low);
   emit_move_insn (gen_highpart (DImode, operands[0]), high);
   DONE;
 })
+
+(define_insn_and_split "<su>mulditi4_bonded_arcv_rpx100"
+  [(set (match_operand:DI 0 "register_operand" "=&r")
+	  (truncate:DI
+	    (lshiftrt:TI
+	      (mult:TI
+		(any_extend:TI (match_operand:DI 1 "register_operand" "r"))
+		(any_extend:TI (match_operand:DI 2 "register_operand" "r")))
+	      (const_int 64))))
+     (set (match_operand:DI 3 "register_operand" "=r")
+	  (mult:DI (match_dup 1)
+		   (match_dup 2)))]
+  "TARGET_64BIT && (TARGET_ZMMUL || TARGET_MUL)
+   && riscv_microarchitecture == arcv_rpx100"
+  "#"
+  "&& reload_completed"
+  [(set (match_dup 0)
+	(truncate:DI
+	  (lshiftrt:TI
+	    (mult:TI
+	      (any_extend:TI (match_dup 1))
+	      (any_extend:TI (match_dup 2)))
+	    (const_int 64))))
+   (set (match_dup 3)
+	(mult:DI (match_dup 1)
+		 (match_dup 2)))]
+  ""
+  [(set_attr "type" "imul")
+   (set_attr "mode" "DI")]
+)
 
 (define_insn "<su>muldi3_highpart"
   [(set (match_operand:DI                0 "register_operand" "=r")
@@ -1316,7 +1365,8 @@
   "(TARGET_ZMMUL || TARGET_MUL) && TARGET_64BIT"
   "mulh<u>\t%0,%1,%2"
   [(set_attr "type" "imul")
-   (set_attr "mode" "DI")])
+   (set_attr "mode" "DI")
+   (set_attr "mul_part" "high")])
 
 (define_expand "usmulditi3"
   [(set (match_operand:TI                          0 "register_operand")
@@ -1325,15 +1375,55 @@
   "(TARGET_ZMMUL || TARGET_MUL) && TARGET_64BIT"
 {
   rtx low = gen_reg_rtx (DImode);
-  emit_insn (gen_muldi3 (low, operands[1], operands[2]));
-
   rtx high = gen_reg_rtx (DImode);
-  emit_insn (gen_usmuldi3_highpart (high, operands[1], operands[2]));
+
+  if (riscv_microarchitecture == arcv_rpx100)
+    {
+      emit_insn (gen_usmulditi4_bonded_arcv_rpx100 (high,
+						    operands[1],
+						    operands[2],
+						    low));
+    }
+  else
+    {
+      emit_insn (gen_muldi3 (low, operands[1], operands[2]));
+      emit_insn (gen_usmuldi3_highpart (high, operands[1], operands[2]));
+    }
 
   emit_move_insn (gen_lowpart (DImode, operands[0]), low);
   emit_move_insn (gen_highpart (DImode, operands[0]), high);
   DONE;
 })
+
+(define_insn_and_split "usmulditi4_bonded_arcv_rpx100"
+  [(set (match_operand:DI 0 "register_operand" "=&r")
+	  (truncate:DI
+	    (lshiftrt:TI
+	      (mult:TI
+		(zero_extend:TI (match_operand:DI 1 "register_operand" "r"))
+		(sign_extend:TI (match_operand:DI 2 "register_operand" "r")))
+	      (const_int 64))))
+     (set (match_operand:DI 3 "register_operand" "=r")
+	  (mult:DI (match_dup 1)
+		   (match_dup 2)))]
+  "TARGET_64BIT && (TARGET_ZMMUL || TARGET_MUL)
+   && riscv_microarchitecture == arcv_rpx100"
+  "#"
+  "&& reload_completed"
+  [(set (match_dup 0)
+	(truncate:DI
+	  (lshiftrt:TI
+	    (mult:TI
+	      (zero_extend:TI (match_dup 1))
+	      (sign_extend:TI (match_dup 2)))
+	    (const_int 64))))
+   (set (match_dup 3)
+	(mult:DI (match_dup 1)
+		 (match_dup 2)))]
+  ""
+  [(set_attr "type" "imul")
+   (set_attr "mode" "DI")]
+)
 
 (define_insn "usmuldi3_highpart"
   [(set (match_operand:DI                0 "register_operand" "=r")
@@ -1347,7 +1437,8 @@
   "(TARGET_ZMMUL || TARGET_MUL) && TARGET_64BIT"
   "mulhsu\t%0,%2,%1"
   [(set_attr "type" "imul")
-   (set_attr "mode" "DI")])
+   (set_attr "mode" "DI")
+   (set_attr "mul_part" "high")])
 
 (define_expand "<u>mulsidi3"
   [(set (match_operand:DI            0 "register_operand" "=r")
@@ -1377,7 +1468,8 @@
   "(TARGET_ZMMUL || TARGET_MUL) && !TARGET_64BIT"
   "mulh<u>\t%0,%1,%2"
   [(set_attr "type" "imul")
-   (set_attr "mode" "SI")])
+   (set_attr "mode" "SI")
+   (set_attr "mul_part" "high")])
 
 
 (define_expand "usmulsidi3"
@@ -1408,7 +1500,8 @@
   "(TARGET_ZMMUL || TARGET_MUL) && !TARGET_64BIT"
   "mulhsu\t%0,%2,%1"
   [(set_attr "type" "imul")
-   (set_attr "mode" "SI")])
+   (set_attr "mode" "SI")
+   (set_attr "mul_part" "high")])
 
 ;;
 ;;  ....................

--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -1132,8 +1132,7 @@
   "TARGET_HARD_FLOAT  || TARGET_ZFINX"
   "fmul.<fmt>\t%0,%1,%2"
   [(set_attr "type" "fmul")
-   (set_attr "mode" "<UNITMODE>")
-   (set_attr "mul_part" "low")])
+   (set_attr "mode" "<UNITMODE>")])
 
 (define_insn "*mulsi3"
   [(set (match_operand:SI          0 "register_operand" "=r")
@@ -1142,8 +1141,7 @@
   "TARGET_ZMMUL || TARGET_MUL"
   "mul%~\t%0,%1,%2"
   [(set_attr "type" "imul")
-   (set_attr "mode" "SI")
-   (set_attr "mul_part" "low")])
+   (set_attr "mode" "SI")])
 
 (define_expand "mulsi3"
   [(set (match_operand:SI          0 "register_operand" "=r")
@@ -1170,8 +1168,7 @@
   "(TARGET_ZMMUL || TARGET_MUL) && TARGET_64BIT"
   "mul\t%0,%1,%2"
   [(set_attr "type" "imul")
-   (set_attr "mode" "DI")
-   (set_attr "mul_part" "low")])
+   (set_attr "mode" "DI")])
 
 (define_expand "mulv<mode>4"
   [(set (match_operand:GPR           0 "register_operand" "=r")
@@ -1272,8 +1269,7 @@
   "(TARGET_ZMMUL || TARGET_MUL) && TARGET_64BIT"
   "mulw\t%0,%1,%2"
   [(set_attr "type" "imul")
-   (set_attr "mode" "SI")
-   (set_attr "mul_part" "low")])
+   (set_attr "mode" "SI")])
 
 (define_insn "*mulsi3_extended2"
   [(set (match_operand:DI                       0 "register_operand" "=r")
@@ -1284,8 +1280,7 @@
   "(TARGET_ZMMUL || TARGET_MUL) && TARGET_64BIT"
   "mulw\t%0,%1,%2"
   [(set_attr "type" "imul")
-   (set_attr "mode" "SI")
-   (set_attr "mul_part" "low")])
+   (set_attr "mode" "SI")])
 
 ;;
 ;;  ........................
@@ -1306,12 +1301,10 @@
   rtx high = gen_reg_rtx (DImode);
 
   if (riscv_microarchitecture == arcv_rpx100)
-    {
-      emit_insn (gen_<su>mulditi4_bonded_arcv_rpx100 (high,
-      						      operands[1],
-						      operands[2],
-						      low));
-    }
+    emit_insn (gen_<su>mulditi4_bonded_arcv_rpx100 (high,
+						    operands[1],
+						    operands[2],
+						    low));
   else
     {
       emit_insn (gen_muldi3 (low, operands[1], operands[2]));

--- a/gcc/testsuite/gcc.target/riscv/arcv-rpx100-bonded-mul-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-rpx100-bonded-mul-1.c
@@ -1,0 +1,30 @@
+/* { dg-do compile } */
+/* { dg-require-effective-target rv64 } */
+/* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-Oz" "-Os" } } */
+/* { dg-options "-mtune=arc-v-rpx-100-series -march=rv64im_zbs -mabi=lp64 -fdump-rtl-sched2" } */
+#include <stdint.h>
+
+__int128_t
+foo (int64_t x, int64_t y, int64_t *result)
+{
+  __int128_t z = (__int128_t) x * y;
+  return z + 1;
+}
+
+__int128_t
+bar (int64_t x, uint64_t y)
+{
+  __int128_t z = (__int128_t) x * y;
+  return z + 1;
+}
+
+__uint128_t
+baz (uint64_t x, uint64_t y)
+{
+  __uint128_t z = (__uint128_t) x * y;
+  return z + 1;
+}
+
+/* { dg-final { scan-rtl-dump "0-->.*a4=trn\\(sxn\\(a0\\)\\*sxn\\(a1\\) 0>>0x40\\).*\n.*1-->.*a5=a0\\*a1.*\n.*6-->.*a0=a5\\+0x1.*" "sched2" } } */
+/* { dg-final { scan-rtl-dump "0-->.*a4=trn\\(zxn\\(a1\\)\\*sxn\\(a0\\) 0>>0x40\\).*\n.*1-->.*a5=a1\\*a0.*\n.*6-->.*a0=a5\\+0x1.*" "sched2" } } */
+/* { dg-final { scan-rtl-dump "0-->.*a4=trn\\(zxn\\(a0\\)\\*zxn\\(a1\\) 0>>0x40\\).*\n.*1-->.*a5=a0\\*a1.*\n.*6-->.*a0=a5\\+0x1.*" "sched2" } } */


### PR DESCRIPTION
RPX100 allows a mulh(s/u) followed by a mul operation to be bonded, saving 3 cycles in the multiplier and allowing the mul's result to be used 1 cycle earlier than expected.

- Add a mul_part attribute to al multiplication instructions in riscv.md to distinguish instructions that return the high and low part.
- Define_expand <us>mulditi3 is modified to emit the high part first for rpx100
- To preserve this order, a bonded define_insn_and_split is introduced
- The same things for the usmul... variants
- Detect this case in riscv_macro_fusion_pair_p
- riscv_sched_adjust_cost reflects the mul result being available 1 cycle sooner in this case

TODO: the cprop_hardreg1 pass sometimes breaks the matching input constraint for the bonded pair, preventing the bonded execution.