### PR TITLE
fix for P10019563-77915

### DIFF
--- a/gcc/config/arc64/arc64-protos.h
+++ b/gcc/config/arc64/arc64-protos.h
@@ -23,7 +23,7 @@ extern bool arc64_legitimate_store_address_p (machine_mode, rtx);
 extern bool arc64_short_access_p (rtx, machine_mode, bool);
 extern rtx arc64_eh_return_handler_rtx (void);
 extern int arc64_asm_preferred_eh_data_format (int, int);
-
+extern bool arc64_insn_has_symbol_p (rtx_insn *insn);
 extern bool arc64_check_mov_const (HOST_WIDE_INT);
 extern bool arc64_split_mov_const (rtx *);
 extern bool arc64_expand_cpymem (rtx *);
@@ -49,7 +49,7 @@ extern int set_accumulator_p (rtx_insn *, rtx_insn *);
 extern const char *arc64_output_return (void);
 extern bool arc64_hard_regno_rename_ok (unsigned, unsigned);
 extern void arc64_expand_vector_init (rtx, rtx);
-
+extern void arc64_split_move_gpf (rtx *, machine_mode);
 #endif /* RTX_CODE */
 
 #endif /* GCC_ARC64_PROTOS_H */

--- a/gcc/config/arc64/arc64.cc
+++ b/gcc/config/arc64/arc64.cc
@@ -512,7 +512,18 @@ arc64_save_reg_p (int regno)
   return false;
 }
 
-/* Compute the frame info.  */
+/* This function calculates the stack frame before the compiler outputs
+   the prologue and epilogue instructions.
+   It takes care of the stack allocation calculating frame sizes and
+   tracking memory byte offsets for every callee saved register.
+
+   On 32 bit like hs5x running double precision FPU logic without a native
+   64bit wide load/store unit (!TARGET_LL64) tje 64 bit
+   double words (DFmode) cannot be transferred atomically.  They must be split.
+   This function dynamically assigns a separate, individual 32 bit word slot
+   (UNITS_PER_WORD) to both halves of an FPU register pair sequentially.
+   By manually stepping the iterator (regno += 2) we take care that the low
+   half and high half are allocated next to eachother.  */
 
 static void
 arc64_compute_frame_info (void)
@@ -527,23 +538,41 @@ arc64_compute_frame_info (void)
 
   if (!ARC_NAKED_P(cfun->machine->fn_type))
     {
+      /* Initialize the offset tracking array to unallocated (-1) status.  */
+      for (regno = 0; regno < FIRST_PSEUDO_REGISTER; regno++)
+	frame->reg_offset[regno] = -1;
+
       /* Find out which GPR need to be saved.  */
-      for (regno = R0_REGNUM, offset = 0;
-	   regno <= F31_REGNUM;
-	   regno++)
+      /* Move the iterator step inside the loop body to control
+	 64bit FPU pairs dynamically when compiling for hs5x.  */
+      for (regno = R0_REGNUM, offset = 0; regno <= F31_REGNUM;)
 	if (arc64_save_reg_p (regno))
 	  {
-	    /* TBI: probably I need to make the saving of the FP registers
-	       separate bulk from GPIs such that I can use latter on enter/leave
-	       instruction seamlessly (i.e. first save FPregs/latter GPI, the
-	       leave return feature will not work).  */
-	    /* TBI: the FPUS only configuration is having only 32bit registers,
-	       thus I can stack 2 FP registers in one stack slot ;).  */
+	    /* Separate FPU registers when double prec is active and the
+	       hardware lacks native 64 bit load/store support
+	       (!TARGET_LL64). */
+	    if (ARC64_HAS_FP_BASE && FP_REGNUM_P (regno)
+		&& ARC64_HAS_FPUD && !TARGET_LL64)
+	      {
+		frame->reg_offset[regno] = offset;
+		offset += UNITS_PER_WORD;
+
+		frame->reg_offset[regno + 1] = offset;
+		offset += UNITS_PER_WORD;
+
+		regno += 2;
+		continue;
+	      }
+
 	    frame->reg_offset[regno] = offset;
 	    offset += UNITS_PER_WORD;
+	    regno++;
 	  }
 	else
-	  frame->reg_offset[regno] = -1;
+	  {
+	    frame->reg_offset[regno] = -1;
+	    regno++;
+	  }
 
       /* Check if we need to save the return address.  */
       if (!crtl->is_leaf
@@ -610,16 +639,41 @@ frame_stack_add (HOST_WIDE_INT offset)
 					    offset)));
 }
 
