### PR TITLE
tmp: add option to disable for testing

### DIFF
--- a/gcc/config/riscv/arcv.cc
+++ b/gcc/config/riscv/arcv.cc
@@ -85,6 +85,9 @@ arcv_pair_fusion_mode_allowed_p (machine_mode mode, bool is_load)
   if (!TARGET_ARCV_FUSION)
     return true;
 
+  if (!TARGET_ARCV_ADJACENT_MEM_FUSION)
+    return false;
+
   return ((is_load && (mode == DImode
 		     || mode == SImode
 		     || mode == HImode

--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -10971,6 +10971,16 @@ riscv_override_options_internal (struct gcc_options *opts)
     {
       opts->x_target_flags &= ~MASK_ARCV_ADVANCED_FUSION;
     }
+
+  /* Enable adjacent load/store fusion on ARC-V cores unless explicitly
+     disabled.  */
+  if ((riscv_microarchitecture == arcv_rmx500
+       || riscv_microarchitecture == arcv_rhx100
+       || riscv_microarchitecture == arcv_rpx100)
+      && (target_flags_explicit & MASK_ARCV_ADJACENT_MEM_FUSION) == 0)
+    opts->x_target_flags |= MASK_ARCV_ADJACENT_MEM_FUSION;
+  else if ((target_flags_explicit & MASK_ARCV_ADJACENT_MEM_FUSION) == 0)
+    opts->x_target_flags &= ~MASK_ARCV_ADJACENT_MEM_FUSION;
 }
 
 /* Implement TARGET_OPTION_OVERRIDE.  */

--- a/gcc/config/riscv/riscv.opt
+++ b/gcc/config/riscv/riscv.opt
@@ -736,3 +736,7 @@ Use 128-bit long double.
 marc-v-rmx-500-series-advanced-fusion
 Target Mask(ARCV_ADVANCED_FUSION)
 Explicitly disable or enable advanced fusion for the RMX-500 core.
+
+marc-v-adjacent-mem-fusion
+Target Mask(ARCV_ADJACENT_MEM_FUSION)
+Enable or disable adjacent load/store macro-op fusion on ARC-V cores.


### PR DESCRIPTION
rmx500 does not have adjacent load-store fusions.