### PR TITLE
P10019563 86920

### DIFF
--- a/gcc/config/arc/arc.md
+++ b/gcc/config/arc/arc.md
@@ -4954,10 +4954,13 @@ archs4x, archs4xd"
   "ld<mALLI>%U1.di\\t%0,%1"
   [(set_attr "type" "load")])
 
+; Direct store pattern utilizing arc_stdi_memory_operand to
+; reject [reg+reg] on ARCv2. This prevents the combiner from
+; optimizing separate pointer additions back into illegal encodings.
 (define_insn "stdi<mode>"
-  [(unspec_volatile [(match_operand:ALLI 0 "memory_operand"    "m,m,Usc")
-		     (match_operand:ALLI 1 "nonmemory_operand" "r,Cm3,i")]
-		    VUNSPEC_ARC_STDI)]
+  [(unspec_volatile [(match_operand:ALLI 0 "arc_stdi_memory_operand" "m,m,Usc")  
+                     (match_operand:ALLI 1 "nonmemory_operand"       "r,Cm3,i")]
+                    VUNSPEC_ARC_STDI)]
   ""
   "st<mALLI>%U0.di\\t%1,%0"
   [(set_attr "length" "*,*,8")

--- a/gcc/config/riscv/arcv-rhx100.md
+++ b/gcc/config/riscv/arcv-rhx100.md
@@ -156,3 +156,8 @@
 (define_bypass 3 "arcv_rhx100_fmul"    "arcv_rhx100_fmul*")
 (define_bypass 4 "arcv_rhx100_fmul_dp" "arcv_rhx100_fmul*")
 (define_bypass 2 "arcv_rhx100_fmul*"  "arcv_rhx100_fmul*" "arcv_fmadd_acc_bypass_p")
+
+(define_insn_reservation "arcv_rhx100_unknown" 1
+  (and (eq_attr "tune" "arcv_rhx100")
+       (eq_attr "type" "ghost,vfrecp,vclmul,vldm,vmffs,vclmulh,vlsegde,vfcvtitof,vsm4k,vfcvtftoi,vfdiv,vsm3c,vsm4r,viwmuladd,vfwredu,vcpop,vfwmuladd,vstux,vsshift,vfwcvtftof,vfncvtftof,vfwmaccbf16,vext,vssegte,rdvl,vaeskf1,vfslide1up,vmov,vimovvx,vaesef,vfsqrt,viminmax,vfwcvtftoi,vssegtox,vfclass,viwmul,vector,vgmul,vsm3me,vfcmp,vstm,vfredo,vfwmul,vaeskf2,vstox,vfncvtbf16,vislide1up,vgather,vldox,viwred,vctz,vghsh,vsts,vslidedown,vfmerge,vicmp,vsmul,vlsegdff,vfalu,vfmov,vislide1down,vfminmax,vcompress,vldr,vldff,vlsegdux,vimuladd,vsalu,vidiv,sf_vqmacc,vfslide1down,vaesem,vimerge,vfncvtftoi,vfwcvtitof,vicalu,vaesz,sf_vc_se,vsha2cl,vmsfs,vldux,vmidx,vslideup,vired,vlde,vfwredo,vfmovfv,vbrev,vfncvtitof,rdfrm,vsetvl,vssegts,vimul,vialu,vbrev8,vfwalu,rdvlenb,sf_vfnrclip,vclz,vnclip,sf_vc,vimov,vste,vfmuladd,vfmovvf,vwsll,vsetvl_pre,vlds,vlsegds,vmiota,vmalu,wrvxrm,wrfrm,viwalu,vaesdm,vssegtux,vaesdf,vimovxv,vror,vnshift,vstr,vaalu,vsha2ms,crypto,vfwcvtbf16,vlsegdox,vrol,vandn,vfsgnj,vmpop,vfredu,vsha2ch,vshift,vrev8,vfmul"))
+  "arcv_rhx100_ALU_A_fuse0_early")

--- a/gcc/config/riscv/arcv-rmx100.md
+++ b/gcc/config/riscv/arcv-rmx100.md
@@ -102,3 +102,9 @@
 
 (define_bypass 9 "arcv_rmx100_div_insn" "arcv_rmx100_*" "arcv_mpy_1c_bypass_p")
 (define_bypass 9 "arcv_rmx100_div_insn" "arcv_rmx100_*" "arcv_mpy_2c_bypass_p")
+
+(define_insn_reservation "arcv_rmx100_unknown" 1
+  (and (eq_attr "tune" "arcv_rhx100")
+       (eq_attr "type" "ghost,vfrecp,vclmul,vldm,vmffs,vclmulh,vlsegde,vfcvtitof,vsm4k,vfcvtftoi,vfdiv,vsm3c,vsm4r,viwmuladd,vfwredu,vcpop,vfwmuladd,vstux,vsshift,vfwcvtftof,vfncvtftof,vfwmaccbf16,vext,vssegte,rdvl,vaeskf1,vfslide1up,vmov,vimovvx,vaesef,vfsqrt,viminmax,vfwcvtftoi,vssegtox,vfclass,viwmul,vector,vgmul,vsm3me,vfcmp,vstm,vfredo,vfwmul,vaeskf2,vstox,vfncvtbf16,vislide1up,vgather,vldox,viwred,vctz,vghsh,vsts,vslidedown,vfmerge,vicmp,vsmul,vlsegdff,vfalu,vfmov,vislide1down,vfminmax,vcompress,vldr,vldff,vlsegdux,vimuladd,vsalu,vidiv,sf_vqmacc,vfslide1down,vaesem,vimerge,vfncvtftoi,vfwcvtitof,vicalu,vaesz,sf_vc_se,vsha2cl,vmsfs,vldux,vmidx,vslideup,vired,vlde,vfwredo,vfmovfv,vbrev,vfncvtitof,rdfrm,vsetvl,vssegts,vimul,vialu,vbrev8,vfwalu,rdvlenb,sf_vfnrclip,vclz,vnclip,sf_vc,vimov,vste,vfmuladd,vfmovvf,vwsll,vsetvl_pre,vlds,vlsegds,vmiota,vmalu,wrvxrm,wrfrm,viwalu,vaesdm,vssegtux,vaesdf,vimovxv,vror,vnshift,vstr,vaalu,vsha2ms,crypto,vfwcvtbf16,vlsegdox,vrol,vandn,vfsgnj,vmpop,vfredu,vsha2ch,vshift,vrev8,vfmul"))
+  "arcv_rmx100_ALU")
+

--- a/gcc/config/riscv/arcv-rmx500.md
+++ b/gcc/config/riscv/arcv-rmx500.md
@@ -116,3 +116,8 @@
 (define_bypass 1 "arcv_rmx500_load_insn" "arcv_rmx500_div_insn")
 (define_bypass 9 "arcv_rmx500_mpy*" "arcv_rmx500_mpy*_insn")
 (define_bypass 9 "arcv_rmx500_mpy*" "arcv_rmx500_div_insn")
+
+(define_insn_reservation "arcv_rmx500_unknown" 1
+  (and (eq_attr "tune" "arcv_rhx100")
+       (eq_attr "type" "ghost,vfrecp,vclmul,vldm,vmffs,vclmulh,vlsegde,vfcvtitof,vsm4k,vfcvtftoi,vfdiv,vsm3c,vsm4r,viwmuladd,vfwredu,vcpop,vfwmuladd,vstux,vsshift,vfwcvtftof,vfncvtftof,vfwmaccbf16,vext,vssegte,rdvl,vaeskf1,vfslide1up,vmov,vimovvx,vaesef,vfsqrt,viminmax,vfwcvtftoi,vssegtox,vfclass,viwmul,vector,vgmul,vsm3me,vfcmp,vstm,vfredo,vfwmul,vaeskf2,vstox,vfncvtbf16,vislide1up,vgather,vldox,viwred,vctz,vghsh,vsts,vslidedown,vfmerge,vicmp,vsmul,vlsegdff,vfalu,vfmov,vislide1down,vfminmax,vcompress,vldr,vldff,vlsegdux,vimuladd,vsalu,vidiv,sf_vqmacc,vfslide1down,vaesem,vimerge,vfncvtftoi,vfwcvtitof,vicalu,vaesz,sf_vc_se,vsha2cl,vmsfs,vldux,vmidx,vslideup,vired,vlde,vfwredo,vfmovfv,vbrev,vfncvtitof,rdfrm,vsetvl,vssegts,vimul,vialu,vbrev8,vfwalu,rdvlenb,sf_vfnrclip,vclz,vnclip,sf_vc,vimov,vste,vfmuladd,vfmovvf,vwsll,vsetvl_pre,vlds,vlsegds,vmiota,vmalu,wrvxrm,wrfrm,viwalu,vaesdm,vssegtux,vaesdf,vimovxv,vror,vnshift,vstr,vaalu,vsha2ms,crypto,vfwcvtbf16,vlsegdox,vrol,vandn,vfsgnj,vmpop,vfredu,vsha2ch,vshift,vrev8,vfmul"))
+  "arcv_rmx500_ALU_fuse0_early")

--- a/gcc/config/riscv/arcv-rpx100.md
+++ b/gcc/config/riscv/arcv-rpx100.md
@@ -136,3 +136,8 @@
 (define_bypass 9 "arcv_rpx100_mpy64l_insn" "arcv_rpx100_store_insn")
 (define_bypass 10 "arcv_rpx100_mpy64h_insn" "arcv_rpx100_load_insn")
 (define_bypass 10 "arcv_rpx100_mpy64h_insn" "arcv_rpx100_store_insn")
+
+(define_insn_reservation "arcv_rpx100_unknown" 1
+  (and (eq_attr "tune" "arcv_rhx100")
+       (eq_attr "type" "ghost,vfrecp,vclmul,vldm,vmffs,vclmulh,vlsegde,vfcvtitof,vsm4k,vfcvtftoi,vfdiv,vsm3c,vsm4r,viwmuladd,vfwredu,vcpop,vfwmuladd,vstux,vsshift,vfwcvtftof,vfncvtftof,vfwmaccbf16,vext,vssegte,rdvl,vaeskf1,vfslide1up,vmov,vimovvx,vaesef,vfsqrt,viminmax,vfwcvtftoi,vssegtox,vfclass,viwmul,vector,vgmul,vsm3me,vfcmp,vstm,vfredo,vfwmul,vaeskf2,vstox,vfncvtbf16,vislide1up,vgather,vldox,viwred,vctz,vghsh,vsts,vslidedown,vfmerge,vicmp,vsmul,vlsegdff,vfalu,vfmov,vislide1down,vfminmax,vcompress,vldr,vldff,vlsegdux,vimuladd,vsalu,vidiv,sf_vqmacc,vfslide1down,vaesem,vimerge,vfncvtftoi,vfwcvtitof,vicalu,vaesz,sf_vc_se,vsha2cl,vmsfs,vldux,vmidx,vslideup,vired,vlde,vfwredo,vfmovfv,vbrev,vfncvtitof,rdfrm,vsetvl,vssegts,vimul,vialu,vbrev8,vfwalu,rdvlenb,sf_vfnrclip,vclz,vnclip,sf_vc,vimov,vste,vfmuladd,vfmovvf,vwsll,vsetvl_pre,vlds,vlsegds,vmiota,vmalu,wrvxrm,wrfrm,viwalu,vaesdm,vssegtux,vaesdf,vimovxv,vror,vnshift,vstr,vaalu,vsha2ms,crypto,vfwcvtbf16,vlsegdox,vrol,vandn,vfsgnj,vmpop,vfredu,vsha2ch,vshift,vrev8,vfmul"))
+  "arcv_rpx100_ALU_A_fuse0_early")

--- a/gcc/testsuite/gcc.target/arc/uncached-stdi.c
+++ b/gcc/testsuite/gcc.target/arc/uncached-stdi.c
@@ -1,0 +1,24 @@
+/* { dg-do compile } */
+/* { dg-options "-Os" } */
+
+#ifndef __uncached
+#define __uncached __attribute__((uncached))
+#endif
+
+volatile char *
+_hl_pack_ptr(volatile char *p, const void *s, int len)
+{
+    volatile __uncached char *buf = p + 4;
+
+    for (int i = 0; i < len; i++)
+        buf[i] = ((const char *)s)[i];
+
+    return p;
+}
+
+
+/* Singleregister uncached store byte should be present in the output.  */
+/* { dg-final { scan-assembler "stb(_s)?\\.di" } } */
+
+/* Ensure that stb.di and srt_s.di are not present.  */
+/* { dg-final { scan-assembler-not {stb\.di\s+r[0-9]+,\s*\[r[0-9]+,\s*r[0-9]+\]} } } */


### PR DESCRIPTION
GCC relays on the instruction scheduler when doing fusion.
During this phase for the arcv tuned versions of riscv
- like RHX100 - there were instructions that (although not
supposed to be part of fusion process) they were checked
for their type attributes.

This was happening in
riscv_sched_variable_issue (gcc/config/riscv/riscv.cc)
Inside there is this statment:
gcc_assert (insn_has_dfa_reservation_p (insn));

When the compiler encountered at a vector instruction with
attribute type VIMOVVX  ended up crashing because of missing
corresponding hw units. This forces all the types to be able
to associate to have a unit reservation. This checking is
happening although some instructions arent supposed to be
fused.

In GCC15 there wasn't an issue because of a bug that took
place during the generation of the target C files.
A detailed example of what the wrong code generation was is
given here:
https://pyreneesgf.atlassian.net/browse/P10019563-86920
But GCC16 was no longer allowed to steal SIFIVE pipeline mappings.The
target generated code was fixed so that it strictly repeats
the tuning restriction on every single block (e.g., repeating
riscv_microarchitecture == TUNE_SIFIVE_7).