### PR TITLE
arcv: fix vsetvl error due to wrong insn pattern

### DIFF
--- a/gcc/config/riscv/arcv-vector.md
+++ b/gcc/config/riscv/arcv-vector.md
@@ -281,10 +281,10 @@
   "arcv.vclr.v.i\t%0,%4%p1"
   [(set_attr "type" "viwmuladd")
    (set_attr "mode" "<MODE>")
-   (set_attr "vl_op_idx" "4")
+   (set_attr "vl_op_idx" "5")
    (set (attr "ta") (symbol_ref "riscv_vector::get_ta(operands[5])"))
    (set (attr "ma") (symbol_ref "riscv_vector::get_ma(operands[6])"))
-   (set (attr "avl_type_idx") (const_int 7))])
+   (set (attr "avl_type_idx") (const_int 8))])
 
 (define_insn "@pred_arcv_vsra<mode>"
   [(set (match_operand:V_VLSI 0 "register_operand" "=vd, vd, vr, vr, vd, vd, vr, vr, vd, vd, vr, vr")

--- a/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vclr_v_i-compile-1.c
+++ b/gcc/testsuite/gcc.target/riscv/arcv-vdsp-vclr_v_i-compile-1.c
@@ -10,7 +10,7 @@
 
 /*
 ** test_vclr_v_i_i8:
-**  vsetivli	zero,1,e8,m1,ta,ma
+**  vsetvli	zero,a0,e8,m1,ta,ma
 **  arcv\.vclr\.v\.i\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
 **  ret
 */
@@ -21,7 +21,7 @@ vint8m1_t test_vclr_v_i_i8 (vint8m1_t vs2, size_t vl)
 
 /*
 ** test_vclr_v_i_i8_m:
-**  vsetivli	zero,1,e8,m1,ta,ma
+**  vsetvli	zero,a0,e8,m1,ta,ma
 **  arcv\.vclr\.v\.i\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1,\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
 **  ret
 */
@@ -32,7 +32,7 @@ vint8m1_t test_vclr_v_i_i8_m (vbool8_t mask, vint8m1_t vs2, size_t vl)
 
 /*
 ** test_vclr_v_i_i16:
-**  vsetivli	zero,1,e16,m1,ta,ma
+**  vsetvli	zero,a0,e16,m1,ta,ma
 **  arcv\.vclr\.v\.i\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
 **  ret
 */
@@ -43,7 +43,7 @@ vint16m1_t test_vclr_v_i_i16 (vint16m1_t vs2, size_t vl)
 
 /*
 ** test_vclr_v_i_i16_m:
-**  vsetivli	zero,1,e16,m1,ta,ma
+**  vsetvli	zero,a0,e16,m1,ta,ma
 **  arcv\.vclr\.v\.i\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1,\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
 **  ret
 */
@@ -54,7 +54,7 @@ vint16m1_t test_vclr_v_i_i16_m (vbool16_t mask, vint16m1_t vs2, size_t vl)
 
 /*
 ** test_vclr_v_i_i32:
-**  vsetivli	zero,1,e32,m1,ta,ma
+**  vsetvli	zero,a0,e32,m1,ta,ma
 **  arcv\.vclr\.v\.i\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
 **  ret
 */
@@ -65,7 +65,7 @@ vint32m1_t test_vclr_v_i_i32 (vint32m1_t vs2, size_t vl)
 
 /*
 ** test_vclr_v_i_i32_m:
-**  vsetivli	zero,1,e32,m1,ta,ma
+**  vsetvli	zero,a0,e32,m1,ta,ma
 **  arcv\.vclr\.v\.i\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1,\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
 **  ret
 */
@@ -76,7 +76,7 @@ vint32m1_t test_vclr_v_i_i32_m (vbool32_t mask, vint32m1_t vs2, size_t vl)
 
 /*
 ** test_vclr_v_i_i64:
-**  vsetivli	zero,1,e64,m1,ta,ma
+**  vsetvli	zero,a0,e64,m1,ta,ma
 **  arcv\.vclr\.v\.i\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1
 **  ret
 */
@@ -87,7 +87,7 @@ vint64m1_t test_vclr_v_i_i64 (vint64m1_t vs2, size_t vl)
 
 /*
 ** test_vclr_v_i_i64_m:
-**  vsetivli	zero,1,e64,m1,ta,ma
+**  vsetvli	zero,a0,e64,m1,ta,ma
 **  arcv\.vclr\.v\.i\s+(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1]),\s*1,\s*(?:v[0-9]|v[1-2][0-9]|[a-x0-9]+[0-1])\.t
 **  ret
 */


### PR DESCRIPTION
The compiler aborted inside the vsetvl pass during has_vl(): gcc_assert (!m_vl || REG_P (m_vl))

The attribute vl_op_idx was set to 4 as if was an instruction with immediate payload. 
Had to be changed to index 5 which holds the vector length operand.
Also the avl_type_idx was set to 7 while it had to be 8.
Also a dejagnu test needed to be changed - but thats orthogonal to this issue in sense that was wrong test anyhow.
Extra info can be found here:
https://pyreneesgf.atlassian.net/browse/P10019563-86957