### PR TITLE
arc64: Fix for P10019563-86826

### DIFF
--- a/gcc/config/arc64/arith.md
+++ b/gcc/config/arc64/arith.md
@@ -1062,20 +1062,17 @@
 ;; 64 + (signe) 32 x (signe) 32 -> 64
 (define_expand "<ANY_EXTEND:su_optab>maddsidi4"
   [(set (match_operand: DI 0 "register_operand")
-	(plus:DI
-	 (mult:DI
-	  (ANY_EXTEND:DI (match_operand:SI 1 "register_operand"))
-	  (ANY_EXTEND:DI (match_operand:SI 2 "register_operand")))
-	 (match_operand:DI 3 "register_operand")))]
+        (plus:DI
+         (mult:DI
+          (ANY_EXTEND:DI (match_operand:SI 1 "register_operand"))
+          (ANY_EXTEND:DI (match_operand:SI 2 "register_operand")))
+         (match_operand:DI 3 "register_operand")))]
   "TARGET_SIMD"
   {
-   rtx acc = gen_rtx_REG (DImode, R58_REGNUM);
-
-   emit_move_insn (acc, operands[3]);
    emit_insn (gen_<ANY_EXTEND:su_optab>macd (operands[0], operands[1],
-                                            operands[2], acc));
+                                            operands[2], operands[3]));
    DONE;
-   })
+  })
 
 (define_insn "<ANY_EXTEND:su_optab>macd0"
  [(set (reg:DI R58_REGNUM)

--- a/gcc/testsuite/gcc.target/arc64/maddsidi4-simd.c
+++ b/gcc/testsuite/gcc.target/arc64/maddsidi4-simd.c
@@ -1,0 +1,40 @@
+/* { dg-do compile } */
+/* { dg-options "-mcpu=hs5x -O2" } */
+
+#include <stdint.h>
+
+uint64_t
+__umul128(const uint64_t a, const uint64_t b, uint64_t * const productHi)
+{
+    const uint32_t aLo = (uint32_t)a;
+    const uint32_t aHi = (uint32_t)(a >> 32);
+    const uint32_t bLo = (uint32_t)b;
+    const uint32_t bHi = (uint32_t)(b >> 32);
+
+    const uint64_t b00 = (uint64_t)aLo * bLo;
+    const uint64_t b01 = (uint64_t)aLo * bHi;
+    const uint64_t b10 = (uint64_t)aHi * bLo;
+    const uint64_t b11 = (uint64_t)aHi * bHi;
+
+    const uint32_t b00Lo = (uint32_t)b00;
+    const uint32_t b00Hi = (uint32_t)(b00 >> 32);
+
+    const uint64_t mid1 = b10 + b00Hi;
+    const uint32_t mid1Lo = (uint32_t)(mid1);
+    const uint32_t mid1Hi = (uint32_t)(mid1 >> 32);
+
+    const uint64_t mid2 = b01 + mid1Lo;
+    const uint32_t mid2Lo = (uint32_t)(mid2);
+    const uint32_t mid2Hi = (uint32_t)(mid2 >> 32);
+
+    const uint64_t pHi = b11 + mid1Hi + mid2Hi;
+    const uint64_t pLo = ((uint64_t)mid2Lo << 32) | b00Lo;
+
+    *productHi = pHi;
+    return pLo;
+}
+
+/* Check that the compiler generates vadd2+macdu */
+/* { dg-final { scan-assembler "vadd23" } } */
+/* { dg-final { scan-assembler "macdu" } } */
+


### PR DESCRIPTION
**arc64: Fix crash in emit_move_multi_word during rtl expansion**

Fix for multiword moves on hs5x introduced during:
define_expand "<ANY_EXTEND:su_optab>maddsidi4" 
Originally when this expand was trying to move data in DI mode
to the reg 58 the gcc internal emit_move_insn function had inside an issue: 
Inside  there is the following loop which endsup trying to make use of reg 59 which is reserved.

**Namely:**
```
for (i = 0; i < 2; i++) {
rtx xpart = operand_subword (x, i, 1, mode);
:
   gcc_assert (xpart && ypart); //at the second run (i=1) tries
                                //to take r59 and it crashes.
:
}
```
**Solution:**
Remove the use of emit_move_insn and pass the operands directly into the gen_<ANY_EXTEND:su_optab>macd bypassing
the logic inside emit_move_insn. The <ANY_EXTEND:su_optab>macd accepts r58 and produces a pattern that is subject to a define_insn_and_split.

(define_insn_and_split "<ANY_EXTEND:su_optab>macd"
This split takes place after ra and already contains the move (set (reg:DI R58_REGNUM) (match_dup 3) generating
a move (vadd2) followed by a macdu. For more info check:
https://pyreneesgf.atlassian.net/browse/P10019563-86826