### PR TITLE
tmp: Remove TARGET_ARCV_FUSION and TARGET_ARCV_RHX100

### DIFF
--- a/gcc/config/riscv/riscv-fusion.cc
+++ b/gcc/config/riscv/riscv-fusion.cc
@@ -49,7 +49,7 @@ riscv_macro_fusion_p (void)
 
 /* Return true iff the instruction fusion described by OP is enabled.  */
 
-static bool
+bool
 riscv_fusion_enabled_p (enum riscv_fusion_pairs op)
 {
   return riscv_get_fusible_ops () & op;

--- a/gcc/config/riscv/riscv-fusion.cc
+++ b/gcc/config/riscv/riscv-fusion.cc
@@ -155,7 +155,7 @@ void
 riscv_sched_fusion_priority (rtx_insn *insn, int max_pri, int *fusion_pri,
 			     int *pri)
 {
-  if (TARGET_ARCV_FUSION
+  if (TARGET_ARCV_RHX100
       && arcv_sched_fusion_priority (insn, max_pri, fusion_pri, pri))
     return;
 
@@ -187,9 +187,8 @@ riscv_adjacent_memops_p (rtx mem0, rtx mem1, bool is_load)
   if (GET_MODE (mem0) != GET_MODE (mem1))
     return false;
 
-  /* Check if the mode is allowed for ARC-V fusion restrictions.  */
-  if (TARGET_ARCV_FUSION
-	  && !arcv_pair_fusion_mode_allowed_p (GET_MODE (mem0), is_load))
+  if (TARGET_ARCV_RHX100
+      && !arcv_pair_fusion_mode_allowed_p (GET_MODE (mem0), is_load))
     return false;
 
   rtx mem_addr0 = XEXP (mem0, 0);

--- a/gcc/config/riscv/riscv-protos.h
+++ b/gcc/config/riscv/riscv-protos.h
@@ -861,6 +861,7 @@ enum riscv_fusion_pairs
 
 extern bool riscv_macro_fusion_p (void);
 extern bool riscv_macro_fusion_pair_p (rtx_insn *, rtx_insn *);
+extern bool riscv_fusion_enabled_p (enum riscv_fusion_pairs);
 extern unsigned int riscv_get_fusible_ops (void);
 extern void riscv_sched_fusion_priority (rtx_insn *, int, int *, int *);
 

--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -4584,7 +4584,8 @@ riscv_rtx_costs (rtx x, machine_mode mode, int outer_code, int opno ATTRIBUTE_UN
 	}
       gcc_fallthrough ();
     case SIGN_EXTRACT:
-      if ((TARGET_XTHEADBB || TARGET_ARCV_RHX100)
+      if ((TARGET_XTHEADBB
+	   || riscv_fusion_enabled_p (RISCV_FUSE_BFEXT))
 	  && outer_code == SET
 	  && CONST_INT_P (XEXP (x, 1))
 	  && CONST_INT_P (XEXP (x, 2)))

--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -11279,7 +11279,7 @@ riscv_sched_init (FILE *, int, int)
 {
   clear_vconfig ();
 
-  if (TARGET_ARCV_FUSION)
+  if (TARGET_ARCV_RHX100)
     arcv_sched_init ();
 }
 
@@ -11287,7 +11287,7 @@ riscv_sched_init (FILE *, int, int)
 static int
 riscv_sched_variable_issue (FILE *, int, rtx_insn *insn, int more)
 {
-  if (TARGET_ARCV_FUSION)
+  if (TARGET_ARCV_RHX100)
     if (!arcv_can_issue_more_p (riscv_issue_rate (), more))
       return 0;
 
@@ -11336,7 +11336,7 @@ riscv_sched_variable_issue (FILE *, int, rtx_insn *insn, int more)
 	}
     }
 
-  if (TARGET_ARCV_FUSION)
+  if (TARGET_ARCV_RHX100)
     return arcv_sched_variable_issue (insn, more);
 
   return more - 1;
@@ -11486,7 +11486,7 @@ riscv_sched_adjust_cost (rtx_insn *insn, int dep_type, rtx_insn *dep_insn, int c
 static int
 riscv_sched_adjust_priority (rtx_insn *insn, int priority)
 {
-  if (TARGET_ARCV_FUSION)
+  if (TARGET_ARCV_RHX100)
     return arcv_sched_adjust_priority (insn, priority);
 
   return priority;
@@ -11501,7 +11501,7 @@ riscv_sched_reorder2 (FILE *file ATTRIBUTE_UNUSED,
 		      int *n_readyp,
 		      int clock ATTRIBUTE_UNUSED)
 {
-  if (TARGET_ARCV_FUSION)
+  if (TARGET_ARCV_RHX100)
     return arcv_sched_reorder2 (ready, n_readyp);
 
   return 0;

--- a/gcc/config/riscv/riscv.h
+++ b/gcc/config/riscv/riscv.h
@@ -977,10 +977,6 @@ extern enum riscv_cc get_riscv_cc (const rtx use);
 #define TARGET_ARCV_RHX100 \
   (riscv_microarchitecture == arcv_rhx100)
 
-/* True if the target is an ARC-V core with fusion support.  */
-#define TARGET_ARCV_FUSION \
-  (riscv_microarchitecture == arcv_rhx100)
-
 /* True if the target supports misaligned vector loads and stores.  */
 #define TARGET_VECTOR_MISALIGN_SUPPORTED \
    riscv_vector_unaligned_access_p

--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -3168,7 +3168,7 @@
      && (INTVAL (operands[2]) == 1))
    && !TARGET_XTHEADBB
    && !TARGET_XANDESPERF
-   && !(TARGET_ARCV_RHX100
+   && !(riscv_fusion_enabled_p (RISCV_FUSE_BFEXT)
 	&& <any_extract:is_zero_extract>)
    && !(TARGET_64BIT
         && (INTVAL (operands[3]) > 0)
@@ -4687,10 +4687,10 @@
 	  (mult:SI (sign_extend:SI (match_operand:HI 1 "register_operand"))
 		   (sign_extend:SI (match_operand:HI 2 "register_operand")))
 	  (match_operand:SI 3 "register_operand")))]
-  "TARGET_XTHEADMAC || (TARGET_ARCV_RHX100
+  "TARGET_XTHEADMAC || (riscv_fusion_enabled_p (RISCV_FUSE_MULT_ADD)
 			&& !TARGET_64BIT && (TARGET_ZMMUL || TARGET_MUL))"
 {
-  if (TARGET_ARCV_RHX100)
+  if (riscv_fusion_enabled_p (RISCV_FUSE_MULT_ADD))
     {
       rtx tmp0 = gen_reg_rtx (SImode), tmp1 = gen_reg_rtx (SImode);
       emit_insn (gen_extendhisi2 (tmp0, operands[1]));
@@ -4720,7 +4720,7 @@
 	  (mult:SI (zero_extend:SI (match_operand:HI 1 "register_operand"))
 		   (zero_extend:SI (match_operand:HI 2 "register_operand")))
 	  (match_operand:SI 3 "register_operand")))]
-  "TARGET_ARCV_RHX100
+  "riscv_fusion_enabled_p (RISCV_FUSE_MULT_ADD)
    && !TARGET_64BIT && (TARGET_ZMMUL || TARGET_MUL)"
 {
   rtx tmp0 = gen_reg_rtx (SImode), tmp1 = gen_reg_rtx (SImode);
@@ -4760,7 +4760,7 @@
 		 (match_operand:SI 2 "register_operand" "r,r"))
 	(match_operand:SI 3 "register_operand" "r,?0")))
     (clobber (match_scratch:SI 4 "=&r,&r"))]
