### PR TITLE
arc: incorrect branch generation (beq_s instead of bnv)

### DIFF
--- a/gcc/config/arc/arc.cc
+++ b/gcc/config/arc/arc.cc
@@ -1796,7 +1796,8 @@ arc_init_reg_tables (void)
 	  if (i == (int) CCmode || i == (int) CC_ZNmode || i == (int) CC_Zmode
 	      || i == (int) CC_Cmode
 	      || i == CC_FP_GTmode || i == CC_FP_GEmode || i == CC_FP_ORDmode
-	      || i == CC_FPUmode || i == CC_FPUEmode || i == CC_FPU_UNEQmode)
+	      || i == CC_FPUmode || i == CC_FPUEmode || i == CC_FPU_UNEQmode
+	      || i == CC_Vmode)
 	    arc_mode_class[i] = 1 << (int) C_MODE;
 	  else
 	    arc_mode_class[i] = 0;


### PR DESCRIPTION
pr64006.c test case was failing due to incorrect branch generation. 

As far as I can see this issue was caused by a code deletion arc.cc inside the arc_init_reg_tables().

Due to this change the compiler was generating a branch that does not check the overflow while the branch should have been take/not tacken depending on the overflow.