-/* Helper for prologue: emit frame store with pre_modify or pre_dec to
-   save register REG on stack.  An initial offset OFFSET can be passed
-   to the function.  If a DISPLACEMENT is defined, it will be used to
-   generate pre_modify instead of pre_dec.  */
-
 static HOST_WIDE_INT
 frame_save_reg (rtx reg, HOST_WIDE_INT offset, HOST_WIDE_INT displacement)
 {
   rtx addr, tmp;
 
+  if (!TARGET_LL64 && REG_P (reg) && FP_REGNUM_P (REGNO (reg)))
+    {
+      machine_mode mode = GET_MODE (reg);
+      HOST_WIDE_INT mode_size = GET_MODE_SIZE (mode);
+
+      HOST_WIDE_INT actual_offset = offset - 
+	      (displacement ? displacement : mode_size);
+
+      rtx flat_addr = plus_constant (Pmode, stack_pointer_rtx, actual_offset);
+      addr = gen_frame_mem (GET_MODE (reg), flat_addr);
+
+      /* stack_pointer_rtx will determined the mode of the add - depending if 
+       * the core is 64/32 bit. */
+      rtx sp_adjust = emit_insn (gen_add3_insn (stack_pointer_rtx,
+                                                stack_pointer_rtx, 
+                                                GEN_INT (actual_offset)));
+      
+      RTX_FRAME_RELATED_P (sp_adjust) = 1;
+      add_reg_note (sp_adjust, REG_CFA_ADJUST_CFA, gen_rtx_SET (
+        stack_pointer_rtx, plus_constant (Pmode,
+                stack_pointer_rtx, actual_offset)));
+
+      tmp = emit_move_insn (addr, reg);
+      RTX_FRAME_RELATED_P (tmp) = 1;
+
+      return (displacement ? displacement : GET_MODE_SIZE (GET_MODE (reg)))
+              - offset;
+    }
+
+  /* Original code for hs6x target registers.  */
   if (offset)
     {
       tmp = plus_constant (Pmode, stack_pointer_rtx,
@@ -659,21 +713,64 @@ arc64_save_callee_saves (void)
   HOST_WIDE_INT frame_allocated = 0;
   rtx reg;
 
-  for (regno = F31_REGNUM; regno >= R0_REGNUM; regno--)
+  for (regno = F31_REGNUM; regno >= R0_REGNUM;)
     {
       HOST_WIDE_INT disp = 0;
       if (frame->reg_offset[regno] == -1
 	  /* Hard frame pointer is saved in a different place.  */
 	  || (frame_pointer_needed && regno == R27_REGNUM)
-	  /* blink register is saved in a different place.  */
 	  || (regno == BLINK_REGNUM))
-	continue;
+	{
+	  regno--;
+	  continue;
+	}
 
       save_mode = word_mode;
       if (ARC64_HAS_FP_BASE && FP_REGNUM_P (regno))
 	{
 	  save_mode = ARC64_HAS_FPUD ? DFmode : SFmode;
 	  disp = UNITS_PER_WORD;
+
+	  if (save_mode == DFmode && !TARGET_LL64)
+	    {
+	      /* Force pass through general purpose registers.
+		 Move FPU data to r12:r13, allocate stack space, and
+		 store via core GPR paths.  */
+	      int even_base = (regno % 2 == 0) ? regno : regno - 1;
+	      rtx sp_reg = stack_pointer_rtx;
+
+	      rtx gpr_lo = gen_rtx_REG (SImode, R12_REGNUM); /* r12.  */
+	      rtx gpr_hi = gen_rtx_REG (SImode, R13_REGNUM); /* r13.  */
+	      rtx fpu_lo = gen_rtx_REG (SImode, even_base);
+	      rtx fpu_hi = gen_rtx_REG (SImode, even_base + 1);
+
+	      emit_move_insn (gpr_lo, fpu_lo);
+	      emit_move_insn (gpr_hi, fpu_hi);
+
+	      rtx insn_sp = emit_insn (gen_addsi3 (sp_reg, sp_reg,
+				      GEN_INT (-8)));
+	      RTX_FRAME_RELATED_P (insn_sp) = 1;
+	      add_reg_note (insn_sp, REG_CFA_ADJUST_CFA, gen_rtx_SET (sp_reg,
+				      plus_constant (SImode, sp_reg, -8)));
+
+	      rtx insn_lo = emit_move_insn (gen_frame_mem
+			      (SImode, sp_reg), gpr_lo);
+	      RTX_FRAME_RELATED_P (insn_lo) = 1;
+
+	      rtx insn_hi = emit_move_insn (gen_frame_mem (SImode,
+			    plus_constant (SImode, sp_reg, 4)), gpr_hi);
+	      RTX_FRAME_RELATED_P (insn_hi) = 1;
+
+	      add_reg_note (insn_lo, REG_CFA_OFFSET, gen_rtx_SET (
+			    gen_frame_mem (SImode, sp_reg), fpu_lo));
+	      add_reg_note (insn_hi, REG_CFA_OFFSET, gen_rtx_SET (
+	      gen_frame_mem (SImode, plus_constant (SImode, sp_reg, 4)),
+	      fpu_hi));
+
+	      frame_allocated += 8;
+	      regno = even_base - 1;
+	      continue;
+	    }
 	}
       else if (regno >= 1
 	       && (((regno - 1) % 2) == 0)
@@ -696,6 +793,7 @@ arc64_save_callee_saves (void)
       reg = gen_rtx_REG (save_mode, regno);
       frame_allocated += frame_save_reg (reg, offset, disp);
       offset = 0;
+      --regno;
     }
 
   /* Save BLINK if required.  */
@@ -723,15 +821,44 @@ arc64_save_callee_saves (void)
   return frame_allocated;
 }
 
-/* Helper for epilogue: emit frame load with post_modify or post_inc
-   to restore register REG from stack.  The initial offset is passed
-   via OFFSET.  */
+/* This function emits the individual movement instructions
+   necessary during the function epilog to restore a single callee saved
+   register from its slot in the stack frame.  It also handles the tracking
+   of stack pointer deallocation.  It returns the number of bytes out off
+   the stack.  */
 
 static HOST_WIDE_INT
 frame_restore_reg (rtx reg, HOST_WIDE_INT displacement)
 {
   rtx addr, insn, tmp;
 
+  /* Try to force flat linear pop sequences for FPU registers.  */
+  if (!TARGET_LL64 && REG_P (reg) && FP_REGNUM_P (REGNO (reg)))
+    {
+      HOST_WIDE_INT actual_disp = displacement ? displacement :
+				  GET_MODE_SIZE (GET_MODE (reg));
+
+      /* Load from the current flat frame stack slice address without
+	 post increment.  */
+      rtx flat_addr = plus_constant (Pmode, stack_pointer_rtx, displacement);
+      addr = gen_frame_mem (GET_MODE (reg), flat_addr);
+
+      insn = emit_move_insn (reg, addr);
+      RTX_FRAME_RELATED_P (insn) = 1;
+      add_reg_note (insn, REG_CFA_RESTORE, reg);
+
+      rtx sp_adjust = emit_insn (gen_addsi3 (stack_pointer_rtx,
+			  stack_pointer_rtx, GEN_INT (actual_disp)));
+      RTX_FRAME_RELATED_P (sp_adjust) = 1;
+      add_reg_note (sp_adjust, REG_CFA_ADJUST_CFA,
+		    gen_rtx_SET (stack_pointer_rtx, plus_constant (Pmode,
+				    stack_pointer_rtx, actual_disp)));
+
+      return actual_disp;
+    }
+
+  /* Original native logic continues untouched for integer and
+     hs6x target registers.  */
   if (displacement)
     {
       tmp = plus_constant (Pmode, stack_pointer_rtx, displacement);
@@ -759,8 +886,6 @@ frame_restore_reg (rtx reg, HOST_WIDE_INT displacement)
 
   return displacement ? displacement : GET_MODE_SIZE (GET_MODE (reg));
 }
-
-/* ARC' epilogue restore regs routine.  */
 
 static HOST_WIDE_INT
 arc64_restore_callee_saves (bool sibcall_p ATTRIBUTE_UNUSED)
@@ -796,7 +921,7 @@ arc64_restore_callee_saves (bool sibcall_p ATTRIBUTE_UNUSED)
       frame_deallocated += frame_restore_reg (reg, 0);
     }
 
-  for (regno = R0_REGNUM; regno <= F31_REGNUM; regno++)
+  for (regno = R0_REGNUM; regno <= F31_REGNUM;)
     {
       HOST_WIDE_INT disp = 0;
       bool double_load_p = false;
@@ -806,13 +931,55 @@ arc64_restore_callee_saves (bool sibcall_p ATTRIBUTE_UNUSED)
 	  || (frame_pointer_needed && regno == R27_REGNUM)
 	  /* blink register has been restored.  */
 	  || (regno == BLINK_REGNUM))
-	continue;
+	{
+	  regno++;
+	  continue;
+	}
 
       restore_mode = word_mode;
       if (ARC64_HAS_FP_BASE && FP_REGNUM_P (regno))
 	{
 	  restore_mode = ARC64_HAS_FPUD ? DFmode : SFmode;
 	  disp = UNITS_PER_WORD;
+
+	  if (restore_mode == DFmode && !TARGET_LL64)
+	    {
+	      int even_base = (regno % 2 == 0) ? regno : regno - 1;
+	      rtx sp_reg = stack_pointer_rtx;
+
+	      rtx gpr_lo = gen_rtx_REG (SImode, R12_REGNUM); /* r12.  */
+	      rtx gpr_hi = gen_rtx_REG (SImode, R13_REGNUM); /* r13.  */
+	      rtx fpu_lo = gen_rtx_REG (SImode, even_base);
+	      rtx fpu_hi = gen_rtx_REG (SImode, even_base + 1);
+
+	      /* extract data back into core pipeline registers first via
+		 standard loads (ld) */
+	      rtx insn_lo = emit_move_insn (gpr_lo,
+			      gen_frame_mem (SImode, sp_reg));
+	      RTX_FRAME_RELATED_P (insn_lo) = 1;
+	      add_reg_note (insn_lo, REG_CFA_RESTORE, fpu_lo);
+
+	      rtx insn_hi = emit_move_insn (gpr_hi, gen_frame_mem (SImode,
+				      plus_constant (SImode, sp_reg, 4)));
+	      RTX_FRAME_RELATED_P (insn_hi) = 1;
+	      add_reg_note (insn_hi, REG_CFA_RESTORE, fpu_hi);
+
+	      /* Move data from GPRs back to the final FPU register halves.  */
+	      emit_move_insn (fpu_lo, gpr_lo);
+	      emit_move_insn (fpu_hi, gpr_hi);
+
+	      /* get stack allocations manually.  */
+	      rtx insn_sp = emit_insn (gen_addsi3 (sp_reg, sp_reg,
+				      GEN_INT (8)));
+	      RTX_FRAME_RELATED_P (insn_sp) = 1;
+	      add_reg_note (insn_sp, REG_CFA_ADJUST_CFA,
+			    gen_rtx_SET (sp_reg, plus_constant (
+					    SImode, sp_reg, 8)));
+
+	      frame_deallocated += 8;
+	      regno = even_base + 2;
+	      continue;
+	    }
 	}
       else if ((regno % 2) == 0
 	       && (!frame_pointer_needed || ((regno + 1) != R27_REGNUM))
@@ -837,7 +1004,9 @@ arc64_restore_callee_saves (bool sibcall_p ATTRIBUTE_UNUSED)
       frame_deallocated += frame_restore_reg (reg, disp);
 
       if (double_load_p)
-	regno++;
+	 regno += 2;
+      else
+	 regno++;
     }
 
   return frame_deallocated;
@@ -1457,6 +1626,82 @@ arc64_function_value_regno_p (const unsigned int regno)
   return false;
 }
 
+/* Helper function to split a 64bit floating point operation 
+ * into two sequential 32bit (SImode) move operations.  */
+void
+arc64_split_move_gpf (rtx *operands, machine_mode mode)
+{
+  rtx dest = operands[0];
+  rtx src = operands[1];
+  rtx hi_dest, hi_src, lo_dest, lo_src;
+
+  if (MEM_P (src))
+    {
+      rtx addr = XEXP (src, 0);
+      if (GET_RTX_CLASS (GET_CODE (addr)) == RTX_AUTOINC)
+        addr = XEXP (addr, 0);
+      rtx clean_mem = change_address (src, SImode, addr);
+      lo_src = adjust_address (clean_mem, SImode, 0);
+      hi_src = adjust_address (clean_mem, SImode, 4);
+    }
+  else if (REG_P (src))
+    {
+      lo_src = gen_rtx_REG (SImode, REGNO (src));
+      hi_src = gen_rtx_REG (SImode, REGNO (src) + 1);
+    }
+  else
+    {
+      lo_src = operand_subword_force (src, 0, mode);
+      hi_src = operand_subword_force (src, 1, mode);
+    }
+
+  if (MEM_P (dest))
+    {
+      rtx addr = XEXP (dest, 0);
+      if (GET_RTX_CLASS (GET_CODE (addr)) == RTX_AUTOINC)
+        addr = XEXP (addr, 0);
+      rtx clean_mem = change_address (dest, SImode, addr);
+      lo_dest = adjust_address (clean_mem, SImode, 0);
+      hi_dest = adjust_address (clean_mem, SImode, 4);
+    }
+  else if (REG_P (dest))
+    {
+      lo_dest = gen_rtx_REG (SImode, REGNO (dest));
+      hi_dest = gen_rtx_REG (SImode, REGNO (dest) + 1);
+    }
+  else
+    {
+      lo_dest = operand_subword_force (dest, 0, mode);
+      hi_dest = operand_subword_force (dest, 1, mode);
+    }
+
+  /* Pre-increment updates.  */
+  if (MEM_P (src) && GET_CODE (XEXP (src, 0)) == PRE_INC)
+    emit_insn (gen_adddi3 (XEXP (XEXP (src, 0), 0), XEXP (XEXP (src, 0), 0), GEN_INT (8)));
+  if (MEM_P (dest) && GET_CODE (XEXP (dest, 0)) == PRE_INC)
+    emit_insn (gen_adddi3 (XEXP (XEXP (dest, 0), 0), XEXP (XEXP (dest, 0), 0), GEN_INT (8)));
+
+  /* Emit moves with overlap protections.  */
+  if (reg_overlap_mentioned_p (lo_dest, hi_src))
+    {
+      emit_move_insn (hi_dest, hi_src);
+      emit_move_insn (lo_dest, lo_src);
+    }
+  else
+    {
+      emit_move_insn (lo_dest, lo_src);
+      emit_move_insn (hi_dest, hi_src);
+    }
+
+  /* Post-increment updates.  */
+  if (MEM_P (src) && GET_CODE (XEXP (src, 0)) == POST_INC)
+    emit_insn (gen_adddi3 (XEXP (XEXP (src, 0), 0), XEXP (XEXP (src, 0), 0), GEN_INT (8)));
+  if (MEM_P (dest) && GET_CODE (XEXP (dest, 0)) == POST_INC)
+    emit_insn (gen_adddi3 (XEXP (XEXP (dest, 0), 0), XEXP (XEXP (dest, 0), 0), GEN_INT (8)));
+
+return;
+}
+
 static bool
 arc64_split_complex_arg (const_tree)
 {
@@ -1506,6 +1751,14 @@ static unsigned int
 arc64_hard_regno_nregs (unsigned int regno,
 			machine_mode mode)
 {
+  if (ARC64_HAS_FP_BASE && FP_REGNUM_P (regno))
+    {
+      if (GET_MODE_SIZE (mode) == 8)
+        return TARGET_LL64 ? 1 : 2;
+      if (GET_MODE_SIZE (mode) == 4)
+	return 1;
+    }
+
   if (FP_REGNUM_P (regno))
     return CEIL (GET_MODE_SIZE (mode), UNITS_PER_FP_REG);
   return CEIL (GET_MODE_SIZE (mode), UNITS_PER_WORD);
@@ -1680,7 +1933,8 @@ arc64_get_effective_mode_for_address_scaling (const machine_mode mode)
 {
   if (GET_MODE_SIZE (mode) == (UNITS_PER_WORD * 2))
     {
-      gcc_assert (DOUBLE_LOAD_STORE);
+      if (!TARGET_LL64)
+	gcc_assert (DOUBLE_LOAD_STORE);
       return Pmode;
     }
   return mode;
@@ -4892,6 +5146,8 @@ arc64_macro_fusion_pair_p (rtx_insn *prev, rtx_insn *curr)
   return false;
 }
 
+
+/*TODO: This function needs to be refactored.  */
 static void
 arc64_override_options (void)
 {
@@ -4916,6 +5172,21 @@ arc64_override_options (void)
 	      target_flags |= MASK_LL64;
 	    }
 	}
+
+	if (strcmp (arcv3_cpu_string, "hs5x") == 0)
+	{
+	  if (!TARGET_LL64)
+	    target_flags &= ~MASK_LL64;
+	}
+        else if (strcmp (arcv3_cpu_string, "hs6x") == 0)
+        {
+          /* if the core is hs6x and -mno-ll64 wasnt specified
+	   * in the command line then enable the 64 bit ls unit.  */
+          if (!(global_options_set.x_target_flags & MASK_LL64)){
+            //target_flags |= MASK_LL64;
+	    return;
+	  }
+        }
     }
 
   if (TARGET_LL64 && TARGET_64BIT)
@@ -5546,9 +5817,17 @@ arc64_expand_prologue (void)
 
   frame_allocated = frame->frame_size;
 
-  frame_allocated -= arc64_save_callee_saves ();
+  /*TODO: In case of a core that doesnt have 
+   * 64 bit ls unit saving a 64 bit takes multiple cycles (add+st+st).
+   * Extra care needs to be done in case an interrupt arrives after the
+   * add and before the last store writes to the wbb.
+   * For this there are solutions like (disabling the intrrupts).
+   * I need to investigate if anything consume the interrupted 
+   * stack frame before the second store executes.  */
 
   /* If something left, allocate.  */
+  frame_allocated -= arc64_save_callee_saves ();
+
   if (frame_allocated > 0)
     frame_stack_add ((HOST_WIDE_INT) 0 - frame_allocated);
 
@@ -6117,7 +6396,7 @@ arc64_split_double_move_p (rtx *operands, machine_mode mode)
       return false;
     }
 
-  /* Evereything else is going for a split.  */
+  /* Everything else is going for a split. */
   return true;
 }
 
