### PR TITLE
arc64: restrict profiling execution test 20020201-1.c to native targets

### DIFF
--- a/gcc/testsuite/gcc.dg/20020201-1.c
+++ b/gcc/testsuite/gcc.dg/20020201-1.c
@@ -6,6 +6,7 @@
 
 /* { dg-options "-fprofile-arcs" } */
 /* { dg-do run } */
+/* { dg-skip-if "For now skip arc64 target and cores" { "arc32*-*-* arc64*-*-*" } } */
 
 #include <stdlib.h>
 


### PR DESCRIPTION
This test used to be enabled only for native targets. Those targets implicitly support threads.
Because getpid() is an operating system primitive designed to return the process id it turns 
out that standalone platforms (baremetal) completely lack support for such function. As a 
result there isnt possible to link to such a function in bare metal environment.
In gcc15 the test was applied only to native targets:
/* { dg-do run { target native } } */
This prevented all our targets from failing this test.
