### PR TITLE
arcv: simplify arcv_next_fusible_insn

### DIFF
--- a/gcc/config/riscv/arcv.cc
+++ b/gcc/config/riscv/arcv.cc
@@ -87,21 +87,13 @@ arcv_next_fusible_insn (rtx_insn *insn)
       if (insn == 0)
 	break;
 
-      if (!NONDEBUG_INSN_P (insn))
+      if (NOTE_INSN_BASIC_BLOCK_P (insn) || JUMP_TABLE_DATA_P (insn))
+  return NULL;
+
+      if (!NONDEBUG_INSN_P (insn) || GET_CODE (PATTERN (insn)) == USE)
 	continue;
 
-      if (NOTE_INSN_BASIC_BLOCK_P (insn))
-	return NULL;
-
-      if (GET_CODE (insn) == CODE_LABEL
-	  || GET_CODE (insn) == BARRIER
-	  || GET_CODE (PATTERN (insn)) == USE)
-	continue;
-
-      if (JUMP_TABLE_DATA_P (insn))
-	return NULL;
-
-      break;
+  break;
     }
 
   return insn;


### PR DESCRIPTION
The removed checks were impossible to trigger, !NONDEBUG_INSN_P checked that already. The early are moved forward because they were unreachable.