@@ -6719,6 +6998,60 @@ arc64_expand_vector_init (rtx target, rtx vals)
     default:
       gcc_unreachable ();
     }
+}
+
+bool
+arc64_insn_has_symbol_p (rtx_insn *insn)
+{
+  if (!insn || !INSN_P (insn))
+    return false;
+
+  if (JUMP_P (insn)
+      || CALL_P (insn)
+      || any_condjump_p (insn)
+      || GET_CODE (PATTERN (insn)) == RETURN
+      || GET_CODE (PATTERN (insn)) == SIMPLE_RETURN)
+    return false;
+
+  rtx pattern_to_scan = PATTERN (insn);
+
+  subrtx_iterator::array_type array;
+  FOR_EACH_SUBRTX (iter, array, pattern_to_scan, ALL)
+    {
+      const_rtx x = *iter;
+      if (x != NULL_RTX)
+	{
+	  if (GET_CODE (x) == SYMBOL_REF)
+	    return true;
+
+	  if (GET_CODE (x) == LABEL_REF)
+	    return true;
+	  if (MEM_P (x))
+	    {
+	      rtx addr = XEXP (x, 0);
+
+	      if (GET_CODE (addr) == SYMBOL_REF || CONST_INT_P (addr))
+		return true;
+
+	      if (GET_CODE (addr) == PLUS)
+		{
+		  rtx offset = XEXP (addr, 1);
+		  rtx base = XEXP (addr, 0);
+
+		  if (CONST_INT_P (offset))
+		    {
+		      HOST_WIDE_INT val = INTVAL (offset);
+		      if (val < -256 || val > 255)
+			return true;
+		    }
+
+		  if (CONST_INT_P (base) || GET_CODE (base) == SYMBOL_REF)
+		    return true;
+		}
+	    }}
+    }
+
+  return false;
 }
 
 /* Target hooks.  */

