### PR TITLE
CI: update lint to view the PR as one big diff

### DIFF
--- a/.github/workflows/gcc-contrib-lint.yml
+++ b/.github/workflows/gcc-contrib-lint.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Generate PR patch
         id: patch
         run: |
-          git format-patch HEAD~${{ github.event.pull_request.commits }}..HEAD --output=pr.patch
+          git diff HEAD~${{ github.event.pull_request.commits }}..HEAD > pr.patch
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
This avoids failures due to lines that are added and later removed, and ensures the line numbers match the final version.