-  "TARGET_ARCV_RHX100
+  "riscv_fusion_enabled_p (RISCV_FUSE_MULT_ADD)
    && !TARGET_64BIT && (TARGET_ZMMUL || TARGET_MUL)"
   "#"
   "&& reload_completed"
@@ -4788,7 +4788,7 @@
 		 (match_operand:SI 2 "register_operand" "r,r"))
 	(match_operand:SI 3 "register_operand" "r,?0"))))
     (clobber (match_scratch:SI 4 "=&r,&r"))]
-  "TARGET_ARCV_RHX100
+  "riscv_fusion_enabled_p (RISCV_FUSE_MULT_ADD)
    && (TARGET_ZMMUL || TARGET_MUL)"
   "#"
   "&& reload_completed"
@@ -4816,7 +4816,7 @@
 	(zero_extract:SI (match_operand:SI 1 "register_operand" "r")
 			 (match_operand 2 "const_int_operand")
 			 (match_operand 3 "const_int_operand")))]
-  "TARGET_ARCV_RHX100 && !TARGET_64BIT
+  "riscv_fusion_enabled_p (RISCV_FUSE_BFEXT) && !TARGET_64BIT
      && (INTVAL (operands[2]) > 1 || !TARGET_ZBS)"
   "#"
   "&& reload_completed"


### PR DESCRIPTION
in favor of checking for specific fusion.