### PR TITLE
arcv: add move and constant insns for ls-update fusions

### DIFF
--- a/gcc/config/riscv/arcv.cc
+++ b/gcc/config/riscv/arcv.cc
@@ -306,7 +306,8 @@ arcv_arith_type_insn_p (rtx_insn *insn)
 	 || type == TYPE_MINU
 	 || type == TYPE_MAXU
 	 || type == TYPE_CLZ
-	 || type == TYPE_CTZ);
+	 || type == TYPE_CTZ
+	 || type == TYPE_MOVE);
 }
 
 
@@ -351,19 +352,34 @@ arcv_ls_update (rtx_insn *prev, rtx_insn *curr)
   rtx c_src = SET_SRC (curr_set);
   rtx c_dest = SET_DEST (curr_set);
 
-  /* Check if curr has at least one register source.  */
-  if (CONST_INT_P (c_src) ||
-      (!CONST_INT_P (c_src) && !REG_P (XEXP (c_src, 0))))
+  if (CONSTANT_P (c_src))
     return false;
 
-  int c_rs1 = REGNO (XEXP (c_src, 0));
-  int c_rd  = REGNO (c_dest);
+  int c_rs1;
+  int c_rs2;
+  bool has_rs2;
 
-  /* Check if there is a second source register.  */
-  bool has_rs2 = (GET_RTX_LENGTH (GET_CODE (c_src)) > 1
+  // Move
+  if (REG_P (c_src))
+    {
+      c_rs1 = REGNO (c_src);
+      has_rs2 = false;
+    }
+  // Arithmetic
+  else if ((REG_P (XEXP (c_src, 0))))
+    {
+      c_rs1 = REGNO (XEXP (c_src, 0));
+      /* Check if there is a second source register.  */
+      has_rs2 = (GET_RTX_LENGTH (GET_CODE (c_src)) > 1
 		  && REG_P (XEXP (c_src, 1)));
+      c_rs2 = has_rs2 ? REGNO (XEXP (c_src, 1)) : -1;
+    }
+  else
+    {
+      return false;
+    }
 
-  int c_rs2 = has_rs2 ? REGNO (XEXP (c_src, 1)) : -1;
+  int c_rd  = REGNO (c_dest);
 
   switch (p_type)
     {

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-ls-update-move-dump.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-ls-update-move-dump.c
@@ -1,0 +1,13 @@
+/* { dg-do compile } */
+/* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-O3" "-Oz" "-Os" } } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" { target rv32 } } */
+/* { dg-options "-O2 -mtune=arc-v-rpx-100-series -march=rv64im -mabi=lp64 -fdump-rtl-sched2" { target rv64 } } */
+
+int *
+fuse_ls_update_li (int *p, int *q, int x)
+  {
+    *q = x;
+    return q;
+  }
+
+/* { dg-final { scan-rtl-dump "ARCV_FUSE_LS_UPDATE" "sched2" } } */


### PR DESCRIPTION
Move types become mv, which is a pseudo-instruction that expands to addi, an arithmetic type which was already considered for the fusions. Const expands to lui and/or addi, which can both form ls-update fusions.