--- a/gcc/config/arc64/arc64.md
+++ b/gcc/config/arc64/arc64.md
@@ -673,6 +673,8 @@ xorl"
   [(eq_attr "type" "jump,branch,jl,bl,bi,branchcc,dbnz,return,bbit,brcc")
    (const_string "false")
 
+   (match_test "arc64_insn_has_symbol_p (insn)")
+   (const_string "false")
    (eq_attr "length" "2,4")
    (const_string "true")
    ]
@@ -689,18 +691,25 @@ xorl"
     ]
    (const_string "true")))
 
+;; Prevent any instruction from being bundled into a delay slot right after an FPU check
+(define_delay (and (eq_attr "type" "fcmp") (match_test "ARC64_HAS_FP_BASE"))
+  [(nil) (nil) (nil)])
+
 ;; Calls delay slots
 (define_delay (and (eq_attr "type" "jl,bl,return")
 		   (eq_attr "length" "2,4,8"))
-  [(eq_attr "call_slottable" "true") (nil) (nil)])
+  [(and (eq_attr "call_slottable" "true")
+	(not (eq_attr "length" "8,12,16")))
+   (nil) (nil)])
 
 ;; Jumps delay slots
 (define_delay (ior (eq_attr "type" "jump,branch,branchcc,dbnz,bbit")
 ;; Accordingly to PRM jumps with LIMM and delay slots are illegal.
 		   (and (eq_attr "type" "brcc")
 			(eq_attr "length" "4,12")))
-  [(eq_attr "slottable" "true") (nil) (nil)])
-
+  [(and (eq_attr "slottable" "true")
+	(not (eq_attr "length" "8,12,16")))
+   (nil) (nil)])
 ;; Is there an instruction that we are actually putting into the delay
 ;; slot?  N.B. Until after delay slot filler consider full insn size.
 ;; This is required for computing a correct loop body size.
