### PR TITLE
arcv: Ignore debug instructions for fusions

### DIFF
--- a/gcc/config/riscv/arcv.cc
+++ b/gcc/config/riscv/arcv.cc
@@ -75,6 +75,39 @@ struct arcv_sched_state {
 
 static struct arcv_sched_state sched_state;
 
+/* Return the next possible fusible insn.  */
+
+static rtx_insn *
+arcv_next_fusible_insn (rtx_insn *insn)
+{
+  while (insn)
+    {
+      insn = NEXT_INSN (insn);
+
+      if (insn == 0)
+	break;
+
+      if (DEBUG_INSN_P (insn)
+	  || NOTE_P (insn))
+	continue;
+
+      if (NOTE_INSN_BASIC_BLOCK_P (insn))
+	return NULL;
+
+      if (GET_CODE (insn) == CODE_LABEL
+	  || GET_CODE (insn) == BARRIER
+	  || GET_CODE (PATTERN (insn)) == USE)
+	continue;
+
+      if (JUMP_TABLE_DATA_P (insn))
+	return NULL;
+
+      break;
+    }
+
+  return insn;
+}
+
 /* Return TRUE if the target microarchitecture supports macro-op
    fusion for two memory operations of mode MODE (the direction
    of transfer is determined by the IS_LOAD parameter).  */
@@ -474,7 +507,7 @@ arcv_macro_fusion_pair_p (rtx_insn *prev, rtx_insn *curr)
 
   /* Look ahead 1 insn to prioritize adjacent load/store pairs.
      If curr and next form a better fusion opportunity, defer this fusion.  */
-  rtx_insn *next = next_insn (curr);
+  rtx_insn *next = arcv_next_fusible_insn (curr);
   if (next)
     {
       rtx next_set = single_set (next);
@@ -600,39 +633,6 @@ void
 arcv_sched_init (void)
 {
   sched_state.last_scheduled_insn = 0;
-}
-
-/* Return the next possible fusible insn.  */
-
-static rtx_insn *
-arcv_next_fusible_insn (rtx_insn *insn)
-{
-  while (insn)
-    {
-      insn = NEXT_INSN (insn);
-
-      if (insn == 0)
-	break;
-
-      if (DEBUG_INSN_P (insn)
-	  || NOTE_P (insn))
-	continue;
-
-      if (NOTE_INSN_BASIC_BLOCK_P (insn))
-	return NULL;
-
-      if (GET_CODE (insn) == CODE_LABEL
-	  || GET_CODE (insn) == BARRIER
-	  || GET_CODE (PATTERN (insn)) == USE)
-	continue;
-
-      if (JUMP_TABLE_DATA_P (insn))
-	return NULL;
-
-      break;
-    }
-
-  return insn;
 }
 
 /* Try to reorder ready queue to promote ARCV fusion opportunities.
@@ -787,12 +787,12 @@ arcv_sched_adjust_priority (rtx_insn *insn, int priority)
   /* Bump the priority of fused load-store pairs for easier
      scheduling of the memory pipe.  The specific increase
      value is determined empirically.  */
-  if (next_insn (insn) && INSN_P (next_insn (insn))
-      && SCHED_GROUP_P (next_insn (insn))
+  rtx_insn *next = arcv_next_fusible_insn (insn);
+  if (next && INSN_P (next) && SCHED_GROUP_P (next)
       && ((get_attr_type (insn) == TYPE_STORE
-	   && get_attr_type (next_insn (insn)) == TYPE_STORE)
+	   && get_attr_type (next) == TYPE_STORE)
 	 || (get_attr_type (insn) == TYPE_LOAD
-	     && get_attr_type (next_insn (insn)) == TYPE_LOAD)))
+	     && get_attr_type (next) == TYPE_LOAD)))
     return priority + 1;
 
   return priority;
