### PR TITLE
fixup! RISC-V: Add instruction patterns for 32-bit multiply-add and b…

### DIFF
--- a/gcc/config/riscv/riscv.md
+++ b/gcc/config/riscv/riscv.md
@@ -4756,7 +4756,8 @@
   "TARGET_XTHEADMAC || (riscv_fusion_enabled_p (RISCV_FUSE_MULT_ADD)
 			&& !TARGET_64BIT && (TARGET_ZMMUL || TARGET_MUL))"
 {
-  if (riscv_fusion_enabled_p (RISCV_FUSE_MULT_ADD))
+  if (riscv_fusion_enabled_p (RISCV_FUSE_MULT_ADD)
+      && !TARGET_XTHEADMAC)
     {
       rtx tmp0 = gen_reg_rtx (SImode), tmp1 = gen_reg_rtx (SImode);
       emit_insn (gen_extendhisi2 (tmp0, operands[1]));
@@ -4826,6 +4827,7 @@
 		 (match_operand:SI 2 "register_operand" "r"))
 	(match_operand:SI 3 "register_operand" "r")))]
   "riscv_fusion_enabled_p (RISCV_FUSE_MULT_ADD)
+   && !TARGET_XTHEADMAC
    && !TARGET_64BIT && (TARGET_ZMMUL || TARGET_MUL)"
   "#"
   "&& 1"
@@ -4853,6 +4855,7 @@
 		 (match_operand:SI 2 "register_operand" "r"))
 	(match_operand:SI 3 "register_operand" "r"))))]
   "riscv_fusion_enabled_p (RISCV_FUSE_MULT_ADD)
+   && !TARGET_XTHEADMAC
    && (TARGET_ZMMUL || TARGET_MUL)"
   "#"
   "&& 1"


### PR DESCRIPTION
…it-extract fusion.

Do not apply mult-add fusion RTL with XThead MAC enabled

The multiply-add fusion insn_and_split patterns and the maddhisi4 expand hook emit separate mul and add insns so the scheduler can recognize RISCV_FUSE_MULT_ADD pairs.  When the XThead MAC extension is enabled, the target already provides th.mula, th.muls, th.mulah, and related insns for the same RTL shapes.  With a tune that enables mult-add fusion, those hooks could be selected instead of the XThead patterns, breaking gcc.target/riscv/xtheadmac-mula-muls.c.