@@ -865,8 +874,10 @@ xorl"
 
 (define_insn "*arc64_movsi"
   [(set
-    (match_operand:SI 0 "arc64_dest_operand"      "=qh,r,    q,    r,    r,h,r,    q,Ustms,Ustor,Ucnst,RBLNKq,r, Ustk<,Ustor")
-    (match_operand:SI 1 "arc64_movl_operand"  "qhS03MV,r,U08S0,S12S0,SyPic,i,i,Uldms,    q,S06S0,    i, Ustk>,m,RBLNKq,    r"))
+    (match_operand:SI 0 "arc64_dest_operand"      "=w,r,w,qh,r,    q,    r,
+                r,h,r,    q,Ustms,Ustor,Ucnst,RBLNKq,r, Ustk<,Ustor,w,m,m")
+    (match_operand:SI 1 "arc64_movl_operand"  "r,w,w,qhS03MV,r,U08S0,S12S0,
+     SyPic,i,i,Uldms,    q,S06S0,    i, Ustk>,m,RBLNKq,    r,m,w,G"))
    ]
   "register_operand (operands[0], SImode)
    || register_operand (operands[1], SImode)
@@ -874,25 +885,194 @@ xorl"
        && memory_operand (operands[0], SImode))
    || (CONST_INT_P (operands[1])
        && satisfies_constraint_Ucnst (operands[0]))"
-   "@
-    mov_s\\t%0,%1
-    mov\\t%0,%1
-    mov_s\\t%0,%1
-    mov\\t%0,%1
-    add\\t%0,pcl,%1
-    mov_s\\t%0,%1
-    mov\\t%0,%1
-    ld_s\\t%0,%1
-    st_s\\t%1,%0
-    st%U0\\t%1,%0
-    st%U0\\t%1,%0
-    pop_s\\t%0
-    ld%U1\\t%0,%1
-    push_s\\t%1
-    st%U0\\t%1,%0"
-   [(set_attr "type" "move,move,move,move,add,move,move,ld,st,st,st,ld,ld,st,st")
-    (set_attr "length" "2,4,2,4,8,6,8,2,2,*,8,2,*,2,*")]
-)
+  {
+    switch (which_alternative)
+      {
+      case 0: return "mov\\t%0,%1";
+      case 1: return "mov\\t%0,%1";
+      case 2: return "mov\\t%0,%1";
+      case 3: return "mov_s\\t%0,%1";
+      case 4: return "mov\\t%0,%1";
+      case 5: return "mov_s\\t%0,%1";
+      case 6: return "mov\\t%0,%1";
+      case 7: return "add\\t%0,pcl,%1";
+      case 8: return "mov_s\\t%0,%1";
+      case 9: return "mov\\t%0,%1";
+      case 10: return "ld_s\\t%0,%1";
+      case 11: return "st_s\\t%1,%0";
+      case 12: return "st%U0\\t%1,%0";
+      case 13: return "st%U0\\t%1,%0";
+      case 14: return "pop_s\\t%0";
+      case 15: return "ld%U1\\t%0,%1";
+      case 16: return "push_s\\t%1";
+      case 17: return "st%U0\\t%1,%0";
+
+      case 18: /* GPR to FPU Cross-Bank Move Target.  */
+	if (!TARGET_LL64 && !RTX_FRAME_RELATED_P (insn))
+	  return "#";
+	return "ld%U1\\t%0,%1";
+
+      case 19: /* FPU to GPR Cross-Bank Move Target.  */
+	if (!TARGET_LL64 && !RTX_FRAME_RELATED_P (insn))
+	  return "#";
+	return "st%U0\\t%1,%0";
+
+      case 20: /* Immediate Zero to Symbolic Memory Store.  */
+	return "st\\t0,%0";
+
+      default: gcc_unreachable ();
+      }
+  }
+  [(set_attr "type" "fmov,fmov,fmov,move,move,move,move,add,move,move,ld,st,
+		     st,st,ld,ld,st,st,ld,st,st")
+   (set_attr "length" "4,4,4,2,4,2,4,8,6,8,2,2,*,8,2,*,2,*,4,4,4")
+   (set (attr "enabled") (const_string "yes"))])
+
+;; under O0 the compiler doesnt run phases that otherwise decide to the the
+;; split
+(define_split
+  [(set (match_operand:DI 0 "nonimmediate_operand" "")
+	(match_operand:DI 1 "general_operand" ""))]
+  "reload_completed && optimize == 0 && !TARGET_LL64 && !TARGET_64BIT"
+  [(const_int 0)]
+  {
+    rtx dest = operands[0];
+    rtx src = operands[1];
+
+    if (REG_P (dest) && MEM_P (src))
+      {
+	int base_regno = REGNO (dest);
+
+	/* Enforce even register boundaries for the implicit
+	   ldd pairing track.  */
+	if (base_regno % 2 == 0)
+	  {
+	    rtx addr = XEXP (src, 0);
+	    rtx clean_mem = change_address (src, SImode, addr);
+
+	    rtx lo_mem = adjust_address (clean_mem, SImode, 0);
+	    rtx hi_mem = adjust_address (clean_mem, SImode, 4);
+
+	    rtx lo_reg = gen_rtx_REG (SImode, base_regno);
+	    rtx hi_reg = gen_rtx_REG (SImode, base_regno + 1);
+
+	    emit_move_insn (lo_reg, lo_mem);
+	    emit_move_insn (hi_reg, hi_mem);
+	    DONE;
+	  }
+      }
+
+    if (MEM_P (dest) && REG_P (src))
+      {
+	int base_regno = REGNO (src);
+
+	if (base_regno % 2 == 0)
+	  {
+	    rtx addr = XEXP (dest, 0);
+	    rtx clean_mem = change_address (dest, SImode, addr);
+
+	    rtx lo_mem = adjust_address (clean_mem, SImode, 0);
+	    rtx hi_mem = adjust_address (clean_mem, SImode, 4);
+
+	    rtx lo_reg = gen_rtx_REG (SImode, base_regno);
+	    rtx hi_reg = gen_rtx_REG (SImode, base_regno + 1);
+
+	    emit_move_insn (lo_mem, lo_reg);
+	    emit_move_insn (hi_mem, hi_reg);
+	    DONE;
+	  }
+      }
+    FAIL;
+  })
+
+;; similar to the splitter from above for O0 i needed to group back
+;; the memory accesses
+(define_peephole2
+  [(set (match_operand:SI 0 "register_operand" "")
+	(match_operand:SI 1 "memory_operand" ""))
+   (set (match_operand:SI 2 "register_operand" "")
+	(match_operand:SI 3 "memory_operand" ""))]
+  "optimize == 0 && !TARGET_LL64
+   && (REGNO (operands[0]) % 2 == 0)
+   && (REGNO (operands[2]) == REGNO (operands[0]) + 1)
+   && rtx_equal_p (XEXP (operands[1], 0), XEXP (operands[3], 0))"
+  [(set (match_dup 0) (match_dup 1))]
+  {
+    /* Convert to DImode to force the native generation of ldd or ldd.as.  */
+    PUT_MODE (operands[0], DImode);
+    PUT_MODE (operands[1], DImode);
+  })
+
+(define_peephole2
+  [(set (match_operand:SI 0 "memory_operand" "")
+	(match_operand:SI 1 "register_operand" ""))
+   (set (match_operand:SI 2 "memory_operand" "")
+	(match_operand:SI 3 "register_operand" ""))]
+  "optimize == 0 && !TARGET_LL64
+   && (REGNO (operands[1]) % 2 == 0)
+   && (REGNO (operands[3]) == REGNO (operands[1]) + 1)
+   && rtx_equal_p (XEXP (operands[0], 0), XEXP (operands[2], 0))"
+  [(set (match_dup 0) (match_dup 1))]
+  {
+    PUT_MODE (operands[0], DImode);
+    PUT_MODE (operands[1], DImode);
+  })
+
+(define_insn "*subsi3_insn"
+  [(set (match_operand:SI 0 "register_operand" "=r,r,r,r")
+	(minus:SI (match_operand:SI 1 "register_operand"  "0,r,0,r")
+		  (match_operand:SI 2 "nonmemory_operand" "r,r,i,i")))]
+  ""
+  {
+    switch (which_alternative)
+      {
+      case 0:
+      case 2: return "sub\\t%0,%0,%2";
+      case 1:
+      case 3: return "sub\\t%0,%1,%2";
+      default: gcc_unreachable ();
+      }
+  }
+  [(set_attr "type" "move")
+   (set_attr "length" "4,4,4,4")])
+
+(define_split
+  [(set (match_operand:SI 0 "nonimmediate_operand" "")
+	(match_operand:SI 1 "general_operand" ""))]
+  "reload_completed && (!TARGET_64BIT && !TARGET_LL64) && !RTX_FRAME_RELATED_P (insn)"
+  [(const_int 0)]
+  {
+    /* check macro ranges explicitly if FP_REGNUM_P
+       is narrow.  */
+    int r0 = REGNO (operands[0]);
+    int r1 = REGNO (operands[1]);
+
+    bool dest_is_fp = (REG_P (operands[0]) && r0 >= F0_REGNUM
+			&& r0 <= F31_REGNUM);
+    bool src_is_fp  = (REG_P (operands[1]) && r1 >= F0_REGNUM
+			&& r1 <= F31_REGNUM);
+
+    /* If this wasnt actually an FPU-memory trade do not split.
+       More testing has to be done here.  */
+    if (!((dest_is_fp && MEM_P (operands[1])) || (MEM_P (operands[0])
+	&& src_is_fp)))
+      FAIL;
+
+    rtx scratch = gen_rtx_REG (SImode, 2);
+    if (MEM_P (operands[1]))
+      {
+	/* Memory to FPU via general purpose.  */
+	emit_move_insn (scratch, operands[1]);
+	emit_move_insn (operands[0], scratch);
+      }
+    else
+      {
+	/* FPU to Memory via general purpose.  */
+	emit_move_insn (scratch, operands[1]);
+	emit_move_insn (operands[0], scratch);
+      }
+    DONE;
+  })
 
 (define_insn "*mov<mode>_cmp0"
   [(set (reg:CC_ZN CC_REGNUM)
@@ -906,8 +1086,9 @@ xorl"
 
 ;; Softcore float move.
 (define_insn "*movsf_softfp"
-   [(set (match_operand:SF 0 "arc64_dest_operand" "=qh,r,qh,r,    q,Ustms,r,Ustor")
-	 (match_operand:SF 1 "general_operand"    "qhZ,r, E,E,Uldms,    q,m,r"))
+   [(set (match_operand:SF 0 "arc64_dest_operand" "=qh,r,qh,r,    q,
+						   Ustms,r,Ustor")
+	 (match_operand:SF 1 "general_operand"    "qhZ,r, E,E,Uldms,q,m,r"))
    ]
    "!ARC64_HAS_FP_BASE
    && (register_operand (operands[0], SFmode)
@@ -924,27 +1105,146 @@ xorl"
    [(set_attr "type" "move,move,move,move,ld,st,ld,st")
     (set_attr "length" "2,4,6,8,2,2,*,*")])
 
-;; For a fp move I use FSMOV.<cc> instruction. However, we can also
-;; use FSSGNJ.
-;; FIXME! add short instruction selection
+
+;; This split catches 64b double loads early before the register allocator runs.
+;; We convert a single SET into a parallel block with two clobbers using "=&r".
+;; This forces the register allocator to find and reserve 2 GPR registers.
+;; Observe that main move pattern (*mov<mode>_hardfp - see next next pattern)
+;; stays completely clean and without clobbers for the early virtual register passes.
+(define_split
+  [(set (match_operand:GPF_HF 0 "register_operand" "")
+        (match_operand:GPF_HF 1 "memory_operand" ""))]
+  "!reload_completed
+   && GET_MODE_SIZE (<MODE>mode) == 8
+   && !TARGET_LL64 && !TARGET_64BIT"
+  [(parallel [(set (match_dup 0) (match_dup 1))
+              (clobber (match_scratch:SI 2 "=&r"))
+              (clobber (match_scratch:SI 3 "=&r"))])]
+  ""
+)
+
+;; This pattern is a bridge to match the expression from the pre-reload split above.
+;; Without this the recognizer (recog) pass will crash with "unrecognizable insn"
+;; because GCC needs to find a matching instruction for every parallel block.
+;; "=&r" forces the allocator to pick free GP registers.
+;; The "=w" makes sure the target is an FPU register.
+;; We return "#" to skip normal assembly printing and send this
+;; straight to the final post-reload splitter.
+(define_insn "*mov<mode>_hardfp_split_helper"
+  [(set (match_operand:GPF_HF 0 "register_operand" "=w")
+        (match_operand:GPF_HF 1 "memory_operand"    "m"))
+   (clobber (match_scratch:SI 2 "=&r"))
+   (clobber (match_scratch:SI 3 "=&r"))]
+  "ARC64_HAS_FP_BASE && GET_MODE_SIZE (<MODE>mode) == 8 && !TARGET_LL64 && !TARGET_64BIT"
+  "#"  ;; Force hand-off directly to the post-reload data move splitter
+  [(set_attr "type" "ld")
+   (set_attr "length" "8")])
+
+
+;; This split runs after the register allocator finishes (see reload_completed).
+;; It matches the parallel block from before and uses the 
+;; two GPR scratch registers (gpr_lo and gpr_hi) that the allocator generated.
+;; Because the 32bit core cannot load memory directly into FPU registers directly,
+;; we break the 64 bit double into two 32bit steps: first we load from memory 
+;; into the GPR registers, and then we move them from GP registers into the 
+;; FPU registers.
+(define_split
+  [(set (match_operand:GPF_HF 0 "register_operand" "")
+        (match_operand:GPF_HF 1 "memory_operand" ""))
+   (clobber (match_operand:SI 2 "register_operand" ""))
+   (clobber (match_operand:SI 3 "register_operand" ""))]
+  "reload_completed
+   && GET_MODE_SIZE (<MODE>mode) == 8
+   && !TARGET_LL64 && !TARGET_64BIT"
+  [(const_int 0)]
+  {
+    rtx dest = operands[0];
+    rtx src = operands[1];
+    rtx gpr_lo = operands[2];
+    rtx gpr_hi = operands[3];
+
+    rtx addr = XEXP (src, 0);
+    if (GET_RTX_CLASS (GET_CODE (addr)) == RTX_AUTOINC)
+      addr = XEXP (addr, 0);
+
+    rtx clean_mem = change_address (src, SImode, addr);
+    rtx mem_lo = adjust_address (clean_mem, SImode, 0);
+    rtx mem_hi = adjust_address (clean_mem, SImode, 4);
+
+    rtx fpu_lo = gen_rtx_REG (SImode, REGNO (dest));
+    rtx fpu_hi = gen_rtx_REG (SImode, REGNO (dest) + 1);
+
+    start_sequence ();
+    emit_move_insn (gpr_lo, mem_lo);
+    emit_move_insn (gpr_hi, mem_hi);
+    emit_move_insn (fpu_lo, gpr_lo);
+    emit_move_insn (fpu_hi, gpr_hi);
+    rtx_insn *seq = get_insns ();
+    end_sequence ();
+    emit_insn (seq);
+    DONE;
+  })
+
+;; This splitter matches clean (set) instructions with NO clobbers.
+;; It executes fallback data splitting and overlap tracking natively.
+(define_split
+  [(set (match_operand:GPF_HF 0 "nonimmediate_operand" "")
+        (match_operand:GPF_HF 1 "general_operand" ""))]
+  "reload_completed
+   && GET_MODE_SIZE (<MODE>mode) == 8
+   && !TARGET_LL64 && !TARGET_64BIT"
+  [(const_int 0)]
+  {
+    arc64_split_move_gpf (operands, <MODE>mode); 
+    DONE;
+  })
+
+;; Split pattern needed to solve a hardware limitation on
+;; the 32bit hs5x core lacking 64bit ls unit
 (define_insn "*mov<mode>_hardfp"
   [(set (match_operand:GPF_HF 0 "arc64_dest_operand" "=w,    w,Ufpms,*r,*w,*r,*r,*r,*Ustor")
 	(match_operand:GPF_HF 1 "arc64_movf_operand"  "w,Ufpms,    w,*w,*r,*r,*G,*m,    *r"))]
   "ARC64_HAS_FP_BASE
    && (register_operand (operands[0], <MODE>mode)
        || register_operand (operands[1], <MODE>mode))"
-  "@
-   f<sfxtab>mov\\t%0,%1
-   fld<sizef>%U1\\t%0,%1
-   fst<sizef>%U0\\t%1,%0
-   fmv<fmvftab>2<fmvitab>\\t%0,%1
-   fmv<fmvitab>2<fmvftab>\\t%0,%1
-   mov<mcctab>\\t%0,%1
-   mov<mcctab>\\t%0,%1
-   ld<slfp>%U1\\t%0,%1
-   st<slfp>%U0\\t%1,%0"
+  {
+    switch (which_alternative)
+      {
+      case 0:
+        return "f<sfxtab>mov\\t%0,%1";
+      case 1:
+        return "fld<sizef>%U1\\t%0,%1";
+      case 2:
+        return "fst<sizef>%U0\\t%1,%0";
+      case 3: /* GPR to FPU Move (*w, *r).  */
+      case 4: /* FPU to GPR Move (*r, *w).  */
+        /* if this is a 64 bit double precision mode on a 32bit pipeline hs5x
+           we must return # to trigger the splitter.  This forces the register
+           allocator to treat the GPR operand as a true 64bit aligned
+           register pair.  */
+        if (GET_MODE_SIZE (<MODE>mode) == 8 && !TARGET_LL64 && !TARGET_64BIT)
+          return "#";
+        return (which_alternative == 3)
+          ?"fmv<fmvftab>2<fmvitab>\\t%0,%1" :
+          "fmv<fmvitab>2<fmvftab>\\t%0,%1";
+
+      case 5:
+        return "mov<mcctab>\\t%0,%1";
+      case 6:
+        return "mov<mcctab>\\t%0,%1";
+      case 7:
+      case 8:
+        if (GET_MODE_SIZE (<MODE>mode) == 8 && !TARGET_LL64 && !TARGET_64BIT)
+          return "#";
+        return (which_alternative == 7)
+          ?"ld<slfp>%U1\\t%0,%1" :
+          "st<slfp>%U0\\t%1,%0";
+      default: gcc_unreachable ();
+      }
+  }
   [(set_attr "type" "fmov,ld,st,move,move,move,move,ld,st")
-   (set_attr "length" "4,*,*,4,4,4,8,*,*")])
+   (set_attr "length" "4,*,*,4,4,4,8,*,*")
+   (set (attr "enabled") (const_string "yes"))])
 
 ;; move 128bit
 (define_insn_and_split "*mov<mode>_insn"
@@ -960,6 +1260,7 @@ xorl"
    pushdl_s\\t%1
    stdl%U0\\t%1,%0"
    "&& reload_completed
+    && TARGET_64BIT
     && arc64_split_double_move_p (operands, <MODE>mode)"
    [(const_int 0)]
    {
@@ -968,33 +1269,188 @@ xorl"
    }
   [(set_attr "type" "move,ld,ld,st,st")
    (set_attr "length" "8,2,*,2,*")])
+
+;; stack pop with autoincrement splitter
+(define_split
+  [(set (match_operand:GPF_HF 0 "nonimmediate_operand" "")
+	(mem:GPF_HF (match_operand:SI 1 "address_operand" "")))]
+  "reload_completed
+   && GET_MODE_SIZE (<MODE>mode) == 8
+   && !TARGET_LL64 && !TARGET_64BIT"
+  [(const_int 0)]
+  {
+    rtx dest = operands[0];
+    rtx addr = operands[1];
+    rtx sp_reg = stack_pointer_rtx;
+    HOST_WIDE_INT offset_val = 8;
+
+    if (GET_RTX_CLASS (GET_CODE (addr)) == RTX_AUTOINC)
+      {
+	enum rtx_code code = GET_CODE (addr);
+	sp_reg = XEXP (addr, 0);
+
+	if (code == POST_MODIFY || code == PRE_MODIFY)
+	  offset_val = INTVAL (XEXP (XEXP (addr, 1), 1));
+	else if (code == PRE_DEC)
+	  offset_val = -8;
+
+	if (code == PRE_MODIFY || code == PRE_DEC)
+	  emit_insn (gen_addsi3 (sp_reg, sp_reg, GEN_INT (offset_val)));
+      }
+    else
+	sp_reg = addr;
+
+    rtx lo_reg = simplify_gen_subreg (SImode, dest, <MODE>mode, 0);
+    rtx hi_reg = simplify_gen_subreg (SImode, dest, <MODE>mode, 4);
+
+    emit_move_insn (lo_reg, gen_frame_mem (SImode, sp_reg));
+    emit_move_insn (hi_reg, gen_frame_mem (SImode, plus_constant (SImode,
+	sp_reg,
+	4)));
+
+    if (GET_RTX_CLASS (GET_CODE (addr)) == RTX_AUTOINC)
+      {
+	enum rtx_code code = GET_CODE (addr);
+	if (code == POST_MODIFY || code == POST_INC)
+	  emit_insn (gen_addsi3 (sp_reg, sp_reg, GEN_INT (offset_val)));
+      }
+    DONE;
+  })
+
+;; push
+(define_split
+  [(set (mem:GPF_HF (match_operand:SI 1 "address_operand" ""))
+	(match_operand:GPF_HF 0 "register_operand" ""))]
+  "reload_completed
+   && GET_MODE_SIZE (<MODE>mode) == 8
+   && !TARGET_LL64 && !TARGET_64BIT"
+  [(const_int 0)]
+  {
+    rtx src = operands[0];
+    rtx addr = operands[1];
+    rtx sp_reg = stack_pointer_rtx;
+    HOST_WIDE_INT offset_val = -8;
+
+    if (GET_RTX_CLASS (GET_CODE (addr)) == RTX_AUTOINC)
+      {
+	enum rtx_code code = GET_CODE (addr);
+	sp_reg = XEXP (addr, 0);
+
+	if (code == POST_MODIFY || code == PRE_MODIFY)
+	  offset_val = INTVAL (XEXP (XEXP (addr, 1), 1));
+	else if (code == POST_INC)
+	  offset_val = 8;
+
+	if (code == PRE_MODIFY || code == PRE_DEC)
+	  emit_insn (gen_addsi3 (sp_reg, sp_reg, GEN_INT (offset_val)));
+      }
+    else
+      {
+	sp_reg = addr;
+      }
+
+    rtx lo_reg = simplify_gen_subreg (SImode, src, <MODE>mode, 0);
+    rtx hi_reg = simplify_gen_subreg (SImode, src, <MODE>mode, 4);
+
+    emit_move_insn (gen_frame_mem (SImode, sp_reg), lo_reg);
+    emit_move_insn (gen_frame_mem (SImode, plus_constant (SImode, sp_reg,
+	4)),
+	hi_reg);
+
+    if (GET_RTX_CLASS (GET_CODE (addr)) == RTX_AUTOINC)
+      {
+	enum rtx_code code = GET_CODE (addr);
+	if (code == POST_MODIFY || code == POST_INC)
+	  emit_insn (gen_addsi3 (sp_reg, sp_reg, GEN_INT (offset_val)));
+      }
+    DONE;
+  })
+
 ;;
 ;; Short insns: movl_s g,h; movl_s b,u8
 ;; Long insns: movl, stl, ldl
 ;;
 (define_insn "*arc64_movdi"
-   [(set (match_operand:DI 0 "arc64_dest_operand" "=qh,    q,    r,    r,r,    r,         r,    r,    r,Ucnst,    r,r,Ustk<,Ustor")
-	 (match_operand:DI 1 "arc64_movl_operand"  "qh,U08S0,BCLRX,BSETX,r,S12S0,S32S0SymMV,U38S0,SyPic,S32S0,Ustk>,m,    r, r"))]
-   "TARGET_64BIT
+  [(set (match_operand:DI 0 "arc64_dest_operand" "=qh,    q,    r,    r,r,r,r,r,r,Ucnst,r,r,Ustk<,Ustor")
+	 (match_operand:DI 1 "arc64_movl_operand"  
+"qh,U08S0,BCLRX,BSETX,r,S12S0,S32S0SymMV,U38S0,SyPic,S32S0,Ustk>,m,    r, r"))]
+   ;; this entire block was originally made only for TARGET_64BIT.
+   ;; That caused the 32bit hs5x compiler to completely drop DImode requests
+   ;; under -O0, falling back to standalone scalar operations
+   ;; Now I allow for hs5x that supports double precision.
+   "(TARGET_64BIT || (!TARGET_64BIT && TARGET_LL64))
     && (register_operand (operands[0], DImode)
-        || register_operand (operands[1], DImode)
-        || (CONST_INT_P (operands[1])
-            && satisfies_constraint_Ucnst (operands[0])))"
-   "@
-    movl_s\\t%0,%1
-    movl_s\\t%0,%1
-    bclrl\\t%0,%q1,%t1
-    bsetl\\t%0,%L1,%T1
-    movl\\t%0,%1
-    movl\\t%0,%1
-    movl\\t%0,%1
-    vpack2wl\\t%0,%L1,%H1
-    addl\\t%0,pcl,%1
-    stl%U0\\t%1,%0
-    popl_s\\t%0
-    ldl%U1\\t%0,%1
-    pushl_s\\t%1
-    stl%U0\\t%1,%0"
+	|| register_operand (operands[1], DImode)
+	|| (CONST_INT_P (operands[1])
+	    && satisfies_constraint_Ucnst (operands[0])))"
+   {
+     static char buf[128];
+     switch (which_alternative)
+       {
+       case 0: return "movl_s\\t%0,%1";
+       case 1: return "movl_s\\t%0,%1";
+       case 2: return "bclrl\\t%0,%q1,%t1";
+       case 3: return "bsetl\\t%0,%L1,%T1";
+       case 4: return "movl\\t%0,%1";
+       case 5: return "movl\\t%0,%1";
+       case 6: return "movl\\t%0,%1";
+       case 7: return "vpack2wl\\t%0,%L1,%H1";
+       case 8: return "addl\\t%0,pcl,%1";
+
+       case 9:  /* Immediate constant store alternative.  */
+         return "stl%U0\\t%1,%0";
+
+       /* - Memory Store Alternative (Ustor, r)
+	  If we are on a 32-bit machine core native 64-bit store instructions
+	  do not exist so there is need to extract the base and
+	  calculate offset. Same happens at case 10 and 11.  */
+       case 13: /* Memory Store Alternative (Ustor, r).  */
+	  if (!TARGET_64BIT)
+	   {
+	     rtx addr = XEXP (operands[0], 0);
+	     if (GET_CODE (addr) == PLUS && CONST_INT_P (XEXP (addr, 1)))
+	       {
+		 HOST_WIDE_INT offset = INTVAL (XEXP (addr, 1));
+		 const char *src_name = reg_names[REGNO (operands[1])];
+		 const char *base_name = reg_names[REGNO (XEXP (addr, 0))];
+		 if (offset > 0 && (offset % 4 == 0))
+		   {
+		     sprintf (buf, "std.as\t%s,[%s,%ld]", src_name,
+						     base_name, offset/4);
+		     return buf;
+		   }
+	       }
+	     return "std\\t%1,%0";
+	   }
+	 /* Fallback for zero offset stores.  */
+	 return "stl%U0\\t%1,%0";
+
+       case 10: return "popl_s\\t%0";
+
+       case 11: /* - Memory Load Alternative (r, m).  */
+	  if (!TARGET_64BIT)
+	   {
+	     rtx addr = XEXP (operands[1], 0);
+	     if (GET_CODE (addr) == PLUS && CONST_INT_P (XEXP (addr, 1)))
+	       {
+		 HOST_WIDE_INT offset = INTVAL (XEXP (addr, 1));
+		 const char *dest =reg_names[REGNO (operands[0])];
+		 const char *base= reg_names[REGNO (XEXP (addr, 0))];
+		 if (offset > 0 && (offset % 4 == 0))
+		   {
+		     sprintf (buf, "ldd.as\t%s,[%s,%ld]", dest, base,offset/4);
+		     return buf;
+		   }
+	       }
+	     return "ldd\\t%0,%1";
+	   }
+	 /* Fallback for zero offset loads.  */
+	 return "ldl%U1\\t%0,%1";
+
+       case 12: return "pushl_s\\t%1";
+       default: gcc_unreachable ();
+       }
+   }
    [(set_attr "type" "move,move,bclr,bset,move,move,move,vpack,addl,st,ld,ld,st,st")
     (set_attr "length" "2,2,8,8,4,4,8,8,8,8,2,*,2,*")]
 )

--- a/gcc/config/arc64/arith.md
+++ b/gcc/config/arc64/arith.md
@@ -2481,6 +2481,7 @@
    #
    #"
   "&& reload_completed
+   && TARGET_64BIT
    && arc64_split_double_move_p (operands, <MODE>mode)"
   [(const_int 0)]
   {

--- a/gcc/testsuite/gcc.target/arc64/frame_save_reg.cc
+++ b/gcc/testsuite/gcc.target/arc64/frame_save_reg.cc
@@ -1,0 +1,66 @@
+/* { dg-do run } */
+/* { dg-options "-O1 -mcpu=hs5x -mfpu=fpud" } */
+
+#include <stdlib.h>
+
+volatile double qwerty= 1.0;
+
+volatile double input_pool[12] = {
+  1,2,3,4,5,6,7,8,9,10,11,12
+};
+
+__attribute__((noinline))
+void func2 (void)
+{
+  qwerty = 2.0;
+}
+
+__attribute__((noinline))
+double func1 (double r1, double r2, double r3, 
+	      double r4, double r5, double r6, 
+	      double r7, double r8, double r9, 
+	      double r10, double r11, double r12)
+{
+  double out1 = (r1 * 2.0) + (r2 * 1.0);
+  double out2 = (r3 * 2.0) + (r4 * 1.0);
+  double out3 = (r5 * 2.0) + (r6 * 1.0);
+  double out4 = (r7 * 2.0) + (r8 * 1.0);
+  double out5 = (r9 * 2.0) + (r10 * 1.0);
+  double out6 = (r11 * 2.0) + (r12 * 1.0);
+  double out7 = out1 + out2 + out3;
+  double out8 = out4 + out5 + out6;
+  double out9 = out7 + out8;
+
+  func2 ();
+
+  return out1 + out2 + out3 + out4 + out5 + 
+	 out6 + out7 + out8 + out9;
+}
+
+int main (void)
+{
+  double val1  = input_pool[0];
+  double val2  = input_pool[1];
+  double val3  = input_pool[2];
+  double val4  = input_pool[3];
+  double val5  = input_pool[4];
+  double val6  = input_pool[5];
+  double val7  = input_pool[6];
+  double val8  = input_pool[7];
+  double val9  = input_pool[8];
+  double val10 = input_pool[9];
+  double val11 = input_pool[11]; /*is ok the order changed*/
+  double val12 = input_pool[10];
+
+  double runtime_result = func1 (val1, val2,
+		  val3, val4, val5, val6, 
+                  val7, val8, val9, val10,  
+		  val11, val12);
+
+  if (runtime_result == 1042.0)
+    {
+      return 0;
+    }
+
+  return 1;
+}

--- a/gcc/testsuite/gcc.target/arc64/pr10019563-77915.c
+++ b/gcc/testsuite/gcc.target/arc64/pr10019563-77915.c
@@ -1,0 +1,19 @@
+/* { dg-do run } */
+/* { dg-options "-O3" } */
+
+#include <stdlib.h>
+
+int test0(){
+    float a, b;
+    double c, d;    
+    a = (float)rand()/(float)(RAND_MAX);
+    b = (float)rand()/(float)(RAND_MAX);    
+    c = (double)rand()/(double)(RAND_MAX);
+    d = (double)rand()/(double)(RAND_MAX);    
+    return (int)((double)a + (double)b + c + d);
+}
+
+int main() {
+    int result = test0();
+    return 0;
+}

--- a/gcc/testsuite/gcc.target/arc64/pr10019563-77915_align.c
+++ b/gcc/testsuite/gcc.target/arc64/pr10019563-77915_align.c
@@ -1,0 +1,35 @@
+/* { dg-do compile } */
+/* { dg-options "-O2 -mcpu=hs5x -mll64 -mno-fpmov" } */
+/* { dg-require-effective-target hs5x } */
+
+/* Force a 64 bit aligned double precision data array structure buffer.
+   This guarantees that the base address is a clean multiple of 8 enabling
+   ldd/std operations. */
+double src_array[4] __attribute__((aligned(8))) = {1.0, 2.0, 3.0, 4.0};
+double dest_array[4] __attribute__((aligned(8))) = {0.0, 0.0, 0.0, 0.0};
+
+void test_scaling_block (void)
+{
+  /* Loading a base pointer pointer register and indexing sequentially 
+     forces the backend to generate scaled addressing modes. */
+  dest_array[0] = src_array[0]; /* Triggers flat ldd and std */
+  dest_array[1] = src_array[1]; /* Triggers ldd.as and std.as with offset 2 */
+  dest_array[2] = src_array[2]; /* Triggers ldd.as and std.as with offset 4 */
+  dest_array[3] = src_array[3]; /* Triggers ldd.as and std.as with offset 6 */
+}
+
+/* { dg-final { scan-assembler "ldd\\s+r.,\\\[r.\\\]" { target arc64*-*-* } } }   */
+/* { dg-final { scan-assembler "std\\s+r.,\\\[r.\\\]" { target arc64*-*-* } } }  */
+
+/* Verify that the address scaling suffix is cleanly appended with 
+   the correct 2-byte instruction multiplier offsets (2, 4, and 6) */
+/* { dg-final { scan-assembler "ldd.as\\s+r.,\\\[r.,2\\\]" { target arc64*-*-* } } }  */
+/* { dg-final { scan-assembler "std.as\\s+r.,\\\[r.,2\\\]" { target arc64*-*-* } } } */
+/* { dg-final { scan-assembler "ldd.as\\s+r.,\\\[r.,4\\\]" { target arc64*-*-* } } }  */
+/* { dg-final { scan-assembler "std.as\\s+r.,\\\[r.,4\\\]" { target arc64*-*-* } } }  */
+/* { dg-final { scan-assembler "ldd.as\\s+r.,\\\[r.,6\\\]" { target arc64*-*-* } } }  */
+/* { dg-final { scan-assembler "std.as\\s+r.,\\\[r.,6\\\]" { target arc64*-*-* } } } */
+
+/* Checkl for un-merged 32bit scalar loads or stores that are still there */
+/* { dg-final { scan-assembler-not "ld_s" { target arc64*-*-* } } } */
+/* { dg-final { scan-assembler-not "st_s" { target arc64*-*-* } } } */

--- a/gcc/testsuite/gcc.target/arc64/pr10019563-77915_b.c
+++ b/gcc/testsuite/gcc.target/arc64/pr10019563-77915_b.c
@@ -1,0 +1,19 @@
+/* { dg-do run } */
+/* { dg-options "-O2 -mcpu=hs5x -mfpu=fpud -mll64" } */
+/* { dg-require-effective-target hs5x } */
+
+#include <stdlib.h>
+volatile double a __attribute__((aligned(8))) = 1.2345678901234567;   
+volatile double b __attribute__((aligned(8))) = 0.1234567890123456;   
+volatile double exp_add __attribute__((aligned(8))) = 1.3580246791358023; 
+volatile double exp_sub __attribute__((aligned(8))) = 1.1111111011111111; 
+
+int main() {
+    double res_add = a + b;
+    double res_sub = a - b;
+
+    if (res_add != exp_add || res_sub != exp_sub)
+        abort();
+
+    return 0; 
+}

--- a/gcc/testsuite/gcc.target/arc64/pr10019563-77915_c.c
+++ b/gcc/testsuite/gcc.target/arc64/pr10019563-77915_c.c
@@ -1,0 +1,19 @@
+/* { dg-do run } */
+/* { dg-options "-O2 -mcpu=hs5x -mfpu=fpud" } */
+/* { dg-require-effective-target hs5x } */
+
+#include <stdlib.h>
+volatile double a __attribute__((aligned(8))) = 1.2345678901234567;   
+volatile double b __attribute__((aligned(8))) = 0.1234567890123456;   
+volatile double exp_add __attribute__((aligned(8))) = 1.3580246791358023; 
+volatile double exp_sub __attribute__((aligned(8))) = 1.1111111011111111; 
+
+int main() {
+    double res_add = a + b;
+    double res_sub = a - b;
+
+    if (res_add != exp_add || res_sub != exp_sub)
+        abort();
+
+    return 0; 
+}

--- a/gcc/testsuite/gcc.target/arc64/pr10019563-77915_m.c
+++ b/gcc/testsuite/gcc.target/arc64/pr10019563-77915_m.c
@@ -1,0 +1,17 @@
+/* { dg-do run } */
+/* { dg-options "-O2 -mcpu=hs5x -mfpu=fpud" } */
+/* { dg-require-effective-target hs5x } */
+
+/* Standard success is return 0 */
+
+/* Force 64 bit address alignment */
+volatile double a = 10.0;
+volatile double b = 5.0;
+
+int main() {
+    double res = a - b;
+    if (res == 5.0)
+        return 0;
+    return 1;
+}
+


### PR DESCRIPTION
fix to ensure the that the hs5x target produces correct code despite lacking 64-bit load/store instructions.
I made use of the split mechanism enabled by the # keyword which forces the compiler to look for a define_split. Then the split pattern that takes a single 64bit memory move and breaks it into two 32-bit moves using gen_lowpart and gen_highpart.
I then tried to run dejagnu and found failures that were not due to my patch.