### PR TITLE
Pin arc-gnu-toolchain repo commit in test workflow

### DIFF
--- a/.github/workflows/arc-test.yml
+++ b/.github/workflows/arc-test.yml
@@ -52,6 +52,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: foss-for-synopsys-dwc-arc-processors/arc-gnu-toolchain
+          # TODO Testing with master is broken
+          ref: 80c68c7b7f156cf2ade4e2a85e300c13ef78f547
           path: arc-gnu-toolchain
           fetch-depth: 1
 


### PR DESCRIPTION
c6b97e9 broke the testing target. Temporary restore functionality until this is addressed.