### PR TITLE
Rebase downstream fusion patches to upstream

### DIFF
--- a/gcc/config/riscv/arcv.cc
+++ b/gcc/config/riscv/arcv.cc
@@ -665,7 +665,7 @@ arcv_sched_reorder2 (rtx_insn **ready, int *n_readyp)
 	     && get_attr_type (ready[*n_readyp - i]) != TYPE_STORE
 	     && !SCHED_GROUP_P (ready[*n_readyp - i])
 	     && (!next_insn || !SCHED_GROUP_P (next_insn)))
-	    || (next_insn && NONDEBUG_INSN_P (next_insn)
+	    || (next_insn
 		&& recog_memoized (next_insn) >= 0
 		&& get_attr_type (next_insn) != TYPE_LOAD
 		&& get_attr_type (next_insn) != TYPE_STORE))
@@ -714,7 +714,7 @@ arcv_sched_adjust_priority (rtx_insn *insn, int priority)
      scheduling of the memory pipe.  The specific increase
      value is determined empirically.  */
   rtx_insn *next = arcv_next_fusible_insn (insn);
-  if (next && INSN_P (next) && SCHED_GROUP_P (next)
+  if (next && SCHED_GROUP_P (next)
       && ((get_attr_type (insn) == TYPE_STORE
 	   && get_attr_type (next) == TYPE_STORE)
 	 || (get_attr_type (insn) == TYPE_LOAD
@@ -861,8 +861,7 @@ int
 arcv_sched_variable_issue (rtx_insn *insn, int more)
 {
   rtx_insn *next = arcv_next_fusible_insn (insn);
-  if (next && INSN_P (next)
-      && SCHED_GROUP_P (next))
+  if (next && SCHED_GROUP_P (next))
     {
       if (get_attr_type (insn) == TYPE_LOAD
 	  || get_attr_type (insn) == TYPE_STORE

--- a/gcc/config/riscv/arcv.cc
+++ b/gcc/config/riscv/arcv.cc
@@ -87,8 +87,7 @@ arcv_next_fusible_insn (rtx_insn *insn)
       if (insn == 0)
 	break;
 
-      if (DEBUG_INSN_P (insn)
-	  || NOTE_P (insn))
+      if (!NONDEBUG_INSN_P (insn))
 	continue;
 
       if (NOTE_INSN_BASIC_BLOCK_P (insn))

--- a/gcc/config/riscv/arcv.cc
+++ b/gcc/config/riscv/arcv.cc
@@ -345,7 +345,7 @@ arcv_memop_lui_pair_p (rtx_insn *prev, rtx_insn *curr)
   /* Check if curr is a LUI instruction:
      - LUI via HIGH: (set (reg:X rd) (high (const_int)))
      - LUI via immediate: (set (reg:X rd) (const_int UPPER_IMM_20))  */
-  bool is_lui = (REG_P (curr)
+  bool is_lui = (REG_P (SET_DEST (curr_set))
 		&& ((get_attr_type (curr) == TYPE_MOVE
 		&& GET_CODE (SET_SRC (curr_set)) == HIGH)
 		|| (CONST_INT_P (SET_SRC (curr_set))
@@ -538,17 +538,16 @@ arcv_macro_fusion_pair_p (rtx_insn *prev, rtx_insn *curr)
       rtx store_src = SET_SRC (curr_set);
       rtx load_dest = SET_DEST (prev_set);
 
-      if (REG_P (store_src) && store_src == load_dest)
+      if (REG_P (store_src) && REG_P (load_dest)
+	  && REGNO (store_src) == REGNO (load_dest))
        {
 	 if (dump_file)
-	   fprintf (dump_file, "ARCV_FUSE_LI_STORE\n");
-	 return true;
-       }
-
-      if (SUBREG_P (store_src) && SUBREG_REG (store_src) == load_dest)
-       {
-	 if (dump_file)
-	   fprintf (dump_file, "ARCV_FUSE_LI_STORE (subreg)\n");
+	   {
+	     if (GET_MODE (store_src) != GET_MODE (load_dest))
+	       fprintf (dump_file, "ARCV_FUSE_LI_STORE (subreg)\n");
+	     else
+	       fprintf (dump_file, "ARCV_FUSE_LI_STORE\n");
+	   }
 	 return true;
        }
     }

--- a/gcc/config/riscv/arcv.cc
+++ b/gcc/config/riscv/arcv.cc
@@ -565,39 +565,6 @@ arcv_sched_init (void)
   sched_state.last_scheduled_insn = 0;
 }
 
-/* Return the next possible fusible insn.  */
-
-static rtx_insn *
-arcv_next_fusible_insn (rtx_insn *insn)
-{
-  while (insn)
-    {
-      insn = NEXT_INSN (insn);
-
-      if (insn == 0)
-	break;
-
-      if (DEBUG_INSN_P (insn)
-	  || NOTE_P (insn))
-	continue;
-
-      if (NOTE_INSN_BASIC_BLOCK_P (insn))
-	return NULL;
-
-      if (GET_CODE (insn) == CODE_LABEL
-	  || GET_CODE (insn) == BARRIER
-	  || GET_CODE (PATTERN (insn)) == USE)
-	continue;
-
-      if (JUMP_TABLE_DATA_P (insn))
-	return NULL;
-
-      break;
-    }
-
-  return insn;
-}
-
 /* Try to reorder ready queue to promote ARCV fusion opportunities.
    Returns the number of instructions that can be issued this cycle.  */
 
@@ -747,12 +714,12 @@ arcv_sched_adjust_priority (rtx_insn *insn, int priority)
   /* Bump the priority of fused load-store pairs for easier
      scheduling of the memory pipe.  The specific increase
      value is determined empirically.  */
-  if (next_insn (insn) && INSN_P (next_insn (insn))
-      && SCHED_GROUP_P (next_insn (insn))
+  rtx_insn *next = arcv_next_fusible_insn (insn);
+  if (next && INSN_P (next) && SCHED_GROUP_P (next)
       && ((get_attr_type (insn) == TYPE_STORE
-	   && get_attr_type (next_insn (insn)) == TYPE_STORE)
+	   && get_attr_type (next) == TYPE_STORE)
 	 || (get_attr_type (insn) == TYPE_LOAD
-	     && get_attr_type (next_insn (insn)) == TYPE_LOAD)))
+	     && get_attr_type (next) == TYPE_LOAD)))
     return priority + 1;
 
   return priority;
@@ -894,13 +861,14 @@ arcv_can_issue_more_p (int issue_rate, int more)
 int
 arcv_sched_variable_issue (rtx_insn *insn, int more)
 {
-  if (next_insn (insn) && INSN_P (next_insn (insn))
-      && SCHED_GROUP_P (next_insn (insn)))
+  rtx_insn *next = arcv_next_fusible_insn (insn);
+  if (next && INSN_P (next)
+      && SCHED_GROUP_P (next))
     {
       if (get_attr_type (insn) == TYPE_LOAD
 	  || get_attr_type (insn) == TYPE_STORE
-	  || get_attr_type (next_insn (insn)) == TYPE_LOAD
-	  || get_attr_type (next_insn (insn)) == TYPE_STORE)
+	  || get_attr_type (next) == TYPE_LOAD
+	  || get_attr_type (next) == TYPE_STORE)
 	sched_state.pipeB_scheduled_p = 1;
       else
 	sched_state.alu_pipe_scheduled_p = 1;

--- a/gcc/config/riscv/arcv.cc
+++ b/gcc/config/riscv/arcv.cc
@@ -75,6 +75,39 @@ struct arcv_sched_state {
 
 static struct arcv_sched_state sched_state;
 
+/* Return the next possible fusible insn.  */
+
+static rtx_insn *
+arcv_next_fusible_insn (rtx_insn *insn)
+{
+  while (insn)
+    {
+      insn = NEXT_INSN (insn);
+
+      if (insn == 0)
+	break;
+
+      if (DEBUG_INSN_P (insn)
+	  || NOTE_P (insn))
+	continue;
+
+      if (NOTE_INSN_BASIC_BLOCK_P (insn))
+	return NULL;
+
+      if (GET_CODE (insn) == CODE_LABEL
+	  || GET_CODE (insn) == BARRIER
+	  || GET_CODE (PATTERN (insn)) == USE)
+	continue;
+
+      if (JUMP_TABLE_DATA_P (insn))
+	return NULL;
+
+      break;
+    }
+
+  return insn;
+}
+
 /* Return TRUE if the target microarchitecture supports macro-op
    fusion for two memory operations of mode MODE (the direction
    of transfer is determined by the IS_LOAD parameter).  */
@@ -446,7 +479,7 @@ arcv_macro_fusion_pair_p (rtx_insn *prev, rtx_insn *curr)
 
   /* Look ahead 1 insn to prioritize adjacent load/store pairs.
      If curr and next form a better fusion opportunity, defer this fusion.  */
-  rtx_insn *next = next_insn (curr);
+  rtx_insn *next = arcv_next_fusible_insn (curr);
   if (next)
     {
       rtx next_set = single_set (next);

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-adj-load-dump.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-adj-load-dump.c
@@ -1,0 +1,12 @@
+/* { dg-do compile } */
+/* { dg-require-effective-target rv32 } */
+/* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-O3" "-Oz" "-Os" } } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" } */
+
+int
+fuse_adjacent_load (int *p)
+{
+  return p[0] + p[1];
+}
+
+/* { dg-final { scan-rtl-dump "ARCV_FUSE_ADJACENT_LOAD" "sched2" } } */

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-adj-store-dump.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-adj-store-dump.c
@@ -1,0 +1,13 @@
+/* { dg-do compile } */
+/* { dg-require-effective-target rv32 } */
+/* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-O3" "-Oz" "-Os" } } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" } */
+
+void
+fuse_adjacent_store (int *p, int x, int y)
+{
+  p[0] = x;
+  p[1] = y;
+}
+
+/* { dg-final { scan-rtl-dump "ARCV_FUSE_ADJACENT_STORE" "sched2" } } */

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-li-branch-dump.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-li-branch-dump.c
@@ -1,0 +1,14 @@
+/* { dg-do compile } */
+/* { dg-require-effective-target rv32 } */
+/* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-O3" "-Oz" "-Os" } } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" } */
+
+int
+fuse_li_branch (int x)
+{
+  while (x <= 3)
+    ;
+  return x;
+}
+
+/* { dg-final { scan-rtl-dump "ARCV_FUSE_LI_BRANCH" "sched2" } } */

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-li-store-dump.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-li-store-dump.c
@@ -1,0 +1,12 @@
+/* { dg-do compile } */
+/* { dg-require-effective-target rv32 } */
+/* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-O3" "-Oz" "-Os" } } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" } */
+
+void
+fuse_li_store (int *p)
+{
+  *p = 42;
+}
+
+/* { dg-final { scan-rtl-dump "ARCV_FUSE_LI_STORE" "sched2" } } */

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-ls-update-dump.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-ls-update-dump.c
@@ -1,0 +1,15 @@
+/* { dg-do compile } */
+/* { dg-require-effective-target rv32 } */
+/* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-O3" "-Oz" "-Os" } } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" } */
+
+int
+fuse_ls_update (int *p, int n)
+{
+  int sum = 0;
+  for (int i = 0; i < n; i++)
+    sum += *p++;
+  return sum;
+}
+
+/* { dg-final { scan-rtl-dump "ARCV_FUSE_LS_UPDATE" "sched2" } } */

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-ls-update-rev-dump.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-ls-update-rev-dump.c
@@ -1,0 +1,16 @@
+/* { dg-do compile } */
+/* { dg-require-effective-target rv32 } */
+/* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-O3" "-Oz" "-Os" } } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" } */
+
+void
+fuse_ls_update_rev (int *p, int n, int val)
+{
+  for (int i = 0; i < n; i++)
+    {
+      p++;
+      *p = val;
+    }
+}
+
+/* { dg-final { scan-rtl-dump "ARCV_FUSE_LS_UPDATE \\(curr, prev\\)" "sched2" } } */

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-memop-lui-dump.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-memop-lui-dump.c
@@ -1,0 +1,17 @@
+/* { dg-do compile } */
+/* { dg-require-effective-target rv32 } */
+/* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-O3" "-Oz" "-Os" } } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" } */
+
+extern int g1, g2;
+
+int
+fuse_memop_lui (int *p, int *q)
+{
+  int a = *p;
+  int b = *q;
+  return a + b + g1 + g2;
+}
+
+/* { dg-final { scan-rtl-dump "ARCV_FUSE_MEMOP_LUI \\(prev, curr\\)" "sched2" } } */
+/* { dg-final { scan-rtl-dump "ARCV_FUSE_MEMOP_LUI \\(curr, prev\\)" "sched2" } } */

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-mult-add-dump.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-mult-add-dump.c
@@ -1,0 +1,21 @@
+/* { dg-do compile } */
+/* { dg-require-effective-target rv32 } */
+/* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-O3" "-Oz" "-Os" } } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" } */
+
+int
+fuse_mult_add_op0 (int a, int b, int c, int d)
+{
+  int m = a * b;
+  return m + c + m + d;
+}
+
+int
+fuse_mult_add_op1 (int a, int b, int c)
+{
+  int m = a * b;
+  return a + m + c + m;
+}
+
+/* { dg-final { scan-rtl-dump "ARCV_FUSE_MULT_ADD \\(op0\\)" "sched2" } } */
+/* { dg-final { scan-rtl-dump "ARCV_FUSE_MULT_ADD \\(op1\\)" "sched2" } } */

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-shift-bitextract-dump.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-shift-bitextract-dump.c
@@ -1,0 +1,15 @@
+/* { dg-do compile } */
+/* { dg-require-effective-target rv32 } */
+/* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-O3" "-Oz" "-Os" } } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" } */
+
+unsigned int
+fusion_shift_bitextract (unsigned int x, unsigned int y, unsigned int z)
+{
+    unsigned int t = x << 8;
+    unsigned int a = y + z;
+    t = t >> 4;
+    return t + a;
+}
+
+/* { dg-final { scan-rtl-dump "ARCV_FUSE_SHIFT_BITEXTRACT" "sched2" } } */


### PR DESCRIPTION
This PR rebases the following downstream patches into fixups to the current fusion trunk cleanup branch.
- 2d1beeba18f9e5a0c254a4d08307691107255e9b
- 4c75c463724bd583e49c54fd1b1531d42edd1051
- 83600fe0bc7e410596a79bfb1fa2effc76f30c82
- 0db4e8b8f26607b18fbb7d9c2abe27d1f83d3990

A RMX-500 test case from 2d1beeba18f9e5a0c254a4d08307691107255e9b is not included in this PR.