### PR TITLE
arc: fix register constraints in extvsi patterns

### DIFF
--- a/gcc/config/arc/arc.md
+++ b/gcc/config/arc/arc.md
@@ -6267,7 +6267,7 @@ archs4x, archs4xd"
 ;; Split sign-extension of single least significant bit as and x,$1;neg x
 (define_insn_and_split "*extvsi_1_0"
   [(set (match_operand:SI 0 "register_operand" "=r")
-	(sign_extract:SI (match_operand:SI 1 "register_operand" "0")
+	(sign_extract:SI (match_operand:SI 1 "register_operand" "r")
 			 (const_int 1)
 			 (const_int 0)))]
   "!TARGET_BARREL_SHIFTER"
@@ -6280,7 +6280,7 @@ archs4x, archs4xd"
 
 (define_insn_and_split "*extvsi_n_0"
   [(set (match_operand:SI 0 "register_operand" "=r")
-	(sign_extract:SI (match_operand:SI 1 "register_operand" "0")
+	(sign_extract:SI (match_operand:SI 1 "register_operand" "r")
 			 (match_operand:QI 2 "const_int_operand")
 			 (const_int 0)))]
   "!TARGET_BARREL_SHIFTER

--- a/gcc/testsuite/gcc.target/arc/extvsi-sign-extract.c
+++ b/gcc/testsuite/gcc.target/arc/extvsi-sign-extract.c
@@ -1,0 +1,60 @@
+/* { dg-do run } */
+/* { dg-skip-if "avoid conflicts with -mcpu options" { *-*-* } { "-mcpu=*" } { "-mcpu=em" } } */
+/* { dg-options "-O2 -mcpu=em" } */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/* Test multi-bit extraction pattern (*extvsi_n_0).  */
+struct bitstruct {
+  unsigned a : 21;
+  unsigned b : 8;
+  unsigned c : 2;
+  int d : 17;
+} __attribute__((packed));
+
+static volatile struct bitstruct bits = {
+  .a = 0x100,
+  .b = 0x2f,
+  .c = 0,
+  .d = 0
+};
+
+volatile int global_d;
+
+/* Test snigle-bit extraction pattern (*extvsi_1_0).  */
+struct source_struct {
+  int target_bit : 1;
+  unsigned int padding : 31;
+} __attribute__((packed));
+
+static volatile struct source_struct data = {
+  .target_bit = 1,
+  .padding = 0xabcdef
+};
+
+volatile int destination;
+
+int
+main (void)
+{
+  /* 1. Execute Multi-bit Sign-Extract Test.  */
+  global_d = bits.d;
+  if (global_d != 0)
+    {
+      printf ("FAIL: Multi-bit extract (*extvsi_n_0) failed. Expected 0, got %d\n", global_d);
+      abort ();
+    }
+
+  /* 2. Execute Single-bit Sign-Extract Test.  */
+  destination = data.target_bit;
+  if (destination != -1)
+    {
+      printf ("FAIL: Single-bit extract (*extvsi_1_0) failed. Expected -1, got %d\n", destination);
+      abort ();
+    }
+
+  printf ("PASS: Both sign-extract patterns executed successfully.\n");
+  return 0;
+}
+


### PR DESCRIPTION
The multi-bit extvsi_n_0 and single-bit extvsi_1_0 signed bitfield extraction patterns were utilizing a too restrictive matching constraint "0" for operand 1 while splitting early (&& 1) before ra/reload.

Because early splits occur prior to the reload and register allocation passes when operands are still separate pseudos, this mismatch violates rtl dataflow constraints as it can confuse data flow.

Remark that in the upstream gcc this patch wont apply as there are other split conditions put in place (although again too restrictive).