### PR TITLE
arcv: check_effective_target_arcv_* for other default ABI's

### DIFF
--- a/gcc/testsuite/lib/target-supports.exp
+++ b/gcc/testsuite/lib/target-supports.exp
@@ -14137,12 +14137,13 @@ proc check_effective_target_arcv_udsp { } {
     if { !([istarget riscv32-*-*]) } {
          return 0
      }
+    set gcc_march [riscv_get_arch]
     return [check_no_compiler_messages arcv_udsp object {
         void foo (void)
         {
           asm ("arcv.xvadd.vv x0, x0, x0, e16, m1");
         }
-    } "-march=rv32i_xarcvudsp" ]
+    } "-march=${gcc_march}_xarcvudsp" ]
 }
 
 
@@ -14152,96 +14153,104 @@ proc check_effective_target_arcv_bitrev { } {
     if { !([istarget riscv*-*-*]) } {
         return 0
     }
+    set gcc_march [riscv_get_arch]
     return [check_no_compiler_messages arcv_bitrev object {
         void foo (void)
           {
             asm ("arcv.bitrev x0, x0, x0");
           }
-  } "-march=rv32im_xarcvbitrev" ]
+  } "-march=${gcc_march}_xarcvbitrev" ]
 }
 # Return 1 if the ARC-V BITSTREAM extension is available.
 proc check_effective_target_arcv_bitstream { } {
     if { !([istarget riscv*-*-*]) } {
         return 0
     }
+    set gcc_march [riscv_get_arch]
     return [check_no_compiler_messages arcv_bitstream object {
         void foo (void)
           {
             asm ("arcv.bspeek x0, x0");
           }
-  } "-march=rv32im_xarcvbitstream" ]
+  } "-march=${gcc_march}_xarcvbitstream" ]
 }
 # Return 1 if the ARC-V VDSP extension is available.
 proc check_effective_target_arcv_vdsp { } {
     if { !([istarget riscv*-*-*]) } {
         return 0
     }
+    set gcc_march [regsub {[[:alnum:]]*} [riscv_get_arch] &v]
     return [check_no_compiler_messages arcv_vdsp object {
         void foo (void)
           {
             asm ("arcv.vmv.v.sx v0, v0, x0");
           }
-  } "-march=rv32im_xarcvvdsp" ]
+  } "-march=${gcc_march}_xarcvvdsp" ]
 }
 # Return 1 if the ARC-V VCPLX extension is available.
 proc check_effective_target_arcv_vcplx { } {
     if { !([istarget riscv*-*-*]) } {
         return 0
     }
+    set gcc_march [regsub {[[:alnum:]]*} [riscv_get_arch] &v]
     return [check_no_compiler_messages arcv_vcplx object {
         void foo (void)
           {
             asm ("arcv.vconj.v v0, v0");
           }
-  } "-march=rv32im_xarcvvcplx" ]
+  } "-march=${gcc_march}_xarcvvcplx" ]
 }
 # Return 1 if the ARC-V VSAD extension is available.
 proc check_effective_target_arcv_vsad { } {
     if { !([istarget riscv*-*-*]) } {
         return 0
     }
+    set gcc_march [regsub {[[:alnum:]]*} [riscv_get_arch] &v]
     return [check_no_compiler_messages arcv_vsad object {
         void foo (void)
           {
             asm ("arcv.vwsad.vv v0, v0, v0");
           }
-  } "-march=rv32im_xarcvvsad" ]
+  } "-march=${gcc_march}_xarcvvsad" ]
 }
 # Return 1 if the ARC-V MXMB extension is available.
 proc check_effective_target_arcv_mxmb { } {
     if { !([istarget riscv*-*-*]) } {
         return 0
     }
+    set gcc_march [regsub {[[:alnum:]]*} [riscv_get_arch] &v]
     return [check_no_compiler_messages arcv_mxmb object {
         void foo (void)
           {
             asm ("arcv.vqmxm4.vv v0, v0, v0");
           }
-  } "-march=rv32im_xarcvmxmb" ]
+  } "-march=${gcc_march}_xarcvmxmb" ]
 }
 # Return 1 if the ARC-V MXMC extension is available.
 proc check_effective_target_arcv_mxmc { } {
     if { !([istarget riscv*-*-*]) } {
         return 0
     }
+    set gcc_march [regsub {[[:alnum:]]*} [riscv_get_arch] &v]
     return [check_no_compiler_messages arcv_mxmc object {
         void foo (void)
           {
             asm ("arcv.vqmxm8.vv v0, v0, v0");
           }
-  } "-march=rv32im_xarcvmxmc" ]
+  } "-march=${gcc_march}_xarcvmxmc" ]
 }
 # Return 1 if the ARC-V MXMD extension is available.
 proc check_effective_target_arcv_mxmd { } {
     if { !([istarget riscv*-*-*]) } {
         return 0
     }
+    set gcc_march [regsub {[[:alnum:]]*} [riscv_get_arch] &v]
     return [check_no_compiler_messages arcv_mxmd object {
         void foo (void)
           {
             asm ("arcv.vqmxm16.vv v0, v0, v0");
           }
-  } "-march=rv32im_xarcvmxmd" ]
+  } "-march=${gcc_march}_xarcvmxmd" ]
 }
 
 proc check_effective_target_loongarch_sx { } {


### PR DESCRIPTION
These checks failed in case e.g. -mabi=ilp32d was configured to be the default because the test fails for march=rv32im* because of an ABI mismatch if no D extension is specified.

This caused xarcv extension tests to silently be skipped.