### PR TITLE
arc: Fix incorrect RTL generation for store instruction

### DIFF
--- a/gcc/config/arc/arc.cc
+++ b/gcc/config/arc/arc.cc
@@ -9282,16 +9282,33 @@ prepare_move_operands (rtx *operands, machine_mode mode)
 	      return true;
 	    }
 	}
-      /* Second, we check for the uncached.  */
+
+      /* Second, handle uncached stores.  */
       if (arc_is_uncached_mem_p (operands[0]))
 	{
-	  if (!REG_P (operands[1]))
-	    operands[1] = force_reg (mode, operands[1]);
+	   if (!REG_P (operands[1]))
+	   operands[1] = force_reg (mode, operands[1]);
+
+	   /* Direct uncached stores (st.di) dont support register index
+	      [reg + reg] addressing.  Check and fix the address before
+	      emitting VUNSPEC_ARC_STDI.  */
+	  if (!move_dest_operand (operands[0], mode))
+	    {
+	      /* Force the [reg + reg] in the base register as a separate
+		 insn.  */
+	      rtx tmp0 = copy_to_mode_reg (Pmode, XEXP (operands[0], 0));
+	      rtx tmp1 = change_address (operands[0], mode, tmp0);
+	      MEM_COPY_ATTRIBUTES (tmp1, operands[0]);
+	      operands[0] = tmp1;
+	    }
+
 	  emit_insn (gen_rtx_UNSPEC_VOLATILE
 		     (VOIDmode, gen_rtvec (2, operands[0], operands[1]),
 		      VUNSPEC_ARC_STDI));
 	  return true;
 	}
+
+      /* Third, handle uncached loads.  */
       if (arc_is_uncached_mem_p (operands[1]))
 	{
 	  rtx tmp = operands[0];

--- a/gcc/config/arc/arc.md
+++ b/gcc/config/arc/arc.md
@@ -4954,8 +4954,9 @@ archs4x, archs4xd"
   "ld<mALLI>%U1.di\\t%0,%1"
   [(set_attr "type" "load")])
 
