### PR TITLE
arc + arc64: Don't register optab for unsupported vector modes

### DIFF
--- a/gcc/config/arc/simdext.md
+++ b/gcc/config/arc/simdext.md
@@ -2007,7 +2007,7 @@
   [(set (match_operand:V2SI 0 "register_operand" "=r")
 	(EMUVEC:V2SI (match_operand:V2SI 1 "register_operand" "r")
 		     (match_operand:V2SI 2 "nonmemory_operand" "ri")))]
-  ""
+  "TARGET_PLUS_QMACW"
   "#"
   "reload_completed"
   [(const_int 0)]

--- a/gcc/config/arc64/arith.md
+++ b/gcc/config/arc64/arith.md
@@ -2344,7 +2344,7 @@
   [(set (match_operand:W2xI 0 "register_operand" "=r")
 	(DOPF:W2xI (match_operand:W2xI 1 "register_operand" "r")
 		   (match_operand:W2xI 2 "register_operand" "r")))]
-  "TARGET_64BIT"
+  "TARGET_64BIT && TARGET_WIDE_LDST"
   "#"
   "&& reload_completed"
   [(const_int 0)]
@@ -2366,7 +2366,7 @@
   [(set (match_operand:W2x2 0 "register_operand" "=r")
 	(ADDSUB:W2x2 (match_operand:W2x2 1 "register_operand" "r")
 		     (match_operand:W2x2 2 "register_operand" "r")))]
-  "TARGET_SIMD && TARGET_64BIT"
+  "TARGET_SIMD && TARGET_64BIT && TARGET_WIDE_LDST"
   "#"
   "&& reload_completed"
   [(const_int 0)]
@@ -2388,7 +2388,7 @@
   [(set (match_operand:V4SI 0 "register_operand" "=r")
 	(MINMAX:V4SI (match_operand:V4SI 1 "register_operand" "r")
 		     (match_operand:V4SI 2 "register_operand" "r")))]
-  "TARGET_SIMD && TARGET_64BIT"
+  "TARGET_SIMD && TARGET_64BIT && TARGET_WIDE_LDST"
   "#"
   "&& reload_completed"
   [(const_int 0)]

--- a/gcc/tree-vect-generic.cc
+++ b/gcc/tree-vect-generic.cc
@@ -1598,49 +1598,29 @@ ssa_uniform_vector_p (tree op)
   return NULL_TREE;
 }
 
-/* Return type in which CODE operation with optab OP can be
-   computed.  */
+/* Return the type that should be used to implement OP on type TYPE.
+   This is TYPE itself if the target can do the operation directly,
+   otherwise it is a scalar type or a smaller vector type.  */
 
 static tree
-get_compute_type (enum tree_code code, optab op, tree type)
+get_compute_type (optab op, tree type)
 {
-  /* For very wide vectors, try using a smaller vector mode.  */
-  tree compute_type = type;
-  if (op
-      && (!VECTOR_MODE_P (TYPE_MODE (type))
-	  || optab_handler (op, TYPE_MODE (type)) == CODE_FOR_nothing))
+  if (op)
     {
-      tree vector_compute_type
-	= type_for_widest_vector_mode (type, op);
+      if (VECTOR_MODE_P (TYPE_MODE (type))
+	  && can_implement_p (op, TYPE_MODE (type)))
+	return type;
+
+      /* For very wide vectors, try using a smaller vector mode.  */
+      tree vector_compute_type = type_for_widest_vector_mode (type, op);
       if (vector_compute_type != NULL_TREE
 	  && maybe_ne (TYPE_VECTOR_SUBPARTS (vector_compute_type), 1U)
-	  && (optab_handler (op, TYPE_MODE (vector_compute_type))
-	      != CODE_FOR_nothing))
-	compute_type = vector_compute_type;
+	  && can_implement_p (op, TYPE_MODE (vector_compute_type)))
+	return vector_compute_type;
     }
 
-  /* If we are breaking a BLKmode vector into smaller pieces,
-     type_for_widest_vector_mode has already looked into the optab,
-     so skip these checks.  */
-  if (compute_type == type)
-    {
-      machine_mode compute_mode = TYPE_MODE (compute_type);
-      if (VECTOR_MODE_P (compute_mode))
-	{
-	  if (op
-	      && (optab_handler (op, compute_mode) != CODE_FOR_nothing
-		  || optab_libfunc (op, compute_mode)))
-	    return compute_type;
-	  if (code == MULT_HIGHPART_EXPR
-	      && can_mult_highpart_p (compute_mode,
-				      TYPE_UNSIGNED (compute_type)))
-	    return compute_type;
-	}
-      /* There is no operation in hardware, so fall back to scalars.  */
-      compute_type = TREE_TYPE (type);
-    }
-
-  return compute_type;
+  /* There is no operation in hardware, so fall back to scalars.  */
+  return TREE_TYPE (type);
 }
 
 static tree
@@ -1663,7 +1643,7 @@ expand_vector_scalar_condition (gimple_stmt_iterator *gsi)
   gassign *stmt = as_a <gassign *> (gsi_stmt (*gsi));
   tree lhs = gimple_assign_lhs (stmt);
   tree type = TREE_TYPE (lhs);
-  tree compute_type = get_compute_type (COND_EXPR, mov_optab, type);
+  tree compute_type = get_compute_type (mov_optab, type);
   machine_mode compute_mode = TYPE_MODE (compute_type);
   gcc_assert (compute_mode != BLKmode);
   tree rhs2 = gimple_assign_rhs2 (stmt);
