### PR TITLE
riscv: Allow Zcmp push/pop when shrink-wrap-separate is inactive

### DIFF
--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -7665,7 +7665,8 @@ riscv_avoid_multi_push (const struct riscv_frame_info *frame)
       || cfun->machine->interrupt_handler_p || cfun->machine->varargs_size != 0
       || crtl->args.pretend_args_size != 0
       || (use_shrink_wrapping_separate ()
-	  && !riscv_avoid_shrink_wrapping_separate ())
+	  && !riscv_avoid_shrink_wrapping_separate ()
+	  && crtl->shrink_wrapped_separate)
       || (frame->mask & ~MULTI_PUSH_GPR_MASK))
     return true;
 

--- a/gcc/testsuite/gcc.target/riscv/pr112478.c
+++ b/gcc/testsuite/gcc.target/riscv/pr112478.c
@@ -5,4 +5,4 @@ void foo() {
     asm volatile("# " : ::"ra");
 }
 
-/* { dg-final { scan-assembler "s(w|d)\[ \t\]*ra" } } */
+/* { dg-final { scan-assembler "s(w|d)\[ \t\]*ra|cm\\.push\[ \t\]*\\{.*ra.*\\}" } } */

--- a/gcc/testsuite/gcc.target/riscv/zcmp_no_shrink_wrap.c
+++ b/gcc/testsuite/gcc.target/riscv/zcmp_no_shrink_wrap.c
@@ -1,0 +1,18 @@
+/* { dg-do compile } */ 
+/* { dg-options "-O2 -march=rv32imac_zicsr_zifencei_zcmp -mabi=ilp32 -fshrink-wrap" } */
+/* { dg-skip-if "" { *-*-* } {"-O0" "-O1" "-Os" "-Og" "-O3" "-Oz" "-flto"} } */
+
+extern void
+bar (int);
+
+/* Verify that Zcmp cm.push is used at -O2 when shrink-wrapping is 
+   active but no early return exists.  */
+void
+foo (int a)
+{
+  bar (a);
+  bar (a);
+}
+
+/* { dg-final { scan-assembler "cm\\.push" } } */
+/* { dg-final { scan-assembler "cm\\.pop" } } */

--- a/gcc/testsuite/gcc.target/riscv/zcmp_shrink_wrap.c
+++ b/gcc/testsuite/gcc.target/riscv/zcmp_shrink_wrap.c
@@ -1,0 +1,20 @@
+/* { dg-do compile } */
+/* { dg-options "-O2 -march=rv32imac_zicsr_zifencei_zcmp -mabi=ilp32 -fshrink-wrap" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-Os" "-Og" "-O3" "-Oz" "-flto" } } */
+
+extern void 
+bar (int);
+
+/* Verify that Zcmp cm.push is used at -O2 even when a simple 
+   shrink-wrap early return is present.  */
+void
+foo (int a)
+{
+  if (a == 0)
+    return;
+  bar (a);
+  bar (a);
+}
+
+/* { dg-final { scan-assembler "cm\\.push" } } */
+/* { dg-final { scan-assembler "cm\\.pop" } } */

--- a/gcc/testsuite/gcc.target/riscv/zcmp_shrink_wrap_sep.c
+++ b/gcc/testsuite/gcc.target/riscv/zcmp_shrink_wrap_sep.c
@@ -1,0 +1,21 @@
+/* { dg-do compile } */
+/* { dg-options "-O2 -march=rv32imac_zicsr_zifencei_zcmp -mabi=ilp32 -fshrink-wrap-separate" } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-Os" "-Og" "-O3" "-Oz" "-flto" } } */
+
+/* Verify that Zcmp cm.push is NOT used when shrink-wrap-separate is 
+   actively moving individual callee-saved registers.  */
+void
+foo (int a)
+{
+  if (a == 1)
+    {
+      register int s0 asm ("s0") = 1;
+      asm volatile ("" : : "r" (s0));
+      return;
+    }
+  register int s1 asm ("s1") = 2;
+  asm volatile ("" : : "r" (s1));
+}
+
+/* { dg-final { scan-assembler-not "cm\\.push" } } */
+/* { dg-final { scan-assembler-not "cm\\.pop" } } */

--- a/gcc/testsuite/gcc.target/riscv/zcmp_shrink_wrap_separate.c
+++ b/gcc/testsuite/gcc.target/riscv/zcmp_shrink_wrap_separate.c
@@ -90,4 +90,4 @@ calc_func (signed short *pdata, core_results *res)
     }
 }
 
-/* { dg-final { scan-assembler-not "cm\.push" } } */
+/* { dg-final { scan-assembler "cm\\.push" } } */


### PR DESCRIPTION
This patch isn't merged yet upstream. I pinged the original author about the status.
This enables zcmp instructions for many more cases.

Not sure if this is still the case, but zcmp used to be slower for RHX. So it likely needs to be gated when we are not optimising for size. But for RMX-500 and 700 this will always be faster, or similar in performance.