+; Direct store pattern
 (define_insn "stdi<mode>"
-  [(unspec_volatile [(match_operand:ALLI 0 "memory_operand"    "m,m,Usc")
+  [(unspec_volatile [(match_operand:ALLI 0 "move_dest_operand" "m,m,Usc")
 		     (match_operand:ALLI 1 "nonmemory_operand" "r,Cm3,i")]
 		    VUNSPEC_ARC_STDI)]
   ""
@@ -4964,7 +4965,7 @@ archs4x, archs4xd"
    (set_attr "type" "store")])
 
 (define_insn_and_split "*stdidi_split"
-  [(unspec_volatile [(match_operand:DI 0 "memory_operand"   "m")
+  [(unspec_volatile [(match_operand:DI 0 "non_incdec_memory_operand"   "m")
 		     (match_operand:DI 1 "register_operand" "r")]
 		    VUNSPEC_ARC_STDI)]
   "!TARGET_LL64"
@@ -4980,7 +4981,7 @@ archs4x, archs4xd"
    operands[4] = gen_highpart (SImode, operands[0]);
   }
   "
-  )
+  [(set_attr "type" "store")])
 
 (define_insn_and_split "*lddidi_split"
   [(set (match_operand:DI 0 "register_operand" "=r")
@@ -4999,6 +5000,7 @@ archs4x, archs4xd"
    operands[4] = gen_highpart (SImode, operands[0]);
   }
   "
+  [(set_attr "type" "load")]
   )
 
 (define_insn "trap_s"

--- a/gcc/config/arc/predicates.md
+++ b/gcc/config/arc/predicates.md
@@ -775,3 +775,22 @@
   (ior (match_test "register_operand (op, mode)")
        (and (match_code "const_int, symbol_ref")
 	    (match_test "!optimize_size"))))
+
+(define_predicate "non_incdec_memory_operand"
+  (match_operand 0 "move_dest_operand")
+{
+  rtx addr = XEXP (op, 0);
+  enum rtx_code code = GET_CODE (addr);
+
+  /* Reject post/pre inc/dec to be used for DI mode on
+     targets that dont have 64 ls units.  */
+  if (code == POST_INC
+      || code == PRE_INC
+      || code == POST_DEC
+      || code == PRE_DEC
+      || code == POST_MODIFY
+      || code == PRE_MODIFY)
+    return false;
+
+  return true;
+})

--- a/gcc/testsuite/gcc.target/arc/uncached-stdi-o2.c
+++ b/gcc/testsuite/gcc.target/arc/uncached-stdi-o2.c
@@ -1,0 +1,14 @@
+/* { dg-do compile } */
+/* { dg-options "-O2 -mno-ll64" } */
+
+#include "uncached-stdi.h"
+
+/* First check that all single register uncached store instructions are being generated in the output.  */
+/* { dg-final { scan-assembler "stb.*\\.di" } } */
+/* { dg-final { scan-assembler "\\m(sth|stw).*\\.di" } } */
+/* { dg-final { scan-assembler "st.*\\.di" } } */
+
+/* Second verify that no direct(di) register offset addressing are being generated. */
+/* { dg-final { scan-assembler-not {stb.*\.di\s+r[0-9]+,\s*\[r[0-9]+,\s*r[0-9]+\]} } } */
+/* { dg-final { scan-assembler-not {\m(sth|stw).*\.di\s+r[0-9]+,\s*\[r[0-9]+,\s*r[0-9]+\]} } } */
+/* { dg-final { scan-assembler-not {st.*\.di\s+r[0-9]+,\s*\[r[0-9]+,\s*r[0-9]+\]} } } */

--- a/gcc/testsuite/gcc.target/arc/uncached-stdi-os.c
+++ b/gcc/testsuite/gcc.target/arc/uncached-stdi-os.c
@@ -1,0 +1,13 @@
+/* { dg-do compile } */
+/* { dg-options "-Os -mno-ll64" } */
+
+#include "uncached-stdi.h"
+
+/* { dg-final { scan-assembler "stb.*\\.di" } } */
+/* { dg-final { scan-assembler "\\m(sth|stw).*\\.di" } } */
+/* { dg-final { scan-assembler "st.*\\.di" } } */
+
+/* Second verify that no direct(di) register offset addressing are being generated. */
+/* { dg-final { scan-assembler-not {stb.*\.di\s+r[0-9]+,\s*\[r[0-9]+,\s*r[0-9]+\]} } } */
+/* { dg-final { scan-assembler-not {\m(sth|stw).*\.di\s+r[0-9]+,\s*\[r[0-9]+,\s*r[0-9]+\]} } } */
+/* { dg-final { scan-assembler-not {st.*\.di\s+r[0-9]+,\s*\[r[0-9]+,\s*r[0-9]+\]} } } */

--- a/gcc/testsuite/gcc.target/arc/uncached-stdi.h
+++ b/gcc/testsuite/gcc.target/arc/uncached-stdi.h
@@ -1,0 +1,43 @@
+#ifndef __uncached
+#define __uncached __attribute__((uncached))
+#endif
+
+/*Test for QImode.  */
+volatile char *
+pack_byte_ptr(volatile char *p, const void *s, int len)
+{
+    volatile __uncached char *buf = p + 4;
+    for (int i = 0; i < len; i++)
+        buf[i] = ((const char *)s)[i];
+    return p;
+}
+
+/*Test for HImode.  */
+volatile short *
+pack_halfword_ptr(volatile short *p, const void *s, int len)
+{
+    volatile __uncached short *buf = p + 4;
+    for (int i = 0; i < len; i++)
+        buf[i] = ((const short *)s)[i];
+    return p;
+}
+
+/*Test for SImode.  */
+volatile int *
+pack_word_ptr(volatile int *p, const void *s, int len)
+{
+    volatile __uncached int *buf = p + 4;
+    for (int i = 0; i < len; i++)
+        buf[i] = ((const int *)s)[i];
+    return p;
+}
+
+/*Test for DImode.  */
+volatile long long *
+pack_doubleword_ptr(volatile long long *p, const void *s, int len)
+{
+    volatile __uncached long long *buf = p + 4;
+    for (int i = 0; i < len; i++)
+        buf[i] = ((const long long *)s)[i];
+    return p;
+}


### PR DESCRIPTION
arc: Fix invalid register index addressing for uncached stores

For uncached stores (direct memory stores) the compiler was generating indexed addressing 
using register offsets. However, the arc target doesnt support such stores.

This was happening becasue prepare_move_operands() emits a raw VUNSPEC_ARC_STDI
and returns true - bypassing in this was further validation which was for example happening 
for standard stores. This was fised during rtl expand by validating uncached stores against 
move_dest_operand() and forcing complex addresses into separate register (via copy_to_mode_reg()).

The issue was originally described here:
https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/issues/672
where the store instructions (like stb.di) were emitting invalid
memory offsets.

Also added dejagnu tests to verify that the correct assembly instruction and offsets are 
generated in the output file.