### PR TITLE
arcv: Fix arcv_rhx100 tuning costs causing unexpected spill regressions

### DIFF
--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -850,7 +850,7 @@ static const struct riscv_tune_param arcv_rmx100_tune_info = {
   {COSTS_N_INSNS (17), COSTS_N_INSNS (17)},	/* int_div */
   1,						/* issue_rate */
   4,						/* branch_cost */
-  2,						/* memory_cost */
+  4,						/* memory_cost */
   4,						/* fmv_cost */
   false,					/* slow_unaligned_access */
   false,					/* vector_unaligned_access */
@@ -875,7 +875,7 @@ static const struct riscv_tune_param arcv_rmx500_tune_info = {
   {COSTS_N_INSNS (21), COSTS_N_INSNS (21)},	/* int_div */
   2,						/* issue_rate */
   9,						/* branch_cost */
-  2,						/* memory_cost */
+  4,						/* memory_cost */
   8,						/* fmv_cost */
   false,					/* slow_unaligned_access */
   false,					/* vector_unaligned_access */
@@ -900,7 +900,7 @@ static const struct riscv_tune_param arcv_rhx100_tune_info = {
   {COSTS_N_INSNS (27), COSTS_N_INSNS (43)},	/* int_div */
   4,						/* issue_rate */
   9,						/* branch_cost */
-  2,						/* memory_cost */
+  4,						/* memory_cost */
   8,						/* fmv_cost */
   false,					/* slow_unaligned_access */
   false,					/* vector_unaligned_access */
@@ -925,7 +925,7 @@ static const struct riscv_tune_param arcv_rpx100_tune_info = {
   {COSTS_N_INSNS (27), COSTS_N_INSNS (43)},	/* int_div */
   4,						/* issue_rate */
   9,						/* branch_cost */
-  2,						/* memory_cost */
+  4,						/* memory_cost */
   8,						/* fmv_cost */
   false,					/* slow_unaligned_access */
   false,					/* vector_unaligned_access */


### PR DESCRIPTION
While running the xtheadfmv-fmv.c test case for -march=rv32gc_xtheadfmv, the compiler was dropping the direct register move instructions (th.fmv.hw.x). Instead it fell back to spilling 64 bit data onto the stack using store (sw) and load (fld) loops.

This issue occurred because our custom tuning profile configurations (--with-tune=arc-v-rhx-100-series and also for rmx100, rmx500, and rpx100 cores) had an internal cost model which gave priority to load/store rather than moves.

Correcting the core weights eliminated the slow memory operations and as a result resolved 40 C test file failures (amounting to a few hundred total tests when accounting for optimization flags).

jira ticket:
https://pyreneesgf.atlassian.net/browse/P10019563-86975