### PR TITLE
arc: fma-1.c fix for gcc16 evrp pass

### DIFF
--- a/gcc/testsuite/gcc.target/arc/fma-1.c
+++ b/gcc/testsuite/gcc.target/arc/fma-1.c
@@ -5,10 +5,9 @@
 const float b = 7.8539818525e01;
 extern const float a;
 
-/* Check if the fma operation is generated correctly.  */
-
-int foo (void)
+float foo (void)
 {
   return (float)3.0 * b + a;
 }
+
 /* { dg-final { scan-assembler "fsmadd" } } */


### PR DESCRIPTION
This arc test was failing due to gcc16 value range propagation improvements. 
When the foo function was returning an integer this early tree phase calculates 
the value range calculated for the (float)3.0 * b + a expression truncated to the int value 235. 
By enforcing foo() to return float type the integer truncation explained before is 
eliminated returning the output of a fsmadd insn.

The changes in behavior between gcc16 and gcc15 are due to changes in the file tree-vrp.cc:
gcc16 (looks at a specific variable and every other variable that depends on it) 
FOR_EACH_GORI_EXPORT_AND_DEP_NAME (m_ranger.gori_ssa (), e->src, name, m_tmp)
gcc15 (looks only at a specific variable) 
FOR_EACH_GORI_EXPORT_NAME (m_ranger.gori_ssa (), e->src, name)