@@ -960,13 +960,14 @@ arcv_can_issue_more_p (int issue_rate, int more)
 int
 arcv_sched_variable_issue (rtx_insn *insn, int more)
 {
-  if (next_insn (insn) && INSN_P (next_insn (insn))
-      && SCHED_GROUP_P (next_insn (insn)))
+  rtx_insn *next = arcv_next_fusible_insn (insn);
+  if (next && INSN_P (next)
+      && SCHED_GROUP_P (next))
     {
       if (get_attr_type (insn) == TYPE_LOAD
 	  || get_attr_type (insn) == TYPE_STORE
-	  || get_attr_type (next_insn (insn)) == TYPE_LOAD
-	  || get_attr_type (next_insn (insn)) == TYPE_STORE)
+	  || get_attr_type (next) == TYPE_LOAD
+	  || get_attr_type (next) == TYPE_STORE)
 	sched_state.pipeB_scheduled_p = 1;
       else
 	sched_state.alu_pipe_scheduled_p = 1;

--- a/gcc/config/riscv/arcv.cc
+++ b/gcc/config/riscv/arcv.cc
@@ -87,8 +87,7 @@ arcv_next_fusible_insn (rtx_insn *insn)
       if (insn == 0)
 	break;
 
-      if (DEBUG_INSN_P (insn)
-	  || NOTE_P (insn))
+      if (!NONDEBUG_INSN_P (insn))
 	continue;
 
       if (NOTE_INSN_BASIC_BLOCK_P (insn))
@@ -736,7 +735,7 @@ arcv_sched_reorder2 (rtx_insn **ready, int *n_readyp)
 	     && get_attr_type (ready[*n_readyp - i]) != TYPE_STORE
 	     && !SCHED_GROUP_P (ready[*n_readyp - i])
 	     && (!next_insn || !SCHED_GROUP_P (next_insn)))
-	    || (next_insn && NONDEBUG_INSN_P (next_insn)
+	    || (next_insn
 		&& recog_memoized (next_insn) >= 0
 		&& get_attr_type (next_insn) != TYPE_LOAD
 		&& get_attr_type (next_insn) != TYPE_STORE))
@@ -788,7 +787,7 @@ arcv_sched_adjust_priority (rtx_insn *insn, int priority)
      scheduling of the memory pipe.  The specific increase
      value is determined empirically.  */
   rtx_insn *next = arcv_next_fusible_insn (insn);
-  if (next && INSN_P (next) && SCHED_GROUP_P (next)
+  if (next && SCHED_GROUP_P (next)
       && ((get_attr_type (insn) == TYPE_STORE
 	   && get_attr_type (next) == TYPE_STORE)
 	 || (get_attr_type (insn) == TYPE_LOAD
@@ -961,8 +960,7 @@ int
 arcv_sched_variable_issue (rtx_insn *insn, int more)
 {
   rtx_insn *next = arcv_next_fusible_insn (insn);
-  if (next && INSN_P (next)
-      && SCHED_GROUP_P (next))
+  if (next && SCHED_GROUP_P (next))
     {
       if (get_attr_type (insn) == TYPE_LOAD
 	  || get_attr_type (insn) == TYPE_STORE

--- a/gcc/testsuite/gcc.target/riscv/arcv-debug-fusion-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-debug-fusion-1.c
@@ -1,0 +1,13 @@
+/* { dg-do compile } */
+/* { dg-require-effective-target rv32 } */
+/* { dg-skip-if "" { *-*-* } { "-flto" "-Og" "-O0" "-O1" "-Os" "-Oz" } } */
+/* { dg-options "-c -g -mtune=arc-v-rmx-500-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" } */
+
+void foo(int *a) {
+    int bar = a[0] + a[1];
+    a[0] = bar;
+    a[1] = bar;
+    return;
+}
+
+/* { dg-final { scan-rtl-dump ";;\[ \t\]*(\[0-9\]+)-->\[^\n\]*\\]=.*\n(?:\[^\n\]*\n)*?;;\[ \t\]*\\1-->\[^\n\]*\\]=" "sched2" } } */


### PR DESCRIPTION
Some fusions are not detected when debug info is enabled, but are detected for the same generated code without debug info. Example: Double store fusion not detected when debug insn in between.

Sched2 output without -g:
;;	  2--> b  0: i   9 [a0]=t0
;;	  2--> b  0: i  10 [a0+0x4]=t0

Sched2 output with -g:
;;	  2--> b  0: i  12 [a0]=t0
;;	  2--> b  0: i  13 debug_marker
;;	  3--> b  0: i  14 [a0+0x4]=t0

After this patch with -g:
;;	  2--> b  0: i  12 [a0]=t0
;;	  2--> b  0: i  13 debug_marker
;;	  2--> b  0: i  14 [a0+0x4]=t0