### PR TITLE
Fix RISCV_FUSE_MULT_ADD matching for RV64 sign-extended ops.

### DIFF
--- a/gcc/config/riscv/riscv-fusion.cc
+++ b/gcc/config/riscv/riscv-fusion.cc
@@ -932,8 +932,13 @@ riscv_fuse_b_alui (rtx_insn *prev, rtx_insn *curr)
 }
 
 /* Check for RISCV_FUSE_MULT_ADD fusion.
-   prev (mult) == (set (reg:DI rD_mult) (mult:DI (reg:DI rS1) (reg:DI rS2)))
-   curr (add)  == (set (reg:DI rD_add) (plus:DI (reg:DI rD_mult) (reg:DI rS3)))  */
+   On RV32:
+   prev (mul) == (set (reg rD) (mult:SI (reg:SI rS1) (reg:SI rS2)))
+   curr (add) == (set (reg rD) (plus:SI (reg:SI rD) (reg:SI rS3)))
+
+   On RV64 the result may be sign-extended to DI:
+   prev (mul) == (set (reg:DI rD) (sign_extend:DI (mult:SI ...)))
+   curr (add) == (set (reg:DI rD) (sign_extend:DI (plus:SI ...)))  */
 
 static bool
 riscv_fuse_mult_add (rtx_insn *prev, rtx_insn *curr)
@@ -943,24 +948,34 @@ riscv_fuse_mult_add (rtx_insn *prev, rtx_insn *curr)
   if (!prev_set || !curr_set)
     return false;
 
-  if (GET_CODE (SET_SRC (prev_set)) == MULT
-      && GET_CODE (SET_SRC (curr_set)) == PLUS)
-    {
-      rtx curr_plus = SET_SRC (curr_set);
-      rtx mult_dest = SET_DEST (prev_set);
-      if (!REG_P (mult_dest))
-	return false;
-      unsigned int mult_dest_regno = REGNO (mult_dest);
+  rtx prev_src = SET_SRC (prev_set);
+  rtx curr_src = SET_SRC (curr_set);
+  if (GET_CODE (prev_src) == SIGN_EXTEND
+      && GET_MODE (prev_src) == DImode
+      && GET_MODE (XEXP (prev_src, 0)) == SImode)
+    prev_src = XEXP (prev_src, 0);
+  if (GET_CODE (curr_src) == SIGN_EXTEND
+      && GET_MODE (curr_src) == DImode
+      && GET_MODE (XEXP (curr_src, 0)) == SImode)
+    curr_src = XEXP (curr_src, 0);
 
-      /* Check if multiply result is used in either operand of the addition.  */
-      if (REG_P (XEXP (curr_plus, 0))
-	  && REGNO (XEXP (curr_plus, 0)) == mult_dest_regno)
-	return true;
+  if (GET_CODE (prev_src) != MULT || GET_MODE (prev_src) != SImode
+      || GET_CODE (curr_src) != PLUS || GET_MODE (curr_src) != SImode)
+    return false;
 
-      if (REG_P (XEXP (curr_plus, 1))
-	  && REGNO (XEXP (curr_plus, 1)) == mult_dest_regno)
-	return true;
-    }
+  rtx mult_dest = SET_DEST (prev_set);
+  if (!REG_P (mult_dest))
+    return false;
+  unsigned int mult_dest_regno = REGNO (mult_dest);
+
+  /* Check if multiply result is used in either operand of the addition.  */
+  if (REG_P (XEXP (curr_src, 0))
+      && REGNO (XEXP (curr_src, 0)) == mult_dest_regno)
+    return true;
+
+  if (REG_P (XEXP (curr_src, 1))
+      && REGNO (XEXP (curr_src, 1)) == mult_dest_regno)
+    return true;
 
   return false;
 }

--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -4797,12 +4797,15 @@
      if (REGNO (operands[0]) == REGNO (operands[3]))
        {
 	 emit_insn (gen_mulsi3_extended (operands[4], operands[1], operands[2]));
-	 emit_insn (gen_addsi3_extended (operands[0], operands[3], operands[4]));
+	 emit_insn (gen_addsi3_extended (operands[0], operands[3],
+					 gen_lowpart (SImode, operands[4])));
        }
      else
        {
 	 emit_insn (gen_mulsi3_extended (operands[0], operands[1], operands[2]));
-	 emit_insn (gen_addsi3_extended (operands[0], operands[0], operands[3]));
+	 emit_insn (gen_addsi3_extended (operands[0],
+					 gen_lowpart (SImode, operands[0]),
+					 operands[3]));
        }
     DONE;
    }"

--- a/gcc/testsuite/gcc.target/riscv/arcv-fusion-mult-add-op0-dump.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-fusion-mult-add-op0-dump.c
@@ -1,13 +1,13 @@
 /* { dg-do compile } */
-/* { dg-require-effective-target rv32 } */
 /* { dg-skip-if "" { *-*-* } { "-g" "-flto" "-O0" "-O1" "-O3" "-Oz" "-Os" } } */
-/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv32im -mabi=ilp32 -fdump-rtl-sched2" { target { rv32 } } } */
+/* { dg-options "-O2 -mtune=arc-v-rhx-100-series -march=rv64im -mabi=lp64 -fdump-rtl-sched2" { target { rv64 } } } */
 
 int
-fuse_mult_add_op0 (int a, int b, int c, int d)
+fuse_mult_add_op0 (int a, int b, int c)
 {
   int m = a * b;
-  return m + c + m + d;
+  return m + c;
 }
 
 /* { dg-final { scan-rtl-dump "RISCV_FUSE_MULT_ADD" "sched2" } } */


### PR DESCRIPTION
```
fixup! RISC-V: Add instruction patterns for 32-bit multiply-add and bit-extract fusion.

tmp: Fix RV64 madd_fused_extended split to use SI lowpart operand.

When madd_fused_extended splits with the multiply result left in the
destination register, the subsequent addsi3_extended must take the
first plus:SI operand from gen_lowpart (SImode, operands[0]).  After
mulsi3_extended, operands[0] is reg:DI, so passing it directly
produces invalid RTL such as:

  (sign_extend:DI (plus:SI (reg:DI ...) (reg:SI ...)))

which no insn pattern matches, causing an ICE during split2 on RV64
RHX-100 builds (e.g. picolibc hash_page.c).

Signed-off-by: Luis Silva <luis.silva@globalfoundries.com>
```

```
fixup! RISC-V: Implement riscv_macro_fusion_pair_p for Synopsys RHX-100 series.
    
tmp: Fix RISCV_FUSE_MULT_ADD matching for RV64 sign-extended ops.
   
On RV64, 32-bit multiply-add uses SI-mode RTL sign-extended to DI
(e.g. mulsi3_extended and addsi3_extended), but riscv_fuse_mult_add
only looked for top-level MULT and PLUS nodes.  This failed to match
fused sequences on RV64.

Signed-off-by: Luis Silva <luis.silva@globalfoundries.com>
```