### PR TITLE
fixup! RISC-V: Implement riscv_macro_fusion_pair_p for Synopsys RHX-1…

### DIFF
--- a/gcc/config/riscv/arcv.cc
+++ b/gcc/config/riscv/arcv.cc
@@ -300,7 +300,7 @@ arcv_memop_lui_pair_p (rtx_insn *prev, rtx_insn *curr)
   /* Check if curr is a LUI instruction:
      - LUI via HIGH: (set (reg:X rd) (high (const_int)))
      - LUI via immediate: (set (reg:X rd) (const_int UPPER_IMM_20))  */
-  bool is_lui = (REG_P (curr)
+  bool is_lui = (REG_P (SET_DEST (curr_set))
 		&& ((get_attr_type (curr) == TYPE_MOVE
 		&& GET_CODE (SET_SRC (curr_set)) == HIGH)
 		|| (CONST_INT_P (SET_SRC (curr_set))
@@ -566,17 +566,16 @@ arcv_macro_fusion_pair_p (rtx_insn *prev, rtx_insn *curr)
       rtx store_src = SET_SRC (curr_set);
       rtx load_dest = SET_DEST (prev_set);
 
-      if (REG_P (store_src) && store_src == load_dest)
+      if (REG_P (store_src) && REG_P (load_dest)
+	  && REGNO (store_src) == REGNO (load_dest))
        {
 	 if (dump_file)
-	   fprintf (dump_file, "ARCV_FUSE_LI_STORE\n");
-	 return true;
-       }
-
-      if (SUBREG_P (store_src) && SUBREG_REG (store_src) == load_dest)
-       {
-	 if (dump_file)
-	   fprintf (dump_file, "ARCV_FUSE_LI_STORE (subreg)\n");
+	   {
+	     if (GET_MODE (store_src) != GET_MODE (load_dest))
+	       fprintf (dump_file, "ARCV_FUSE_LI_STORE (subreg)\n");
+	     else
+	       fprintf (dump_file, "ARCV_FUSE_LI_STORE\n");
+	   }
 	 return true;
        }
     }

--- a/gcc/config/riscv/arcv.cc
+++ b/gcc/config/riscv/arcv.cc
@@ -406,7 +406,8 @@ arcv_macro_fusion_pair_p (rtx_insn *prev, rtx_insn *curr)
   /* Fuse multiply-add pair:
      prev: (set rd_mult (mult rs1 rs2))
      curr: (set rd_add (plus rd_mult rs3))  */
-  if (prev_set && curr_set
+  if (TARGET_ARCV_ADVANCED_FUSION
+      && prev_set && curr_set
       && GET_CODE (SET_SRC (prev_set)) == MULT
       && GET_CODE (SET_SRC (curr_set)) == PLUS)
     {

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-adj-load-dump.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-adj-load-dump.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
-/* { dg-require-effective-target rv32 } */
 /* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-O3" "-Oz" "-Os" } } */
-/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" { target rv32 } } */
+/* { dg-options "-O2 -mtune=arc-v-rpx-100-series -march=rv64im -mabi=lp64 -fdump-rtl-sched2" { target rv64 } } */
 
 int
 fuse_adjacent_load (int *p)

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-adj-load-dump.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-adj-load-dump.c
@@ -1,0 +1,12 @@
+/* { dg-do compile } */
+/* { dg-require-effective-target rv32 } */
+/* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-O3" "-Oz" "-Os" } } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" } */
+
+int
+fuse_adjacent_load (int *p)
+{
+  return p[0] + p[1];
+}
+
+/* { dg-final { scan-rtl-dump "ARCV_FUSE_ADJACENT_LOAD" "sched2" } } */

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-adj-store-dump.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-adj-store-dump.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
-/* { dg-require-effective-target rv32 } */
 /* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-O3" "-Oz" "-Os" } } */
-/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" { target rv32 } } */
+/* { dg-options "-O2 -mtune=arc-v-rpx-100-series -march=rv64im -mabi=lp64 -fdump-rtl-sched2" { target rv64 } } */
 
 void
 fuse_adjacent_store (int *p, int x, int y)

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-adj-store-dump.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-adj-store-dump.c
@@ -1,0 +1,13 @@
+/* { dg-do compile } */
+/* { dg-require-effective-target rv32 } */
+/* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-O3" "-Oz" "-Os" } } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" } */
+
+void
+fuse_adjacent_store (int *p, int x, int y)
+{
+  p[0] = x;
+  p[1] = y;
+}
+
+/* { dg-final { scan-rtl-dump "ARCV_FUSE_ADJACENT_STORE" "sched2" } } */

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-li-branch-dump.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-li-branch-dump.c
@@ -1,0 +1,14 @@
+/* { dg-do compile } */
+/* { dg-require-effective-target rv32 } */
+/* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-O3" "-Oz" "-Os" } } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" } */
+
+int
+fuse_li_branch (int x)
+{
+  while (x <= 3)
+    ;
+  return x;
+}
+
+/* { dg-final { scan-rtl-dump "ARCV_FUSE_LI_BRANCH" "sched2" } } */

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-li-branch-dump.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-li-branch-dump.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
-/* { dg-require-effective-target rv32 } */
 /* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-O3" "-Oz" "-Os" } } */
-/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" { target rv32 } } */
+/* { dg-options "-O2 -mtune=arc-v-rpx-100-series -march=rv64im -mabi=lp64 -fdump-rtl-sched2" { target rv64 } } */
 
 int
 fuse_li_branch (int x)

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-li-store-dump.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-li-store-dump.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
-/* { dg-require-effective-target rv32 } */
 /* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-O3" "-Oz" "-Os" } } */
-/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" { target rv32 } } */
+/* { dg-options "-O2 -mtune=arc-v-rpx-100-series -march=rv64im -mabi=lp64 -fdump-rtl-sched2" { target rv64 } } */
 
 void
 fuse_li_store (int *p)
@@ -9,4 +9,5 @@ fuse_li_store (int *p)
   *p = 42;
 }
 
-/* { dg-final { scan-rtl-dump "ARCV_FUSE_LI_STORE" "sched2" } } */
+/* { dg-final { scan-rtl-dump "ARCV_FUSE_LI_STORE\n" "sched2" { target rv32 } } } */
+/* { dg-final { scan-rtl-dump "ARCV_FUSE_LI_STORE \\(subreg\\)" "sched2" { target rv64 } } } */

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-li-store-dump.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-li-store-dump.c
@@ -1,0 +1,12 @@
+/* { dg-do compile } */
+/* { dg-require-effective-target rv32 } */
+/* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-O3" "-Oz" "-Os" } } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" } */
+
+void
+fuse_li_store (int *p)
+{
+  *p = 42;
+}
+
+/* { dg-final { scan-rtl-dump "ARCV_FUSE_LI_STORE" "sched2" } } */

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-ls-update-dump.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-ls-update-dump.c
@@ -1,0 +1,15 @@
+/* { dg-do compile } */
+/* { dg-require-effective-target rv32 } */
+/* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-O3" "-Oz" "-Os" } } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" } */
+
+int
+fuse_ls_update (int *p, int n)
+{
+  int sum = 0;
+  for (int i = 0; i < n; i++)
+    sum += *p++;
+  return sum;
+}
+
+/* { dg-final { scan-rtl-dump "ARCV_FUSE_LS_UPDATE" "sched2" } } */

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-ls-update-rev-dump.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-ls-update-rev-dump.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
-/* { dg-require-effective-target rv32 } */
 /* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-O3" "-Oz" "-Os" } } */
-/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" { target rv32 } } */
+/* { dg-options "-O2 -mtune=arc-v-rpx-100-series -march=rv64im -mabi=lp64 -fdump-rtl-sched2" { target rv64 } } */
 
 void
 fuse_ls_update_rev (int *p, int n, int val)

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-ls-update-rev-dump.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-ls-update-rev-dump.c
@@ -1,0 +1,16 @@
+/* { dg-do compile } */
+/* { dg-require-effective-target rv32 } */
+/* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-O3" "-Oz" "-Os" } } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" } */
+
+void
+fuse_ls_update_rev (int *p, int n, int val)
+{
+  for (int i = 0; i < n; i++)
+    {
+      p++;
+      *p = val;
+    }
+}
+
+/* { dg-final { scan-rtl-dump "ARCV_FUSE_LS_UPDATE \\(curr, prev\\)" "sched2" } } */

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-memop-lui-dump.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-memop-lui-dump.c
@@ -1,7 +1,7 @@
 /* { dg-do compile } */
-/* { dg-require-effective-target rv32 } */
 /* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-O3" "-Oz" "-Os" } } */
-/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" { target rv32 } } */
+/* { dg-options "-O2 -mtune=arc-v-rpx-100-series -march=rv64im -mabi=lp64 -mcmodel=medlow -fdump-rtl-sched2" { target rv64 } } */
 
 extern int g1, g2;
 

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-memop-lui-dump.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-memop-lui-dump.c
@@ -1,0 +1,17 @@
+/* { dg-do compile } */
+/* { dg-require-effective-target rv32 } */
+/* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-O3" "-Oz" "-Os" } } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" } */
+
+extern int g1, g2;
+
+int
+fuse_memop_lui (int *p, int *q)
+{
+  int a = *p;
+  int b = *q;
+  return a + b + g1 + g2;
+}
+
+/* { dg-final { scan-rtl-dump "ARCV_FUSE_MEMOP_LUI \\(prev, curr\\)" "sched2" } } */
+/* { dg-final { scan-rtl-dump "ARCV_FUSE_MEMOP_LUI \\(curr, prev\\)" "sched2" } } */

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-mult-add-dump.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-mult-add-dump.c
@@ -1,0 +1,21 @@
+/* { dg-do compile } */
+/* { dg-require-effective-target rv32 } */
+/* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-O3" "-Oz" "-Os" } } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" } */
+
+int
+fuse_mult_add_op0 (int a, int b, int c, int d)
+{
+  int m = a * b;
+  return m + c + m + d;
+}
+
+int
+fuse_mult_add_op1 (int a, int b, int c)
+{
+  int m = a * b;
+  return a + m + c + m;
+}
+
+/* { dg-final { scan-rtl-dump "ARCV_FUSE_MULT_ADD \\(op0\\)" "sched2" } } */
+/* { dg-final { scan-rtl-dump "ARCV_FUSE_MULT_ADD \\(op1\\)" "sched2" } } */

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-shift-bitextract-dump.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-shift-bitextract-dump.c
@@ -1,0 +1,15 @@
+/* { dg-do compile } */
+/* { dg-require-effective-target rv32 } */
+/* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-O3" "-Oz" "-Os" } } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" } */
+
+unsigned int
+fusion_shift_bitextract (unsigned int x, unsigned int y, unsigned int z)
+{
+    unsigned int t = x << 8;
+    unsigned int a = y + z;
+    t = t >> 4;
+    return t + a;
+}
+
+/* { dg-final { scan-rtl-dump "ARCV_FUSE_SHIFT_BITEXTRACT" "sched2" } } */


### PR DESCRIPTION
…00 series.

    arcv: Fix dead memop+LUI fusion check in arcv_memop_lui_pair_p.

    arcv_memop_lui_pair_p was checking REG_P(curr) where curr is an rtx_insn*.
    REG_P tests GET_CODE(x) == REG, but an instruction RTX always has code INSN,
    JUMP_INSN, etc. — never REG.  This made is_lui unconditionally false, so the
    load+LUI and store+LUI fusion paths in arcv_macro_fusion_pair_p were never
    reached.

    Fix by checking REG_P(SET_DEST(curr_set)) instead, which correctly tests
    whether the LUI destination is a register, matching the intent of the comment:
            (set (reg:X rd) (high (const_int))).

--
    arcv: Fix ARCV_FUSE_LI_STORE mode mismatch on rv64.

    On rv64, the li destination uses DI mode while a sw store source uses SI mode.
    Since GCC uses distinct RTX objects for different modes of the same hard
    register, the pointer equality check (store_src == load_dest) always fails,
    preventing LI_STORE fusion from triggering on rv64.

    Use REGNO comparison instead of pointer equality, consistent with other register
    comparisons in arcv_macro_fusion_pair_p.

    Also remove the now-dead SUBREG_P block: it was intended to handle this mode
    narrowing case via (subreg:SI (reg:DI Rd) 0), but cleanup_subreg_operands in
    reload simplifies such subregs to plain (reg:SI Rd) before sched2 runs.  Detect
    the narrowing instead by comparing GET_MODE in the REG_P path.