@@ -1845,7 +1825,7 @@ expand_vector_conversion (gimple_stmt_iterator *gsi)
 	}
 
       if (optab1)
-	compute_type = get_compute_type (code1, optab1, arg_type);
+	compute_type = get_compute_type (optab1, arg_type);
       enum insn_code icode1;
       if (VECTOR_TYPE_P (compute_type)
 	  && ((icode1 = optab_handler (optab1, TYPE_MODE (compute_type)))
@@ -1926,7 +1906,7 @@ expand_vector_conversion (gimple_stmt_iterator *gsi)
 	}
 
       if (optab1 && optab2)
-	compute_type = get_compute_type (code1, optab1, arg_type);
+	compute_type = get_compute_type (optab1, arg_type);
 
       enum insn_code icode1, icode2;
       if (VECTOR_TYPE_P (compute_type)
@@ -2179,12 +2159,12 @@ expand_vector_operations_1 (gimple_stmt_iterator *gsi)
 	{
           op = optab_for_tree_code (code, type, optab_scalar);
 
-	  compute_type = get_compute_type (code, op, type);
+	  compute_type = get_compute_type (op, type);
 	  if (compute_type == type)
 	    return;
 	  /* The rtl expander will expand vector/scalar as vector/vector
 	     if necessary.  Pick one with wider vector type.  */
-	  tree compute_vtype = get_compute_type (code, opv, type);
+	  tree compute_vtype = get_compute_type (opv, type);
 	  if (subparts_gt (compute_vtype, compute_type))
 	    {
 	      compute_type = compute_vtype;
@@ -2195,7 +2175,7 @@ expand_vector_operations_1 (gimple_stmt_iterator *gsi)
       if (code == LROTATE_EXPR || code == RROTATE_EXPR)
 	{
 	  if (compute_type == NULL_TREE)
-	    compute_type = get_compute_type (code, op, type);
+	    compute_type = get_compute_type (op, type);
 	  if (compute_type == type)
 	    return;
 	  /* Before splitting vector rotates into scalar rotates,
@@ -2208,11 +2188,11 @@ expand_vector_operations_1 (gimple_stmt_iterator *gsi)
 	    {
 	      optab oplv = vashl_optab, opl = ashl_optab;
 	      optab oprv = vlshr_optab, opr = lshr_optab, opo = ior_optab;
-	      tree compute_lvtype = get_compute_type (LSHIFT_EXPR, oplv, type);
-	      tree compute_rvtype = get_compute_type (RSHIFT_EXPR, oprv, type);
-	      tree compute_otype = get_compute_type (BIT_IOR_EXPR, opo, type);
-	      tree compute_ltype = get_compute_type (LSHIFT_EXPR, opl, type);
-	      tree compute_rtype = get_compute_type (RSHIFT_EXPR, opr, type);
+	      tree compute_lvtype = get_compute_type (oplv, type);
+	      tree compute_rvtype = get_compute_type (oprv, type);
+	      tree compute_otype = get_compute_type (opo, type);
+	      tree compute_ltype = get_compute_type (opl, type);
+	      tree compute_rtype = get_compute_type (opr, type);
 	      /* The rtl expander will expand vector/scalar as vector/vector
 		 if necessary.  Pick one with wider vector type.  */
 	      if (subparts_gt (compute_lvtype, compute_ltype))
@@ -2255,7 +2235,7 @@ expand_vector_operations_1 (gimple_stmt_iterator *gsi)
     op = optab_for_tree_code (MINUS_EXPR, type, optab_default);
 
   if (compute_type == NULL_TREE)
-    compute_type = get_compute_type (code, op, type);
+    compute_type = get_compute_type (op, type);
   if (compute_type == type)
     return;
 

--- a/gcc/tree-vect-stmts.cc
+++ b/gcc/tree-vect-stmts.cc
@@ -7079,21 +7079,15 @@ vectorizable_operation (vec_info *vinfo,
   /* Supportable by target?  */
 
   vec_mode = TYPE_MODE (vectype);
-  if (code == MULT_HIGHPART_EXPR)
-    target_support_p = can_mult_highpart_p (vec_mode, TYPE_UNSIGNED (vectype));
-  else
+  optab = optab_for_tree_code (code, vectype, optab_default);
+  if (!optab)
     {
-      optab = optab_for_tree_code (code, vectype, optab_default);
-      if (!optab)
-	{
-          if (dump_enabled_p ())
-            dump_printf_loc (MSG_MISSED_OPTIMIZATION, vect_location,
-                             "no optab.\n");
-	  return false;
-	}
-      target_support_p = (optab_handler (optab, vec_mode) != CODE_FOR_nothing
-			  || optab_libfunc (optab, vec_mode));
+      if (dump_enabled_p ())
+	dump_printf_loc (MSG_MISSED_OPTIMIZATION, vect_location,
+			 "no optab.\n");
+      return false;
     }
+  target_support_p = can_implement_p (optab, vec_mode);
 
   bool using_emulated_vectors_p = vect_emulated_vector_p (vectype);
   if (!target_support_p || using_emulated_vectors_p)


### PR DESCRIPTION
This reverts an earlier revert to the vectorizer.
Both the arcv2 and arcv3 registered optabs that with unsupported vector operand types.
This confuses the vectorizer, it scalarizes the operation because the vector mode is not supported.
But it keeps the operation unscalarized because operation is supported even though it won't every be generated.

Added the correct checks that correspond with support for the vector types.

No tests added. Behaviour was already covered by target-independent tests.